### PR TITLE
Use implicit syntax instead of inheriting from it

### DIFF
--- a/akka-http-server/src/main/scala/endpoints/akkahttp/server/Urls.scala
+++ b/akka-http-server/src/main/scala/endpoints/akkahttp/server/Urls.scala
@@ -12,11 +12,11 @@ trait Urls extends algebra.Urls {
 
   import akka.http.scaladsl.server.Directives._
 
-  class Path[T](override val directive: Directive1[T]) extends Url[T](directive) with PathOps[T]
+  class Path[T](override val directive: Directive1[T]) extends Url[T](directive)
 
   class Url[T](val directive: Directive1[T])
 
-  class QueryString[T](val directive: Directive1[T]) extends QueryStringOps[T]
+  class QueryString[T](val directive: Directive1[T])
 
   type QueryStringParam[T] = FromStringUnmarshaller[T]
 

--- a/algebra/src/main/scala/endpoints/algebra/Urls.scala
+++ b/algebra/src/main/scala/endpoints/algebra/Urls.scala
@@ -29,10 +29,10 @@ import scala.language.higherKinds
 trait Urls {
 
   /** A query string carrying an `A` information */
-  type QueryString[A] <: QueryStringOps[A]
+  type QueryString[A]
 
-  /** Provides convenient methods on [[QueryString]]. Just mix this trait in your concrete representation of [[QueryString]] */
-  trait QueryStringOps[A] { first: QueryString[A] =>
+  /** Provides convenient methods on [[QueryString]]. */
+  implicit class QueryStringOps[A](first: QueryString[A]) {
     /**
       * Convenient method to concatenate two [[QueryString]]s.
       *
@@ -95,10 +95,10 @@ trait Urls {
   implicit def longSegment: Segment[Long]
 
   /** An URL path carrying an `A` information */
-  type Path[A] <: PathOps[A] with Url[A]
+  type Path[A] <: Url[A]
 
-  /** Convenient methods for [[Path]]s. Just mix this trait in your concrete representation of `Path` */
-  trait PathOps[A] { first: Path[A] =>
+  /** Convenient methods for [[Path]]s. */
+  implicit class PathOps[A](first: Path[A]) {
     /** Chains this path with the `second` constant path segment */
     final def / (second: String): Path[A] = chainPaths(first, staticPathSegment(second))
     /** Chains this path with the `second` path segment */

--- a/play-client/src/main/scala/endpoints/play/client/Urls.scala
+++ b/play-client/src/main/scala/endpoints/play/client/Urls.scala
@@ -13,7 +13,7 @@ trait Urls extends algebra.Urls {
 
   val utf8Name = UTF_8.name()
 
-  trait QueryString[A] extends QueryStringOps[A] {
+  trait QueryString[A] {
     def encodeQueryString(a: A): String
   }
 
@@ -51,7 +51,7 @@ trait Urls extends algebra.Urls {
   implicit lazy val longSegment: Segment[Long] = (i: Long) => i.toString
 
 
-  trait Path[A] extends Url[A] with PathOps[A]
+  trait Path[A] extends Url[A]
 
   def staticPathSegment(segment: String) = (_: Unit) => segment
 

--- a/play-server/src/main/scala/endpoints/play/server/Urls.scala
+++ b/play-server/src/main/scala/endpoints/play/server/Urls.scala
@@ -80,7 +80,7 @@ trait Urls extends algebra.Urls {
   /**
     * Query string encoding and decoding
     */
-  trait QueryString[A] extends QueryStringOps[A] {
+  trait QueryString[A] {
     /**
       * @param qs Map of identifiers and parameter values (these are already URL decoded)
       */
@@ -148,7 +148,7 @@ trait Urls extends algebra.Urls {
         Map(name -> Seq(i.toString))
     }
 
-  trait Path[A] extends PathOps[A] with Url[A] {
+  trait Path[A] extends Url[A] {
     def decode(segments: List[String]): Option[(A, List[String])]
     def encode(a: A): String
 

--- a/xhr-client/src/main/scala/endpoints/xhr/Urls.scala
+++ b/xhr-client/src/main/scala/endpoints/xhr/Urls.scala
@@ -30,7 +30,7 @@ trait Urls extends algebra.Urls {
   /**
     * Defines how to build a query string from an `A`
     */
-  trait QueryString[A] extends QueryStringOps[A] {
+  trait QueryString[A] {
     /** @return A query string fragment (e.g. "foo=bar&baz=a%20b") */
     def encode(a: A): String
   }
@@ -65,7 +65,7 @@ trait Urls extends algebra.Urls {
     (i: Long) => i.toString
 
   /** Builds an URL path from an `A` */
-  trait Path[A] extends Url[A] with PathOps[A]
+  trait Path[A] extends Url[A]
 
   def staticPathSegment(segment: String) = (_: Unit) => segment
 


### PR DESCRIPTION
I’m not a big fan of implicit conversions. Therefore, the current design puts lower bounds to abstract type members:

~~~ scala
type Url[A] <: UrlOps[A]
~~~

However, in some cases this is very inconvenient:

~~~ scala
type Url[A] = String // does not compile because String is not a subtype of UrlOps[A]
~~~

This PR uses implicit conversions instead.