### PR TITLE
Unify clients and refactor a bit

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/OptionalResponses.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/OptionalResponses.scala
@@ -1,0 +1,16 @@
+package endpoints.akkahttp.client
+
+import akka.http.scaladsl.model.HttpResponse
+import endpoints.algebra
+
+import scala.concurrent.Future
+
+trait OptionalResponses extends algebra.OptionalResponses { this: Endpoints =>
+
+  override def option[A](inner: HttpResponse => Future[Either[Throwable, A]]): HttpResponse => Future[Either[Throwable, Option[A]]] = {
+    {
+      case resp if resp.status.intValue() == 404 => Future.successful(Right(None))
+      case resp => inner(resp).map(_.right.map(Some(_)))
+    }
+  }
+}

--- a/akka-http/client/src/test/scala/endpoints/akkahttp/client/EndpointsTest.scala
+++ b/akka-http/client/src/test/scala/endpoints/akkahttp/client/EndpointsTest.scala
@@ -2,19 +2,24 @@ package endpoints.akkahttp.client
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
-import endpoints.testsuite.{BasicAuthTestApi, SimpleTestApi}
-import endpoints.testsuite.client.{BasicAuthTestSuite, SimpleTestSuite}
+import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi, SimpleTestApi}
+import endpoints.testsuite.client.{BasicAuthTestSuite, OptionalResponsesTestSuite, SimpleTestSuite}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class TestClient(settings: EndpointsSettings)
                 (implicit EC: ExecutionContext, M: Materializer)
   extends Endpoints(settings)
+  with OptionalResponses
   with BasicAuthTestApi
   with SimpleTestApi
+  with OptionalResponsesTestApi
   with BasicAuthentication
 
-class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[TestClient] {
+class EndpointsTest
+  extends SimpleTestSuite[TestClient]
+    with BasicAuthTestSuite[TestClient]
+    with OptionalResponsesTestSuite[TestClient] {
 
   implicit val system = ActorSystem()
   implicit val materializer = ActorMaterializer()
@@ -26,4 +31,5 @@ class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[
 
   clientTestSuite()
   basicAuthSuite()
+  optionalResponsesSuite()
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -37,30 +37,40 @@ trait Requests extends Urls with Methods {
     * @param url Request URL
     * @param entity Request entity
     * @param headers Request headers
+    * @tparam UrlP Payload carried by url
+    * @tparam BodyP Payload carried by body
+    * @tparam HeadersP Payload carried by headers
+    * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
     */
-  def request[A, B, C, AB](
+  def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled](
     method: Method,
-    url: Url[A],
-    entity: RequestEntity[B] = emptyRequest,
-    headers: RequestHeaders[C] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out]
+    url: Url[UrlP],
+    entity: RequestEntity[BodyP] = emptyRequest,
+    headers: RequestHeaders[HeadersP] = emptyHeaders
+  )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out]
 
   /**
     * Helper method to perform GET request
+    * @tparam UrlP Payload carried by url
+    * @tparam HeadersP Payload carried by headers
     */
-  final def get[A, B](
-    url: Url[A],
-    headers: RequestHeaders[B] = emptyHeaders
-  )(implicit tuplerAC: Tupler[A, B]): Request[tuplerAC.Out] = request(Get, url, headers = headers)
+  final def get[UrlP, HeadersP](
+    url: Url[UrlP],
+    headers: RequestHeaders[HeadersP] = emptyHeaders
+  )(implicit tuplerAC: Tupler[UrlP, HeadersP]): Request[tuplerAC.Out] = request(Get, url, headers = headers)
 
   /**
     * Helper method to perform POST request
+    * @tparam UrlP Payload carried by url
+    * @tparam BodyP Payload carried by body
+    * @tparam HeadersP Payload carried by headers
+    * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
     */
-  final def post[A, B, C, AB](
-    url: Url[A],
-    entity: RequestEntity[B],
-    headers: RequestHeaders[C] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] = request(Post, url, entity, headers)
+  final def post[UrlP, BodyP, HeadersP, UrlAndBodyPTupled](
+    url: Url[UrlP],
+    entity: RequestEntity[BodyP],
+    headers: RequestHeaders[HeadersP] = emptyHeaders
+  )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out] = request(Post, url, entity, headers)
 
 
 }

--- a/play/build.sbt
+++ b/play/build.sbt
@@ -2,6 +2,7 @@ import EndpointsSettings._
 
 val `algebra-jvm` = LocalProject("algebraJVM")
 val `algebra-circe-jvm` = LocalProject("algebra-circeJVM")
+val `testsuite-jvm` = LocalProject("testsuiteJVM")
 
 val `play-server` =
   project.in(file("server"))
@@ -30,7 +31,7 @@ val `play-client` =
         name := "endpoints-play-client",
         libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % playVersion
       )
-      .dependsOn(`algebra-jvm`)
+      .dependsOn(`algebra-jvm`, `testsuite-jvm` % Test)
 
 val `play-client-circe` =
   project.in(file("client-circe"))

--- a/play/client/src/main/scala/endpoints/play/client/BasicAuthentication.scala
+++ b/play/client/src/main/scala/endpoints/play/client/BasicAuthentication.scala
@@ -1,0 +1,25 @@
+package endpoints.play.client
+
+import endpoints.algebra
+import endpoints.algebra.BasicAuthentication.Credentials
+import play.api.libs.ws.WSAuthScheme
+
+trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints =>
+
+  /**
+    * Supplies the credential into the request headers
+    */
+  private[endpoints] lazy val basicAuthentication: RequestHeaders[Credentials] =
+    (credentials, request) => {
+      request.withAuth(credentials.username, credentials.password, WSAuthScheme.BASIC)
+    }
+
+  /**
+    * Checks that the result is not `Forbidden`
+    */
+  private[endpoints] def authenticated[A](inner: Response[A]): Response[Option[A]] =
+    resp =>
+      if (resp.status == 403) Right(None)
+      else inner(resp).right.map(Some(_))
+
+}

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -54,10 +54,16 @@ class Endpoints(host: String, wsClient: WSClient)(implicit val executionContext:
   type Response[A] = WSResponse => Either[Throwable, A]
 
   /** Successfully decodes no information from a response */
-  val emptyResponse: Response[Unit] = _ => Right(())
+  val emptyResponse: Response[Unit] = {
+    case resp if resp.status >= 200 && resp.status < 300 => Right(())
+    case resp => Left(new Throwable(s"Unexpected status code: ${resp.status}"))
+  }
 
   /** Successfully decodes string information from a response */
-  val textResponse: Response[String] = x => Right(x.body)
+  val textResponse: Response[String] = {
+    case resp if resp.status >= 200 && resp.status < 300 => Right(resp.body)
+    case resp => Left(new Throwable(s"Unexpected status code: ${resp.status}"))
+  }
 
   //#concrete-carrier-type
   /**

--- a/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
+++ b/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
@@ -1,0 +1,36 @@
+package endpoints.play.client
+
+import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi, SimpleTestApi}
+import endpoints.testsuite.client.{BasicAuthTestSuite, OptionalResponsesTestSuite, SimpleTestSuite}
+import play.api.libs.ws.WSClient
+import play.api.test.WsTestClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TestClient(address: String, wsClient: WSClient)
+  (implicit EC: ExecutionContext)
+  extends Endpoints(address, wsClient)
+    with OptionalResponses
+    with BasicAuthTestApi
+    with SimpleTestApi
+    with OptionalResponsesTestApi
+    with BasicAuthentication
+
+class EndpointsTest
+  extends SimpleTestSuite[TestClient]
+    with BasicAuthTestSuite[TestClient]
+    with OptionalResponsesTestSuite[TestClient] {
+
+  import ExecutionContext.Implicits.global
+
+  val client: TestClient = WsTestClient.withClient(c => {
+    new TestClient(s"http://localhost:$wiremockPort", c)
+  })
+
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp] = endpoint(args)
+
+  clientTestSuite()
+  basicAuthSuite()
+  optionalResponsesSuite()
+}
+

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/OptionalResponses.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/OptionalResponses.scala
@@ -1,0 +1,15 @@
+package endpoints.scalaj.client
+
+import endpoints.algebra
+
+import scalaj.http.HttpResponse
+
+trait OptionalResponses extends algebra.OptionalResponses { this: Endpoints =>
+
+  override def option[A](inner: HttpResponse[String] => Either[Throwable, A]): HttpResponse[String] => Either[Throwable, Option[A]] = {
+    {
+      case resp if resp.code == 404 => Right(None)
+      case resp => inner(resp).right.map(Some(_))
+    }
+  }
+}

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
@@ -11,10 +11,8 @@ trait Responses extends algebra.Responses {
 
 
    def emptyResponse: Response[Unit] = {
-    case x if x.isError => Try(x.throwError) match {
-      case Failure(ex) => Left(ex)
-      case Success(_) => Right(())
-    }
+    case response if response.code >= 200 && response.code <300 => Right(())
+    case response => Left(new Throwable(s"Unexpected status code: ${response.code}"))
   }
 
    def textResponse: Response[String] = x => if(x.code == 200) Right(x.body) else Left(new Throwable(s"Unexpected status code: ${x.code}"))

--- a/scalaj/client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
+++ b/scalaj/client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
@@ -1,17 +1,22 @@
 package endpoints.scalaj.client
 
-import endpoints.testsuite.{BasicAuthTestApi, SimpleTestApi}
-import endpoints.testsuite.client.{BasicAuthTestSuite, SimpleTestSuite}
-import scala.concurrent.ExecutionContext.Implicits.global
+import endpoints.testsuite.client.{BasicAuthTestSuite, OptionalResponsesTestSuite, SimpleTestSuite}
+import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi, SimpleTestApi}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class TestClient(val address: String) extends SimpleTestApi
   with BasicAuthTestApi
+  with OptionalResponsesTestApi
   with Endpoints
   with BasicAuthentication
+  with OptionalResponses
 
-class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[TestClient] {
+class EndpointsTest
+  extends SimpleTestSuite[TestClient]
+    with BasicAuthTestSuite[TestClient]
+    with OptionalResponsesTestSuite[TestClient] {
 
   val client: TestClient = new TestClient(s"localhost:$wiremockPort")
 
@@ -22,5 +27,7 @@ class EndpointsTest extends SimpleTestSuite[TestClient] with BasicAuthTestSuite[
   clientTestSuite()
 
   basicAuthSuite()
+
+  optionalResponsesSuite()
 
 }

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/OptionalResponsesTestApi.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/OptionalResponsesTestApi.scala
@@ -1,0 +1,13 @@
+package endpoints.testsuite
+
+import endpoints.algebra
+
+trait OptionalResponsesTestApi extends algebra.Endpoints with algebra.OptionalResponses {
+
+
+  val optionalEndpoint: Endpoint[Unit, Option[String]] = endpoint(
+    get[Unit, Unit](path / "users" / "1"),
+    option(textResponse)
+  )
+
+}

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/SimpleTestApi.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/SimpleTestApi.scala
@@ -10,4 +10,10 @@ trait SimpleTestApi extends algebra.Endpoints {
     textResponse
   )
 
+
+  val emptyResponseSmokeEndpoint = endpoint(
+    get(path / "user" / segment[String] / "description" /? (qs[String]("name") & qs[Int]("age"))),
+    emptyResponse
+  )
+
 }

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/BasicAuthTestSuite.scala
@@ -25,7 +25,7 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
 
       }
 
-      "return None is authentication failed" in {
+      "return None if authentication failed" in {
 
         val credentials = BasicAuthentication.Credentials("user1", "pass2")
 

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
@@ -2,7 +2,7 @@ package endpoints.testsuite.client
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import endpoints.algebra.BasicAuthentication
-import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi}
+import endpoints.testsuite.OptionalResponsesTestApi
 
 trait OptionalResponsesTestSuite[T <: OptionalResponsesTestApi] extends ClientTestBase[T] {
 
@@ -24,8 +24,6 @@ trait OptionalResponsesTestSuite[T <: OptionalResponsesTestApi] extends ClientTe
       }
 
       "return None if server returned 404" in {
-
-        val credentials = BasicAuthentication.Credentials("user1", "pass2")
 
         wireMockServer.stubFor(get(urlEqualTo("/users/1"))
           .willReturn(aResponse()

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/OptionalResponsesTestSuite.scala
@@ -1,0 +1,40 @@
+package endpoints.testsuite.client
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import endpoints.algebra.BasicAuthentication
+import endpoints.testsuite.{BasicAuthTestApi, OptionalResponsesTestApi}
+
+trait OptionalResponsesTestSuite[T <: OptionalResponsesTestApi] extends ClientTestBase[T] {
+
+  def optionalResponsesSuite() = {
+
+    "Client interpreter of optional responses" should {
+
+      "return Some when response code is 2xx" in {
+
+        val response = "wiremockeResponse"
+
+        wireMockServer.stubFor(get(urlEqualTo("/users/1"))
+          .willReturn(aResponse()
+            .withStatus(200)
+            .withBody(response)))
+
+        whenReady(call(client.optionalEndpoint, ()))(_ shouldEqual Some(response))
+
+      }
+
+      "return None if server returned 404" in {
+
+        val credentials = BasicAuthentication.Credentials("user1", "pass2")
+
+        wireMockServer.stubFor(get(urlEqualTo("/users/1"))
+          .willReturn(aResponse()
+            .withStatus(404)
+            .withBody("")))
+
+        whenReady(call(client.optionalEndpoint, ()))(_ shouldEqual None)
+
+      }
+    }
+  }
+}

--- a/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/SimpleTestSuite.scala
+++ b/testsuite/testsuite/src/main/scala/endpoints/testsuite/client/SimpleTestSuite.scala
@@ -19,18 +19,20 @@ trait SimpleTestSuite[T <: SimpleTestApi] extends ClientTestBase[T] {
             .withBody(response)))
 
         whenReady(call(client.smokeEndpoint, ("userId", "name1", 18))) { _ shouldEqual response }
+        whenReady(call(client.emptyResponseSmokeEndpoint, ("userId", "name1", 18))) { _ shouldEqual(()) }
 
       }
 
       "throw exception when 5xx is returned from server" in {
-
         wireMockServer.stubFor(get(urlEqualTo("/user/userId/description?name=name1&age=18"))
           .willReturn(aResponse()
             .withStatus(501)
             .withBody("")))
 
         whenReady(call(client.smokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
+        whenReady(call(client.emptyResponseSmokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
       }
+
 
 
     }


### PR DESCRIPTION
I added a couple of missing interpreters and fixed one bug in scalaj.

I renamed the type parameters in requests algebra because it's one of the most confusing pieces for the newcomers in my experience.