### PR TITLE
Add implementedByAsync to PlayRouting endpoints

### DIFF
--- a/sample/server/src/main/scala/sample/Api.scala
+++ b/sample/server/src/main/scala/sample/Api.scala
@@ -2,6 +2,7 @@ package sample
 
 import endpoints.{AssetsRouting, CirceCodecsRouting, PlayRouting}
 
+import scala.concurrent.Future
 import scala.language.higherKinds
 
 object Api extends ApiAlg with PlayRouting with CirceCodecsRouting with AssetsRouting {
@@ -9,6 +10,7 @@ object Api extends ApiAlg with PlayRouting with CirceCodecsRouting with AssetsRo
   val routes = routesFromEndpoints(
     index.implementedBy { case (name, (age, _)) => User(name, age) },
     action.implementedBy(param => ActionResult(index.call(("Julien", (30, "a&b+c"))).url)),
+    actionFut.implementedByAsync(param => Future.successful(ActionResult(index.call(("Julien", (30, "future"))).url))),
     assets.implementedBy(assetsResources())
   )
 

--- a/sample/shared/src/main/scala/sample/ApiAlg.scala
+++ b/sample/shared/src/main/scala/sample/ApiAlg.scala
@@ -9,6 +9,8 @@ trait ApiAlg extends EndpointsAlg with CirceCodecs with AssetsAlg {
 
   val action = endpoint(post(path / "action", jsonRequest[ActionParameter]), jsonResponse[ActionResult])
 
+  val actionFut = endpoint(post(path / "actionFut", jsonRequest[ActionParameter]), jsonResponse[ActionResult])
+
   lazy val digests = AssetsDigests.digests
 
   val assets = assetsEndpoint(path / "assets" / assetSegments)


### PR DESCRIPTION
**Problem:** If a service is defined as `A => Future[B]` it was not possible to return a result in the play implementation.

This add a new method on `Endpoint`: `implementedByAsync` to solve this use case.