### PR TITLE
Add akka-http client

### DIFF
--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -2,6 +2,36 @@ import EndpointsSettings._
 
 val `algebra-jvm` = LocalProject("algebraJVM")
 val `algebra-circe-jvm` = LocalProject("algebra-circeJVM")
+val `testsuite-jvm` = LocalProject("testsuiteJVM")
+
+val akkaHttpVersion = "10.0.1"
+val akkaHttpJsonVersion = "1.17.0"
+
+val `akka-http-client` =
+  project.in(file("client"))
+    .settings(publishSettings: _*)
+    .settings(`scala 2.11 to 2.12`: _*)
+    .settings(
+      name := "endpoints-akka-http-client",
+      libraryDependencies ++= Seq(
+        "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
+        "org.scalatest" %% "scalatest" % "3.0.1" % Test
+      )
+    )
+    .dependsOn(`algebra-jvm`, `testsuite-jvm` % Test)
+
+val `akka-http-client-circe` =
+  project.in(file("client-circe"))
+    .settings(publishSettings: _*)
+    .settings(`scala 2.11 to 2.12`: _*)
+    .settings(
+      name := "endpoints-akka-http-client-circe",
+      libraryDependencies ++= Seq(
+        "io.circe" %% "circe-parser" % circeVersion
+      )
+    )
+    .dependsOn(`akka-http-client`, `algebra-circe-jvm`)
 
 val `akka-http-server` =
   project.in(file("server"))
@@ -10,8 +40,8 @@ val `akka-http-server` =
     .settings(
       name := "endpoints-akka-http-server",
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-http" % "10.0.1",
-        "com.typesafe.akka" %% "akka-http-testkit" % "10.0.1" % Test,
+        "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
         "org.scalatest" %% "scalatest" % "3.0.1" % Test
       )
     )
@@ -24,7 +54,7 @@ val `akka-http-server-circe` =
     .settings(
       name := "endpoints-akka-http-server-circe",
       libraryDependencies ++= Seq(
-        "de.heikoseeberger" %% "akka-http-circe" % "1.11.0"
+        "de.heikoseeberger" %% "akka-http-circe" % akkaHttpJsonVersion
       )
     )
     .dependsOn(`akka-http-server`, `algebra-circe-jvm`)

--- a/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/CirceEntities.scala
+++ b/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/CirceEntities.scala
@@ -1,0 +1,35 @@
+package endpoints.akkahttp.client
+
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import endpoints.algebra
+import endpoints.algebra.CirceEntities.CirceCodec
+import io.circe.jawn
+
+import scala.concurrent.Future
+
+trait CirceEntities extends algebra.CirceEntities { this: Endpoints =>
+
+  /** Builds a request entity by using the supplied codec */
+  def jsonRequest[A : CirceCodec]: RequestEntity[A] = {
+    case (a, req) => req.copy(entity = HttpEntity(implicitly[CirceCodec[A]].encoder(a).noSpaces))
+  }
+
+  /** Decodes a response entity by using the supplied codec */
+  def jsonResponse[A : CirceCodec]: Response[A] =
+    response =>
+      if(response.status == StatusCodes.OK) {
+        for {
+          strictResponse <- response.entity.toStrict(settings.toStrictTimeout)
+          json <- jawn.parse(settings.stringContentExtractor(strictResponse)) match {
+            case Left(err) => Future.failed(new Throwable(err.message))
+            case Right(v) => Future.successful(v)
+          }
+          res <- CirceCodec[A].decoder.decodeJson(json) match {
+            case Left(err) => Future.successful(Left(new Throwable(err.message)))
+            case Right(v) => Future.successful(Right(v))
+          }
+        } yield res
+      } else {
+        Future.failed(new Throwable(s"Unexpected status code: ${response.status.intValue()}"))
+      }
+}

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
@@ -1,0 +1,28 @@
+package endpoints.akkahttp.client
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import endpoints.algebra
+import endpoints.algebra.BasicAuthentication.Credentials
+
+import scala.concurrent.Future
+
+trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints =>
+
+  /**
+    * Supplies the credential into the request headers
+    */
+  private[endpoints] lazy val basicAuthentication: RequestHeaders[Credentials] =
+    (credentials, headers) => {
+      headers :+ Authorization(BasicHttpCredentials(credentials.username, credentials.password))
+    }
+
+  /**
+    * Checks that the result is not `Forbidden`
+    */
+  private[endpoints] def authenticated[A](response: Response[A]): Response[Option[A]] =
+    resp =>
+      if (resp.status == StatusCodes.Forbidden) Future.successful(Right(None))
+      else response(resp).map(_.right.map(Some.apply))
+
+}

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -1,0 +1,93 @@
+package endpoints.akkahttp.client
+
+import akka.http.scaladsl.model._
+import akka.stream.Materializer
+import endpoints.algebra.{Decoder, Encoder, MuxRequest}
+import endpoints.{Tupler, algebra}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class Endpoints(val settings: EndpointsSettings)
+               (implicit val EC: ExecutionContext, val M: Materializer) extends algebra.Endpoints with Urls with Methods {
+  type RequestHeaders[A] = (A, List[HttpHeader]) => List[HttpHeader]
+
+  lazy val emptyHeaders: RequestHeaders[Unit] = (_, req) => req
+
+  type Request[A] = A => Future[HttpResponse]
+
+  type RequestEntity[A] = (A, HttpRequest) => HttpRequest
+
+  lazy val emptyRequest: RequestEntity[Unit] = (_, req) => req
+
+  def request[A, B, C, AB](
+                            method: Method, url: Url[A],
+                            entity: RequestEntity[B], headers: RequestHeaders[C]
+                          )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
+    (abc: tuplerABC.Out) => {
+      val (ab, c) = tuplerABC.unapply(abc)
+      val (a, b) = tuplerAB.unapply(ab)
+      val uri =
+        if (settings.baseUri == Uri("/")) Uri(url.encode(a))
+        else Uri(s"${settings.baseUri.path}${url.encode(a)}")
+
+      val request = method(entity(b, HttpRequest(uri = uri)))
+        .withHeaders(headers(c, List.empty))
+
+      settings.requestExecutor(request)
+    }
+
+  type Response[A] = HttpResponse => Future[Either[Throwable, A]]
+
+  val emptyResponse: Response[Unit] = _ => Future.successful(Right(()))
+
+  val textResponse: Response[String] = x =>
+    if (x.status == StatusCodes.OK) {
+      x.entity.toStrict(settings.toStrictTimeout)
+        .map(settings.stringContentExtractor)
+        .map(Right.apply)
+    } else {
+      Future.failed(new Throwable(s"Unexpected status code: ${x.status.intValue()}"))
+    }
+
+
+  type Endpoint[A, B] = A => Future[B]
+
+  def endpoint[A, B](request: Request[A], response: Response[B]): Endpoint[A, B] =
+    a =>
+      for {
+        resp <- request(a)
+        result <- response(resp).flatMap(futureFromEither)
+      } yield result
+
+  private def futureFromEither[A](errorOrA: Either[Throwable, A]): Future[A] =
+    errorOrA match {
+      case Left(error) => Future.failed(error)
+      case Right(a) => Future.successful(a)
+    }
+
+  class MuxEndpoint[Req <: algebra.MuxRequest, Resp, Transport](
+                                                                 request: Request[Transport],
+                                                                 response: Response[Transport]
+                                                               ) {
+    def apply(
+               req: Req
+             )(implicit
+               encoder: Encoder[Req, Transport],
+               decoder: Decoder[Transport, Resp]
+             ): Future[req.Response] =
+      request(encoder.encode(req)).flatMap { resp =>
+        response(resp).flatMap { t =>
+          futureFromEither(t).flatMap(tt =>
+            futureFromEither(decoder.decode(tt)).map(_.asInstanceOf[req.Response])
+          )
+        }
+      }
+  }
+
+  def muxEndpoint[Req <: MuxRequest, Resp, Transport](
+                                                       request: Request[Transport],
+                                                       response: Response[Transport]
+                                                     ): MuxEndpoint[Req, Resp, Transport] =
+    new MuxEndpoint[Req, Resp, Transport](request, response)
+
+}

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/EndpointsSettings.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/EndpointsSettings.scala
@@ -1,0 +1,36 @@
+package endpoints.akkahttp.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, Uri}
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Flow, Sink, Source}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Try
+
+final case class EndpointsSettings(
+  requestExecutor: AkkaHttpRequestExecutor,
+  baseUri: Uri = Uri("/"),
+  toStrictTimeout: FiniteDuration = 2.seconds,
+  stringContentExtractor: HttpEntity.Strict => String = _.data.utf8String
+)
+
+trait AkkaHttpRequestExecutor {
+  def apply(request: HttpRequest): Future[HttpResponse]
+}
+
+object AkkaHttpRequestExecutor {
+  def cachedHostConnectionPool(host: String, port: Int)(implicit system: ActorSystem, materializer: Materializer): AkkaHttpRequestExecutor =
+    default(Http().cachedHostConnectionPool[Int](host, port))
+
+  def default(poolClientFlow: Flow[(HttpRequest, Int), (Try[HttpResponse], Int), Http.HostConnectionPool])(implicit materializer: Materializer): AkkaHttpRequestExecutor =
+    new AkkaHttpRequestExecutor {
+      override def apply(request: HttpRequest): Future[HttpResponse] =
+        Source.single(request -> 1)
+          .via(poolClientFlow)
+          .map(_._1.get)
+          .runWith(Sink.head)
+    }
+}

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Methods.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Methods.scala
@@ -1,0 +1,16 @@
+package endpoints.akkahttp.client
+
+import akka.http.scaladsl.model.{HttpMethod, HttpMethods, HttpRequest}
+import endpoints.algebra
+
+trait Methods extends algebra.Methods {
+  type Method = HttpRequest => HttpRequest
+
+  def Get = _.copy(method = HttpMethods.GET)
+
+  def Post = _.copy(method = HttpMethods.POST)
+
+  def Put = _.copy(method = HttpMethods.PUT)
+
+  def Delete = _.copy(method = HttpMethods.DELETE)
+}

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
@@ -1,0 +1,87 @@
+package endpoints.akkahttp.client
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+import endpoints.Tupler
+import endpoints.algebra
+
+/**
+  * [[algebra.Urls]] interpreter that builds URLs.
+  */
+trait Urls extends algebra.Urls {
+
+  val utf8Name = UTF_8.name()
+
+  trait QueryString[A] {
+    def encodeQueryString(a: A): Option[String]
+  }
+
+  def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
+    (ab: tupler.Out) => {
+      val (a, b) = tupler.unapply(ab)
+
+      (first.encodeQueryString(a), second.encodeQueryString(b)) match {
+        case (Some(left), Some(right)) => Some(s"$left&$right")
+        case (Some(left), None) => Some(left)
+        case (None, Some(right)) => Some(right)
+        case (None, None) => None
+      }
+    }
+
+  def qs[A](name: String)(implicit value: QueryStringParam[A]): QueryString[A] =
+    a => Some(s"$name=${value.apply(a)}")
+
+  def optQs[A](name: String)(implicit value: QueryStringParam[A]): QueryString[Option[A]] = {
+    case Some(a) => qs[A](name).encodeQueryString(a)
+    case None => None
+  }
+
+  type QueryStringParam[A] = A => String
+
+  implicit lazy val stringQueryString: QueryStringParam[String] = s => URLEncoder.encode(s, utf8Name)
+
+  implicit lazy val intQueryString: QueryStringParam[Int] = i => i.toString
+
+  implicit lazy val longQueryString: QueryStringParam[Long] = i => i.toString
+
+
+  trait Segment[A] {
+    def encode(a: A): String
+  }
+
+  implicit lazy val stringSegment: Segment[String] = (s: String) => URLEncoder.encode(s, utf8Name)
+
+  implicit lazy val intSegment: Segment[Int] = (i: Int) => i.toString
+
+  implicit lazy val longSegment: Segment[Long] = (i: Long) => i.toString
+
+
+  trait Path[A] extends Url[A]
+
+  def staticPathSegment(segment: String) = (_: Unit) => segment
+
+  def segment[A](implicit s: Segment[A]): Path[A] = a => s.encode(a)
+
+  def chainPaths[A, B](first: Path[A], second: Path[B])(implicit tupler: Tupler[A, B]): Path[tupler.Out] =
+    (ab: tupler.Out) => {
+      val (a, b) = tupler.unapply(ab)
+      first.encode(a) ++ "/" ++ second.encode(b)
+    }
+
+
+  trait Url[A] {
+    def encode(a: A): String
+  }
+
+  def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] =
+    (ab: tupler.Out) => {
+      val (a, b) = tupler.unapply(ab)
+
+      qs.encodeQueryString(b) match {
+        case Some(q) => s"${path.encode(a)}?$q"
+        case None => path.encode(a)
+      }
+    }
+
+}

--- a/akka-http/client/src/test/scala/endpoints/akkahttp/client/EndpointsTest.scala
+++ b/akka-http/client/src/test/scala/endpoints/akkahttp/client/EndpointsTest.scala
@@ -1,0 +1,33 @@
+package endpoints.akkahttp.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.scaladsl.{Sink, Source}
+import endpoints.testsuite.{BasicAuthTestApi, SimpleTestApi}
+import endpoints.testsuite.client.{BasicAuthTestSuite, SimpleTestSuite}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class TestClient(settings: EndpointsSettings)
+                (implicit EC: ExecutionContext, M: Materializer)
+  extends Endpoints(settings)
+  with BasicAuthTestApi
+  with SimpleTestApi
+  with BasicAuthentication
+
+class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[TestClient] {
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  val client: TestClient = new TestClient(EndpointsSettings(AkkaHttpRequestExecutor.cachedHostConnectionPool("localhost", wiremockPort)))
+
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp] = endpoint(args)
+
+  clientTestSuite()
+  basicAuthSuite()
+}

--- a/documentation/manual/src/ornate/interfaces-and-interpreters.md
+++ b/documentation/manual/src/ornate/interfaces-and-interpreters.md
@@ -46,6 +46,8 @@ artifact. This artifact also provides its interpreters (in the
 |---|---|
 |[endpoints-akka-http-server](https://index.scala-lang.org/julienrf/endpoints/endpoints-akka-http-server)|Server backed by Akka-http|
 |[endpoints-akka-http-server-circe](https://index.scala-lang.org/julienrf/endpoints/endpoints-akka-http-server)|Interpreter for `CirceEntities` compatible with `endpoints-akka-http-server`|
+|[endpoints-akka-http-client](https://index.scala-lang.org/julienrf/endpoints/endpoints-akka-client)|Client backed by Akka-http|
+|[endpoints-akka-http-client-circe](https://index.scala-lang.org/julienrf/endpoints/endpoints-akka-http-client-circe)|Interpreter for `CirceEntities` compatible with `endpoints-akka-http-client`|
 |[endpoints-play-client](https://index.scala-lang.org/julienrf/endpoints/endpoints-play-client)|Client backed by Play framework|
 |[endpoints-play-client-circe](https://index.scala-lang.org/julienrf/endpoints/endpoints-play-client-circe)|Interpreter for `CirceEntities` compatible with `endpoints-play-client`|
 |[endpoints-play-server](https://index.scala-lang.org/julienrf/endpoints/endpoints-play-server)|Server backed by Play framework|

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -67,5 +67,4 @@ object EndpointsSettings {
   // --- Common dependencies
 
   val circeVersion = "0.6.1"
-
 }

--- a/scalaj/client-circe/src/test/scala/endpoints/scalaj/client/CirceEntitiesTest.scala
+++ b/scalaj/client-circe/src/test/scala/endpoints/scalaj/client/CirceEntitiesTest.scala
@@ -5,7 +5,9 @@ import endpoints.testsuite.JsonTestApi
 import endpoints.testsuite.User
 import endpoints.testsuite.Address
 import endpoints.testsuite.client.JsonTestSuite
-import org.scalatest.WordSpec
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
 
 class TestClient(val address: String ) extends JsonTestApi with Endpoints with CirceEntities {
 
@@ -21,7 +23,8 @@ class CirceEntitiesTest extends JsonTestSuite[TestClient] {
 
   val client: TestClient = new TestClient(s"localhost:$wiremockPort")
 
-  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Resp = endpoint.callUnsafe(args)
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp] =
+    endpoint.callAsync(args)
 
   clientTestSuite()
 

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
@@ -17,11 +17,6 @@ trait Responses extends algebra.Responses {
     }
   }
 
-   def textResponse: Response[String] = x => {
-    Try(x.throwError.body) match {
-      case Failure(ex) => Left(ex)
-      case Success(x) => Right(x)
-    }
-  }
+   def textResponse: Response[String] = x => if(x.code == 200) Right(x.body) else Left(new Throwable(s"Unexpected status code: ${x.code}"))
 
 }

--- a/scalaj/client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
+++ b/scalaj/client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
@@ -2,6 +2,9 @@ package endpoints.scalaj.client
 
 import endpoints.testsuite.{BasicAuthTestApi, SimpleTestApi}
 import endpoints.testsuite.client.{BasicAuthTestSuite, SimpleTestSuite}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
 
 class TestClient(val address: String) extends SimpleTestApi
   with BasicAuthTestApi
@@ -12,7 +15,8 @@ class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[
 
   val client: TestClient = new TestClient(s"localhost:$wiremockPort")
 
-  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Resp = endpoint.callUnsafe(args)
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp] =
+    endpoint.callAsync(args)
 
 
   clientTestSuite()

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
@@ -4,6 +4,8 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import endpoints.algebra.BasicAuthentication
 import endpoints.testsuite.{BasicAuthTestApi, SimpleTestApi}
 
+import scala.concurrent.Future
+
 trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
 
   def basicAuthSuite() = {
@@ -21,9 +23,7 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        val result = call(client.protectedEndpoint, credentials)
-
-        result shouldEqual Some(response)
+        whenReady(call(client.protectedEndpoint, credentials))(_ shouldEqual Some(response))
 
       }
 
@@ -36,16 +36,9 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
             .withStatus(403)
             .withBody("")))
 
-        val result = call(client.protectedEndpoint, credentials)
-
-        result shouldEqual None
+        whenReady(call(client.protectedEndpoint, credentials))(_ shouldEqual None)
 
       }
-
-
     }
-
   }
-
-
 }

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/JsonTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/JsonTestSuite.scala
@@ -25,9 +25,7 @@ trait JsonTestSuite[T <: JsonTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(addressStr)))
 
-        val result = call(client.smokeEndpoint, user)
-
-        result shouldEqual address
+        whenReady(call(client.smokeEndpoint, user))(_ shouldEqual address)
 
       }
 

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/SimpleTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/SimpleTestSuite.scala
@@ -1,11 +1,7 @@
 package endpoints.testsuite.client
 
-import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
-import endpoints.algebra
 import endpoints.testsuite.SimpleTestApi
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpec}
 
 trait SimpleTestSuite[T <: SimpleTestApi] extends ClientTestBase[T] {
 
@@ -22,9 +18,7 @@ trait SimpleTestSuite[T <: SimpleTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        val result = call(client.smokeEndpoint, ("userId", "name1", 18))
-
-        result shouldEqual response
+        whenReady(call(client.smokeEndpoint, ("userId", "name1", 18))) { _ shouldEqual response }
 
       }
 
@@ -35,10 +29,7 @@ trait SimpleTestSuite[T <: SimpleTestApi] extends ClientTestBase[T] {
             .withStatus(501)
             .withBody("")))
 
-        a[Exception] should be thrownBy {
-          call(client.smokeEndpoint, ("userId", "name1", 18))
-        }
-
+        whenReady(call(client.smokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
       }
 
 


### PR DESCRIPTION
Rough version for akka-http client. Let me know what you think

I see this as todo:

- [x] Tests
- [x] We need to open issues for other clients which also use this `Urls.scala`.. I've copied it from the play-client project and added a few fixes regarding query string encoding (optional params)
- [x] Documentation in the code (not sure what you all need?)
- [x] Update docs in markdown files

Example of a client: https://github.com/Fristi/endpoints-test/blob/master/client/src/main/scala/com.veon/Client.scala