### PR TITLE
Builders API

### DIFF
--- a/akka-http-server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http-server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -41,6 +41,10 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
 
   def emptyHeaders: RequestHeaders[Unit] = convToDirective1(Directives.pass)
 
+  def joinHeaders[H1, H2](h1: RequestHeaders[H1], h2: RequestHeaders[H2])(implicit tupler: Tupler[H1, H2]): RequestHeaders[tupler.Out] = {
+    h1.flatMap(h1p => h2.map(h2p => tupler.apply(h1p, h2p)))
+  }
+
   def emptyResponse: Response[Unit] = x => Directives.complete((StatusCodes.OK, ""))
 
   def textResponse: Response[String] = x => Directives.complete((StatusCodes.OK, x))

--- a/algebra/src/main/scala/endpoints/algebra/Builders.scala
+++ b/algebra/src/main/scala/endpoints/algebra/Builders.scala
@@ -6,7 +6,7 @@ import endpoints.algebra.BasicAuthentication.Credentials
 trait Builders {
   self: Endpoints =>
 
-  def anEndpoint: EndpointBuilder[Unit, Unit, Unit, Unit] = EndpointBuilder(Get, path, emptyHeaders, emptyRequest, emptyResponse)
+  val anEndpoint: EndpointBuilder[Unit, Unit, Unit, Unit] = EndpointBuilder(Get, path, emptyHeaders, emptyRequest, emptyResponse)
 
   case class EndpointBuilder[U, ReqH, ReqE, RespE]
   (method: Method,
@@ -66,7 +66,7 @@ trait JsonBuilders extends Builders {
 trait BasicAuthBuilders extends Builders {
   self: BasicAuthentication =>
 
-  implicit class EndpointJsonOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
+  implicit class EndpointBasicAuthOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
 
     def withBasicAuth(implicit tupler: Tupler[ReqH, Credentials]): EndpointBuilder[U, tupler.Out, ReqE, Option[RespE]] = {
       val newResponse = authenticated(endp.response)
@@ -82,7 +82,7 @@ trait BasicAuthBuilders extends Builders {
 trait OptionalResponseBuilders extends Builders {
   self: OptionalResponses =>
 
-  implicit class EndpointJsonOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
+  implicit class EndpointOptionalResponseOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
 
     def withOptionalResponse[NewResp](resp: Response[NewResp]): EndpointBuilder[U, ReqH, ReqE, Option[NewResp]] = {
       val newResponse = option(resp)

--- a/algebra/src/main/scala/endpoints/algebra/Builders.scala
+++ b/algebra/src/main/scala/endpoints/algebra/Builders.scala
@@ -1,0 +1,101 @@
+package endpoints.algebra
+
+import endpoints.Tupler
+import endpoints.algebra.BasicAuthentication.Credentials
+
+trait Builders {
+  self: Endpoints =>
+
+  def anEndpoint: EndpointBuilder[Unit, Unit, Unit, Unit] = EndpointBuilder(Get, path, emptyHeaders, emptyRequest, emptyResponse)
+
+  case class EndpointBuilder[U, ReqH, ReqE, RespE]
+  (method: Method,
+   url: Url[U],
+   requestHeaders: RequestHeaders[ReqH],
+   requestEntity: RequestEntity[ReqE],
+   response: Response[RespE]
+  ) {
+    def withMethod(m: Method): EndpointBuilder[U, ReqH, ReqE, RespE] =
+      this.copy(method = m)
+
+    def withUrl[NewU](u: Url[NewU]): EndpointBuilder[NewU, ReqH, ReqE, RespE] =
+      this.copy(url = u)
+
+    def withRequestHeaders[NewReqH](rh: RequestHeaders[NewReqH]): EndpointBuilder[U, NewReqH, ReqE, RespE] =
+      this.copy(requestHeaders = rh)
+
+    def addRequestHeaders[NewReqH](rh: RequestHeaders[NewReqH])(implicit tupler: Tupler[ReqH, NewReqH]): EndpointBuilder[U, tupler.Out, ReqE, RespE] = {
+      val newHeaders = joinHeaders(this.requestHeaders, rh)
+      this.copy(requestHeaders = newHeaders)
+    }
+
+    def withRequestEntity[NewReqE](re: RequestEntity[NewReqE]): EndpointBuilder[U, ReqH, NewReqE, RespE] =
+      this.copy(requestEntity = re)
+
+    def withResponse[NewRespE](r: Response[NewRespE]): EndpointBuilder[U, ReqH, ReqE, NewRespE] =
+      this.copy(response = r)
+
+    def withTextResponse: EndpointBuilder[U, ReqH, ReqE, String] =
+      this.copy(response = textResponse)
+
+    def build[UE](implicit tuplerUE: Tupler.Aux[U, ReqE, UE], tuplerUEH: Tupler[UE, ReqH]): Endpoint[tuplerUEH.Out, RespE] =
+      endpoint(
+        request(this.method, this.url, this.requestEntity, this.requestHeaders),
+        this.response
+      )
+  }
+
+
+}
+
+trait JsonBuilders extends Builders {
+  self: JsonEntities =>
+
+  implicit class EndpointJsonOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
+
+    def withJsonRequest[NewReqE: JsonRequest]: EndpointBuilder[U, ReqH, NewReqE, RespE] =
+      endp.copy(requestEntity = self.jsonRequest[NewReqE])
+
+    def withJsonResponse[NewRespE: JsonResponse]: EndpointBuilder[U, ReqH, ReqE, NewRespE] =
+      endp.copy(response = self.jsonResponse[NewRespE])
+
+  }
+
+}
+
+trait BasicAuthBuilders extends Builders {
+  self: BasicAuthentication =>
+
+  implicit class EndpointJsonOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
+
+    def withBasicAuth(implicit tupler: Tupler[ReqH, Credentials]): EndpointBuilder[U, tupler.Out, ReqE, Option[RespE]] = {
+      val newResponse = authenticated(endp.response)
+      endp
+        .addRequestHeaders(basicAuthentication)
+        .withResponse(newResponse)
+    }
+
+  }
+
+}
+
+trait OptionalResponseBuilders extends Builders {
+  self: OptionalResponses =>
+
+  implicit class EndpointJsonOps[U, ReqH, ReqE, RespE](endp: EndpointBuilder[U, ReqH, ReqE, RespE]) {
+
+    def withOptionalResponse[NewResp](resp: Response[NewResp]): EndpointBuilder[U, ReqH, ReqE, Option[NewResp]] = {
+      val newResponse = option(resp)
+      endp
+        .withResponse(newResponse)
+    }
+
+    def withOptionalResponse: EndpointBuilder[U, ReqH, ReqE, Option[RespE]] = {
+      val newResponse = option(endp.response)
+      endp
+        .withResponse(newResponse)
+    }
+
+  }
+
+}

--- a/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -17,6 +17,9 @@ trait Requests extends Urls with Methods {
     */
   def emptyHeaders: RequestHeaders[Unit]
 
+  /** Join informations carried by two sets of headers */
+  def joinHeaders[H1, H2](h1: RequestHeaders[H1], h2: RequestHeaders[H2])(implicit tupler: Tupler[H1, H2]): RequestHeaders[tupler.Out]
+
 
   /** Information carried by a whole request (headers and entity) */
   type Request[A]
@@ -38,12 +41,12 @@ trait Requests extends Urls with Methods {
     * @param entity Request entity
     * @param headers Request headers
     */
-  def request[A, B, C, AB](
+  def request[U, E, H, UE](
     method: Method,
-    url: Url[A],
-    entity: RequestEntity[B] = emptyRequest,
-    headers: RequestHeaders[C] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out]
+    url: Url[U],
+    entity: RequestEntity[E] = emptyRequest,
+    headers: RequestHeaders[H] = emptyHeaders
+  )(implicit tuplerUE: Tupler.Aux[U, E, UE], tuplerUEH: Tupler[UE, H]): Request[tuplerUEH.Out]
 
   /**
     * Helper method to perform GET request

--- a/algebra/src/main/scala/endpoints/algebra/Urls.scala
+++ b/algebra/src/main/scala/endpoints/algebra/Urls.scala
@@ -2,7 +2,7 @@ package endpoints.algebra
 
 import endpoints.Tupler
 
-import scala.language.higherKinds
+import scala.language.{higherKinds, implicitConversions}
 
 /**
   * Algebra interface for describing URLs made of a path and a query string.
@@ -96,6 +96,9 @@ trait Urls {
 
   /** An URL path carrying an `A` information */
   type Path[A] <: Url[A]
+
+  // This should remove false positive error in Intellij when using path as an url
+  implicit def pathToUrl[A](path: Path[A]): Url[A] = path
 
   /** Convenient methods for [[Path]]s. */
   implicit class PathOps[A](first: Path[A]) {

--- a/play-client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play-client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -26,6 +26,15 @@ class Endpoints(host: String, wsClient: WSClient)(implicit ec: ExecutionContext)
   /** Does not modify the request */
   lazy val emptyHeaders: RequestHeaders[Unit] = (_, wsRequest) => wsRequest
 
+  /** Put both sets of headers in request */
+  def joinHeaders[H1, H2](h1: RequestHeaders[H1], h2: RequestHeaders[H2])(implicit tupler: Tupler[H1, H2]): RequestHeaders[tupler.Out] = {
+    (h1h2, wsRequest) => {
+      val (h1p, h2p) = tupler.unapply(h1h2)
+      h2(h2p, h1(h1p, wsRequest))
+    }
+  }
+
+
   /**
     * A function that takes an `A` information and eventually returns a `WSResponse`
     */

--- a/play-server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play-server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -56,6 +56,13 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
   /** Always succeeds in extracting no information from the headers */
   lazy val emptyHeaders: RequestHeaders[Unit] = _ => Right(())
 
+  /** Succeeds if both informations can be extracted from headers*/
+  def joinHeaders[H1, H2](h1: RequestHeaders[H1], h2: RequestHeaders[H2])(implicit tupler: Tupler[H1, H2]): RequestHeaders[tupler.Out] = {
+    headers => {
+      h1(headers).right.flatMap(h1p => h2(headers).right.map(h2p => tupler.apply(h1p, h2p)))
+    }
+  }
+
   /**
     * An HTTP request.
     *

--- a/scalaj-client-circe/src/test/scala/endpoints/scalaj/client/CirceEntitiesTest.scala
+++ b/scalaj-client-circe/src/test/scala/endpoints/scalaj/client/CirceEntitiesTest.scala
@@ -23,6 +23,6 @@ class CirceEntitiesTest extends JsonTestSuite[TestClient] {
 
   def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Resp = endpoint.callUnsafe(args)
 
-  clientTestSuite()
+  jsonTestSuite()
 
 }

--- a/scalaj-client/src/main/scala/endpoints/scalaj/client/OptionalResponses.scala
+++ b/scalaj-client/src/main/scala/endpoints/scalaj/client/OptionalResponses.scala
@@ -1,7 +1,8 @@
 package endpoints.scalaj.client
 
+import endpoints.algebra
 
-trait OptionalResponses extends Endpoints {
+trait OptionalResponses extends algebra.OptionalResponses { self: Endpoints =>
 
   def option[A](response: Response[A]): Response[Option[A]] =
     resp => {

--- a/scalaj-client/src/main/scala/endpoints/scalaj/client/OptionalResponses.scala
+++ b/scalaj-client/src/main/scala/endpoints/scalaj/client/OptionalResponses.scala
@@ -1,0 +1,14 @@
+package endpoints.scalaj.client
+
+
+trait OptionalResponses extends Endpoints {
+
+  def option[A](response: Response[A]): Response[Option[A]] =
+    resp => {
+      if(resp.code == 404)
+        Right(None)
+      else
+        response(resp).right.map(Some(_))
+    }
+
+}

--- a/scalaj-client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj-client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -16,7 +16,13 @@ trait Requests extends algebra.Requests with Urls with Methods{
 
    def emptyHeaders: RequestHeaders[Unit] = _ => Seq()
 
-   def emptyRequest: RequestEntity[Unit] = (x: Unit, req: HttpRequest) => req
+  def joinHeaders[H1, H2](h1: RequestHeaders[H1], h2: RequestHeaders[H2])(implicit tupler: Tupler[H1, H2]): RequestHeaders[tupler.Out] =
+    h1h2 => {
+      val (hp1, hp2) = tupler.unapply(h1h2)
+      h1(hp1) ++ h2(hp2)
+    }
+
+  def emptyRequest: RequestEntity[Unit] = (x: Unit, req: HttpRequest) => req
 
 
   def request[U, E, H, UE](method: Method,

--- a/scalaj-client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
+++ b/scalaj-client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
@@ -1,14 +1,18 @@
 package endpoints.scalaj.client
 
-import endpoints.testsuite.{BasicAuthTestApi, SimpleTestApi}
-import endpoints.testsuite.client.{BasicAuthTestSuite, SimpleTestSuite}
+import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi, SimpleTestApi}
+import endpoints.testsuite.client.{BasicAuthTestSuite, OptionalResponsesTestSuite, SimpleTestSuite}
 
 class TestClient(val address: String) extends SimpleTestApi
   with BasicAuthTestApi
+  with OptionalResponsesTestApi
   with Endpoints
   with BasicAuthentication
+  with OptionalResponses
 
-class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[TestClient] {
+class EndpointsTest extends SimpleTestSuite[TestClient]
+  with BasicAuthTestSuite[TestClient]
+  with OptionalResponsesTestSuite[TestClient] {
 
   val client: TestClient = new TestClient(s"localhost:$wiremockPort")
 
@@ -18,5 +22,7 @@ class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[
   clientTestSuite()
 
   basicAuthSuite()
+
+  optionalResponsesSuite()
 
 }

--- a/testsuite/src/main/scala/endpoints/testsuite/BasicAuthTestApi.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/BasicAuthTestApi.scala
@@ -1,8 +1,9 @@
 package endpoints.testsuite
 
 import endpoints.algebra
+import endpoints.algebra.BasicAuthBuilders
 
-trait BasicAuthTestApi extends algebra.Endpoints with algebra.BasicAuthentication {
+trait BasicAuthTestApi extends algebra.Endpoints with algebra.BasicAuthentication with BasicAuthBuilders {
 
 
   val protectedEndpoint = authenticatedEndpoint(
@@ -11,5 +12,14 @@ trait BasicAuthTestApi extends algebra.Endpoints with algebra.BasicAuthenticatio
     emptyRequest,
     textResponse
   )
+
+  val protectedEndpointViaBuilder =
+    anEndpoint
+      .withMethod(Get)
+      .withUrl(path / "users")
+      .withTextResponse
+      .withBasicAuth
+      .build
+
 
 }

--- a/testsuite/src/main/scala/endpoints/testsuite/JsonTestApi.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/JsonTestApi.scala
@@ -1,18 +1,28 @@
 package endpoints.testsuite
 
 import endpoints.algebra
+import endpoints.algebra.JsonBuilders
 import io.circe.generic.JsonCodec
 
-trait JsonTestApi extends algebra.Endpoints with algebra.JsonEntities {
+trait JsonTestApi extends algebra.Endpoints with algebra.JsonEntities with JsonBuilders {
 
   implicit def userCodec: JsonRequest[User]
+
   implicit def addresCodec: JsonResponse[Address]
 
 
-  val smokeEndpoint = endpoint(
+  val jsonEndpoint = endpoint(
     post(path / "user", jsonRequest[User]),
     jsonResponse[Address]
   )
+
+  val jsonEndpointViaBuilder =
+    anEndpoint
+      .withMethod(Post)
+      .withUrl(path / "user")
+      .withJsonRequest[User]
+      .withJsonResponse[Address]
+      .build
 
 }
 

--- a/testsuite/src/main/scala/endpoints/testsuite/OptionalResponsesTestApi.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/OptionalResponsesTestApi.scala
@@ -1,0 +1,33 @@
+package endpoints.testsuite
+
+import endpoints.algebra
+import endpoints.algebra.OptionalResponseBuilders
+
+trait OptionalResponsesTestApi extends algebra.Endpoints with algebra.OptionalResponses with OptionalResponseBuilders {
+
+
+  val optionalResponseEndp = endpoint(
+    request(Get,
+      path / "user",
+      emptyRequest
+    ),
+    option(textResponse)
+  )
+
+  val optionalResponseEndpViaBuilder =
+    anEndpoint
+      .withMethod(Get)
+      .withUrl(path / "user")
+      .withTextResponse
+      .withOptionalResponse
+      .build
+
+  val optionalResponseEndpViaBuilder2 =
+    anEndpoint
+      .withMethod(Get)
+      .withUrl(path / "user")
+      .withOptionalResponse(textResponse)
+      .build
+
+
+}

--- a/testsuite/src/main/scala/endpoints/testsuite/SimpleTestApi.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/SimpleTestApi.scala
@@ -1,13 +1,21 @@
 package endpoints.testsuite
 
 import endpoints.algebra
+import endpoints.algebra.Builders
 
-trait SimpleTestApi extends algebra.Endpoints {
+trait SimpleTestApi extends algebra.Endpoints with Builders {
 
 
   val smokeEndpoint = endpoint(
     get(path / "user" / segment[String] / "description" /? (qs[String]("name") & qs[Int]("age"))),
     textResponse
   )
+
+  val smokeEndpointViaBuilder =
+    anEndpoint
+      .withMethod(Get)
+      .withUrl(path / "user" / segment[String] / "description" /? (qs[String]("name") & qs[Int]("age")))
+      .withTextResponse
+      .build
 
 }

--- a/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
@@ -8,7 +8,7 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
 
   def basicAuthSuite() = {
 
-    "Client interpreter" should {
+    "Basic auth interpreter" should {
 
       "authenticate with given credentials" in {
 

--- a/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
@@ -23,7 +23,10 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
 
         val result = call(client.protectedEndpoint, credentials)
 
+        val resultViaBuilder = call(client.protectedEndpointViaBuilder, credentials)
+
         result shouldEqual Some(response)
+        resultViaBuilder shouldEqual Some(response)
 
       }
 
@@ -38,7 +41,10 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
 
         val result = call(client.protectedEndpoint, credentials)
 
+        val resultViaBuilder = call(client.protectedEndpointViaBuilder, credentials)
+
         result shouldEqual None
+        resultViaBuilder shouldEqual None
 
       }
 

--- a/testsuite/src/main/scala/endpoints/testsuite/client/JsonTestSuite.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/client/JsonTestSuite.scala
@@ -9,7 +9,7 @@ trait JsonTestSuite[T <: JsonTestApi] extends ClientTestBase[T] {
   import io.circe.generic.auto._
   import io.circe.syntax._
 
-  def clientTestSuite() = {
+  def jsonTestSuite() = {
 
     "Client interpreter" should {
 
@@ -25,9 +25,11 @@ trait JsonTestSuite[T <: JsonTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(addressStr)))
 
-        val result = call(client.smokeEndpoint, user)
+        val result = call(client.jsonEndpoint, user)
+        val result2 = call(client.jsonEndpointViaBuilder, user)
 
         result shouldEqual address
+        result2 shouldEqual address
 
       }
 

--- a/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
@@ -8,15 +8,14 @@ trait OptionalResponsesTestSuite[T <: OptionalResponsesTestApi] extends ClientTe
 
   def optionalResponsesSuite() = {
 
-    "Client interpreter" should {
+    "Optional responses interpreter" should {
 
       "return the content if present" in {
 
         val credentials = BasicAuthentication.Credentials("user1", "pass2")
         val response = "wiremockeResponse"
 
-        wireMockServer.stubFor(get(urlEqualTo("/users"))
-          .withBasicAuth(credentials.username, credentials.password)
+        wireMockServer.stubFor(get(urlEqualTo("/user"))
           .willReturn(aResponse()
             .withStatus(200)
             .withBody(response)))
@@ -36,7 +35,7 @@ trait OptionalResponsesTestSuite[T <: OptionalResponsesTestApi] extends ClientTe
 
         val credentials = BasicAuthentication.Credentials("user1", "pass2")
 
-        wireMockServer.stubFor(get(urlEqualTo("/users"))
+        wireMockServer.stubFor(get(urlEqualTo("/user"))
           .willReturn(aResponse()
             .withStatus(404)
             .withBody("")))

--- a/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
@@ -1,0 +1,60 @@
+package endpoints.testsuite.client
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import endpoints.algebra.BasicAuthentication
+import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi}
+
+trait OptionalResponsesTestSuite[T <: OptionalResponsesTestApi] extends ClientTestBase[T] {
+
+  def optionalResponsesSuite() = {
+
+    "Client interpreter" should {
+
+      "return the content if present" in {
+
+        val credentials = BasicAuthentication.Credentials("user1", "pass2")
+        val response = "wiremockeResponse"
+
+        wireMockServer.stubFor(get(urlEqualTo("/users"))
+          .withBasicAuth(credentials.username, credentials.password)
+          .willReturn(aResponse()
+            .withStatus(200)
+            .withBody(response)))
+
+        val result = call(client.optionalResponseEndp, ())
+        val result2 = call(client.optionalResponseEndpViaBuilder, ())
+        val result3 = call(client.optionalResponseEndpViaBuilder2, ())
+
+
+        result shouldEqual Some(response)
+        result2 shouldEqual Some(response)
+        result3 shouldEqual Some(response)
+
+      }
+
+      "return None in case of 404" in {
+
+        val credentials = BasicAuthentication.Credentials("user1", "pass2")
+
+        wireMockServer.stubFor(get(urlEqualTo("/users"))
+          .willReturn(aResponse()
+            .withStatus(404)
+            .withBody("")))
+
+        val result = call(client.optionalResponseEndp, ())
+        val result2 = call(client.optionalResponseEndpViaBuilder, ())
+        val result3 = call(client.optionalResponseEndpViaBuilder2, ())
+
+        result shouldEqual None
+        result2 shouldEqual None
+        result3 shouldEqual None
+
+      }
+
+
+    }
+
+  }
+
+
+}

--- a/testsuite/src/main/scala/endpoints/testsuite/client/SimpleTestSuite.scala
+++ b/testsuite/src/main/scala/endpoints/testsuite/client/SimpleTestSuite.scala
@@ -23,8 +23,10 @@ trait SimpleTestSuite[T <: SimpleTestApi] extends ClientTestBase[T] {
             .withBody(response)))
 
         val result = call(client.smokeEndpoint, ("userId", "name1", 18))
+        val result2 = call(client.smokeEndpointViaBuilder, ("userId", "name1", 18))
 
         result shouldEqual response
+        result2 shouldEqual response
 
       }
 
@@ -37,6 +39,9 @@ trait SimpleTestSuite[T <: SimpleTestApi] extends ClientTestBase[T] {
 
         a[Exception] should be thrownBy {
           call(client.smokeEndpoint, ("userId", "name1", 18))
+        }
+        a[Exception] should be thrownBy {
+          call(client.smokeEndpointViaBuilder, ("userId", "name1", 18))
         }
 
       }

--- a/xhr-client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr-client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -23,6 +23,18 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
   /** Sets up no headers on the given XMLHttpRequest */
   lazy val emptyHeaders: RequestHeaders[Unit] = (_, _) => ()
 
+  /** Join two sets of headers*/
+  def joinHeaders[H1, H2](h1: RequestHeaders[H1], h2: RequestHeaders[H2])(implicit tupler: Tupler[H1, H2]): RequestHeaders[tupler.Out] = {
+    (headers, xhr) => {
+      val (h1p, h2p) = tupler.unapply(headers)
+      h1(h1p, xhr)
+      h2(h2p, xhr)
+      ()
+    }
+
+
+  }
+
   /**
     * A function that takes the information `A` and returns an XMLHttpRequest
     * with an optional request entity. If provided, the request entity must be


### PR DESCRIPTION
This is a try to introduce a builder api, that will allow more readable endpoint definitions. This may be also a first step to address(at least partially) #42. 

Things worth mentioning:
- I have added ability to join request headers. This allowed me to create more extensible definition of basic authentication
- I have added builders for most of the algebras
- I have added support for OptionalResponses for scalaj interpreter
- I have added a controversial implicit conversion from `Path[A]` to `Url[A]`. I'm not 100% sure about that, but motivation for this was to get rid of intellij error. 

The readability of new api can be easily compared in testsuites.

Also, I'm not 100% about naming(of methods and traits) so any sugestions are very welcome.