### PR TITLE
akka-http too extensive matching fix

### DIFF
--- a/akka-http-server/src/main/scala/endpoints/akkahttp/routing/Endpoints.scala
+++ b/akka-http-server/src/main/scala/endpoints/akkahttp/routing/Endpoints.scala
@@ -50,11 +50,13 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
     headers: RequestHeaders[C] = emptyHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] = {
     val methodDirective = convToDirective1(Directives.method(method))
+    // we use Directives.pathPrefix to construct url directives, so now we close it
+    val urlDirective = joinDirectives(url.directive, convToDirective1(Directives.pathEndOrSingleSlash))
     joinDirectives(
       joinDirectives(
         joinDirectives(
           methodDirective,
-          url.directive),
+          urlDirective),
         entity),
       headers)
   }

--- a/akka-http-server/src/test/scala/endpoints/akkahttp/routing/EndpointsTest.scala
+++ b/akka-http-server/src/test/scala/endpoints/akkahttp/routing/EndpointsTest.scala
@@ -1,0 +1,36 @@
+package endpoints.akkahttp.routing
+
+import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.{Matchers, WordSpec}
+import scala.language.reflectiveCalls
+
+/**
+  * Created by wpitula on 2/26/17.
+  */
+class EndpointsTest extends WordSpec with Matchers with ScalatestRouteTest {
+
+  val testRoutes = new Endpoints {
+    val singleStaticGetSegment = endpoint[Unit, Unit](
+      get[Unit, Unit](path / "segment1"),
+      _ => complete("Ok")
+    ).implementedBy(_ => ())
+  }
+
+  "Single segment route" should {
+
+    "match single segment request" in {
+      // tests:
+      Get("/segment1") ~> testRoutes.singleStaticGetSegment ~> check {
+        responseAs[String] shouldEqual "Ok"
+      }
+    }
+    "leave GET requests to other paths unhandled" in {
+      Get("/segment1/segment2") ~> testRoutes.singleStaticGetSegment ~> check {
+        handled shouldBe false
+      }
+    }
+
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,9 @@ val `akka-http-server` =
     .settings(
       name := "endpoints-akka-http-server",
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-http" % "10.0.1"
+        "com.typesafe.akka" %% "akka-http" % "10.0.1",
+        "com.typesafe.akka" %% "akka-http-testkit" % "10.0.1" % Test,
+        "org.scalatest" %% "scalatest" % "3.0.1" % Test
       )
     )
     .dependsOn(`algebra-jvm`)
@@ -478,5 +480,6 @@ val endpoints =
       `example-cqrs-commands-endpoints`,
       `example-cqrs-commands`,
       `example-cqrs-queries-endpoints`,
-      `example-cqrs-queries`
+      `example-cqrs-queries`,
+      `circe-instant-js`, `circe-instant-jvm`
     )


### PR DESCRIPTION
I have found a bug in akka-http interpreter. It has matched `/foo/bar` with endpoint defined as `/foo`. 

Sadly, I don't have time to add more tests, but better this than nothing.

I have also fixed travis build.