### PR TITLE
Partial scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import org.scalajs.sbtplugin.cross.CrossProject
 
 val commonSettings = Seq(
   organization := "org.julienrf",
-  scalaVersion := "2.11.8",
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",
@@ -16,6 +15,14 @@ val commonSettings = Seq(
     "-Xfuture",
     "-Xexperimental"
   )
+)
+val `scala2.11` = Seq(
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.11.8")
+)
+val `scala2.12` = Seq(
+  scalaVersion := "2.12.1",
+  crossScalaVersions := Seq("2.11.8", "2.12.1")
 )
 
 val publishSettings = commonSettings ++ Seq(
@@ -46,6 +53,7 @@ val publishSettings = commonSettings ++ Seq(
 val algebra =
   crossProject.crossType(CrossType.Pure).in(file("algebra"))
     .settings(publishSettings: _*)
+    .settings(`scala2.12`: _*)
     .settings(
       name := "endpoints-algebra"
     )
@@ -54,12 +62,15 @@ val `algebra-js` = algebra.js
 
 val `algebra-jvm` = algebra.jvm
 
+val circeVersion = "0.6.1"
+
 val `algebra-circe` =
   crossProject.crossType(CrossType.Pure).in(file("algebra-circe"))
     .settings(publishSettings: _*)
+    .settings(`scala2.12`: _*)
     .settings(
       name := "endpoints-algebra-circe",
-      libraryDependencies += "io.circe" %%% "circe-generic" % "0.5.0"
+      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
     )
     .dependsOn(`algebra`)
 
@@ -71,6 +82,7 @@ val `xhr-client` =
   project.in(file("xhr-client"))
     .enablePlugins(ScalaJSPlugin)
     .settings(publishSettings: _*)
+    .settings(`scala2.12`: _*)
     .settings(
       name := "endpoints-xhr-client",
       libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
@@ -81,6 +93,7 @@ val `xhr-client-faithful` =
   project.in(file("xhr-client-faithful"))
     .enablePlugins(ScalaJSPlugin)
     .settings(publishSettings: _*)
+    .settings(`scala2.11`: _*)
     .settings(
       name := "endpoints-xhr-client-faithful",
       libraryDependencies += "org.julienrf" %%% "faithful" % "0.2"
@@ -91,30 +104,35 @@ val `xhr-client-circe` =
   project.in(file("xhr-client-circe"))
     .enablePlugins(ScalaJSPlugin)
     .settings(publishSettings: _*)
+    .settings(`scala2.12`: _*)
     .settings(
       name := "endpoints-xhr-client-circe",
-      libraryDependencies += "io.circe" %%% "circe-parser" % "0.5.0"
+      libraryDependencies += "io.circe" %%% "circe-parser" % circeVersion
     )
     .dependsOn(`xhr-client`, `algebra-circe-js`)
+
+val playVersion = "2.5.6"
 
 val `play-circe` =
   project.in(file("play-circe"))
     .settings(publishSettings: _*)
+    .settings(`scala2.11`: _*)
     .settings(
       name := "endpoints-play-circe",
       libraryDependencies ++= Seq(
-        "com.typesafe.play" %% "play" % "2.5.6",
-        "io.circe" %% "circe-core" % "0.5.0"
+        "com.typesafe.play" %% "play" % playVersion,
+        "io.circe" %% "circe-core" % circeVersion
       )
     )
 
 val `play-server` =
   project.in(file("play-server"))
     .settings(publishSettings: _*)
+    .settings(`scala2.11`: _*)
     .settings(
       name := "endpoints-play-server",
       libraryDependencies ++= Seq(
-        "com.typesafe.play" %% "play-netty-server" % "2.5.6"
+        "com.typesafe.play" %% "play-netty-server" % playVersion
       )
     )
     .dependsOn(`algebra-jvm`)
@@ -122,27 +140,30 @@ val `play-server` =
 val `play-server-circe` =
   project.in(file("play-server-circe"))
     .settings(publishSettings: _*)
+    .settings(`scala2.11`: _*)
     .settings(
       name := "endpoints-play-server-circe",
-      libraryDependencies += "io.circe" %% "circe-jawn" % "0.5.0"
+      libraryDependencies += "io.circe" %% "circe-jawn" % circeVersion
     )
     .dependsOn(`play-server`, `algebra-circe-jvm`, `play-circe`)
 
 val `play-client` =
   project.in(file("play-client"))
       .settings(publishSettings: _*)
+      .settings(`scala2.11`: _*)
       .settings(
         name := "endpoints-play-client",
-        libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.5.6"
+        libraryDependencies += "com.typesafe.play" %% "play-ws" % playVersion
       )
       .dependsOn(`algebra-jvm`)
 
 val `play-client-circe` =
   project.in(file("play-client-circe"))
     .settings(publishSettings: _*)
+    .settings(`scala2.11`: _*)
     .settings(
       name := "endpoints-play-client-circe",
-      libraryDependencies += "io.circe" %% "circe-jawn" % "0.5.0"
+      libraryDependencies += "io.circe" %% "circe-jawn" % circeVersion
     )
     .dependsOn(`play-client`, `algebra-circe-jvm`, `play-circe`)
 
@@ -150,6 +171,7 @@ val `example-basic-shared` = {
   val assetsDirectory = (base: File) => base / "src" / "main" / "assets"
   CrossProject("example-basic-shared-jvm", "example-basic-shared-js", file("examples/basic/shared"), CrossType.Pure)
     .settings(commonSettings: _*)
+    .settings(`scala2.12`: _*)
     .settings(
       publishArtifact := false,
       addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
@@ -183,6 +205,7 @@ val `example-basic-client` =
   project.in(file("examples/basic/client"))
     .enablePlugins(ScalaJSPlugin)
     .settings(commonSettings: _*)
+    .settings(`scala2.12`: _*)
     .settings(
       publishArtifact := false
     )
@@ -191,6 +214,7 @@ val `example-basic-client` =
 val `example-basic-server` =
   project.in(file("examples/basic/server"))
     .settings(commonSettings: _*)
+    .settings(`scala2.11`: _*)
     .settings(
       publishArtifact := false,
       unmanagedResources in Compile += (fastOptJS in (`example-basic-client`, Compile)).map(_.data).value,
@@ -200,6 +224,7 @@ val `example-basic-server` =
 
 val endpoints =
   project.in(file("."))
+    .enablePlugins(CrossPerProjectPlugin)
       .settings(
         publishArtifact := false/*,
         releasePublishArtifactsAction := PgpKeys.publishSigned.value,

--- a/play-client-circe/src/main/scala/endpoints/CirceCodecPlayClient.scala
+++ b/play-client-circe/src/main/scala/endpoints/CirceCodecPlayClient.scala
@@ -15,6 +15,6 @@ trait CirceCodecPlayClient extends CirceCodecAlg { this: EndpointPlayClient =>
 
   /** Decodes a response entity by using the supplied codec */
   def jsonResponse[A : CirceCodec]: Response[A] =
-    response => jawn.parse(response.body).flatMap(CirceCodec[A].decoder.decodeJson).toEither
+    response => jawn.parse(response.body).right.flatMap(CirceCodec[A].decoder.decodeJson)
 
 }

--- a/play-server-circe/src/main/scala/endpoints/CirceCodecPlayRouting.scala
+++ b/play-server-circe/src/main/scala/endpoints/CirceCodecPlayRouting.scala
@@ -14,7 +14,8 @@ trait CirceCodecPlayRouting extends EndpointPlayRouting with CirceCodecAlg {
   def jsonRequest[A : CirceCodec] =
     BodyParsers.parse.raw.validate { buffer =>
       jawn.parseFile(buffer.asFile)
-        .flatMap(CirceCodec[A].decoder.decodeJson).toEither
+        .right
+        .flatMap(CirceCodec[A].decoder.decodeJson)
         .left.map(error => Results.BadRequest)
     }
 

--- a/play-server-circe/src/main/scala/endpoints/JsonEntityPlayRoutingCirce.scala
+++ b/play-server-circe/src/main/scala/endpoints/JsonEntityPlayRoutingCirce.scala
@@ -21,7 +21,8 @@ trait JsonEntityPlayRoutingCirce extends EndpointPlayRouting with JsonEntityAlg 
   def jsonRequest[A : Decoder] =
     BodyParsers.parse.raw.validate { buffer =>
       jawn.parseFile(buffer.asFile)
-        .flatMap(Decoder[A].decodeJson).toEither
+         .right
+        .flatMap(Decoder[A].decodeJson)
         .left.map(error => Results.BadRequest)
     }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 
@@ -7,6 +7,8 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 lazy val `sbt-assets` = RootProject(file("../sbt-assets"))
 

--- a/xhr-client-circe/src/main/scala/endpoints/CirceCodecXhrClient.scala
+++ b/xhr-client-circe/src/main/scala/endpoints/CirceCodecXhrClient.scala
@@ -18,6 +18,6 @@ trait CirceCodecXhrClient extends EndpointXhrClient with CirceCodecAlg {
 
   /** Decodes the response entity by using the supplied codec */
   def jsonResponse[A : CirceCodec]: js.Function1[XMLHttpRequest, Either[Exception, A]] =
-    xhr => parser.parse(xhr.responseText).flatMap(CirceCodec[A].decoder.decodeJson).toEither
+    xhr => parser.parse(xhr.responseText).right.flatMap(CirceCodec[A].decoder.decodeJson _)
 
 }

--- a/xhr-client-circe/src/main/scala/endpoints/JsonEntityXhrClientCirce.scala
+++ b/xhr-client-circe/src/main/scala/endpoints/JsonEntityXhrClientCirce.scala
@@ -24,6 +24,6 @@ trait JsonEntityXhrClientCirce extends EndpointXhrClient with JsonEntityAlg {
   }
 
   def jsonResponse[A](implicit decoder: Decoder[A]): js.Function1[XMLHttpRequest, Either[Exception, A]] =
-    xhr => parser.parse(xhr.responseText).flatMap(decoder.decodeJson).toEither
+    xhr => parser.parse(xhr.responseText).right.flatMap(decoder.decodeJson)
 
 }


### PR DESCRIPTION
Hi,

I had to add sbt-doge, so different sub-projects can support different scala versions. We need to wait for `faithful` and `play` to fully support scala 2.12. 

I have updated circe(it required some code changes because Xor was replaced by scala.util.Either) and scalajs.