### PR TITLE
Add sttp client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ val xhr = project.in(file("xhr"))
 val play = project.in(file("play"))
 val `akka-http` = project.in(file("akka-http"))
 val scalaj = project.in(file("scalaj"))
+val sttp = project.in(file("sttp"))
 
 // Test kit
 val testsuite = project.in(file("testsuite"))

--- a/sttp/build.sbt
+++ b/sttp/build.sbt
@@ -1,0 +1,19 @@
+import EndpointsSettings._
+
+val `algebra-jvm` = LocalProject("algebraJVM")
+val `testsuite-jvm` = LocalProject("testsuiteJVM")
+
+val sttpVersion = "1.1.13"
+
+val `sttp-client` =
+  project.in(file("client"))
+    .settings(publishSettings ++ `scala 2.11 to 2.12`: _*)
+    .settings(
+      name := "endpoints-sttp-client",
+      libraryDependencies ++= Seq(
+        "com.softwaremill.sttp" %% "core" % sttpVersion,
+        "com.softwaremill.sttp" %% "akka-http-backend" % sttpVersion % Test,
+        "com.typesafe.akka" %% "akka-stream" % "2.5.11" % Test
+      )
+    )
+    .dependsOn(`algebra-jvm`, `testsuite-jvm` % Test)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
@@ -23,9 +23,9 @@ trait BasicAuthentication[R[_]] extends algebra.BasicAuthentication { self: Endp
     new SttpResponse[Option[A]] {
       override type RB = inner.RB
       override def responseAs = inner.responseAs
-      override def validateResponse(response: sttp.Response[inner.RB]): Either[String, Option[A]] = {
-        if (response.code == 403) Right(None)
-        else inner.validateResponse(response).right.map(Some(_))
+      override def validateResponse(response: sttp.Response[inner.RB]): R[Option[A]] = {
+        if (response.code == 403) backend.responseMonad.unit(None)
+        else backend.responseMonad.map(inner.validateResponse(response))(Some(_))
       }
     }
   }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
@@ -21,9 +21,9 @@ trait BasicAuthentication[R[_]] extends algebra.BasicAuthentication { self: Endp
     */
   private[endpoints] def authenticated[A](inner: Response[A]): Response[Option[A]] = {
     new SttpResponse[Option[A]] {
-      override type RB = inner.RB
+      override type ReceivedBody = inner.ReceivedBody
       override def responseAs = inner.responseAs
-      override def validateResponse(response: sttp.Response[inner.RB]): R[Option[A]] = {
+      override def validateResponse(response: sttp.Response[inner.ReceivedBody]): R[Option[A]] = {
         if (response.code == 403) backend.responseMonad.unit(None)
         else backend.responseMonad.map(inner.validateResponse(response))(Some(_))
       }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
@@ -1,0 +1,32 @@
+package endpoints.sttp.client
+
+import com.softwaremill.sttp
+import endpoints.algebra
+import endpoints.algebra.BasicAuthentication.Credentials
+
+import scala.language.higherKinds
+
+trait BasicAuthentication[R[_]] extends algebra.BasicAuthentication { self: Endpoints[R] =>
+
+  /**
+    * Supplies the credential into the request headers
+    */
+  private[endpoints] lazy val basicAuthentication: RequestHeaders[Credentials] =
+    (credentials, request) => {
+      request.auth.basic(credentials.username, credentials.password)
+    }
+
+  /**
+    * Checks that the result is not `Forbidden`
+    */
+  private[endpoints] def authenticated[A](inner: Response[A]): Response[Option[A]] = {
+    new SttpResponse[Option[A]] {
+      override type RB = inner.RB
+      override def responseAs = inner.responseAs
+      override def validateResponse(response: sttp.Response[inner.RB]): Either[String, Option[A]] = {
+        if (response.code == 403) Right(None)
+        else inner.validateResponse(response).right.map(Some(_))
+      }
+    }
+  }
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -1,0 +1,112 @@
+package endpoints.sttp.client
+
+import java.net.URI
+
+import endpoints.algebra
+import endpoints.Tupler
+import com.softwaremill.sttp
+
+import scala.language.higherKinds
+
+/**
+  * An interpreter for [[endpoints.algebra.Endpoints]] that builds a client issuing requests using
+  * a sttp’s [[com.softwaremill.sttp.SttpBackend]].
+  *
+  * Doest not support streaming responses for now
+  *
+  * @param host     Base of the URL of the service that implements the endpoints (e.g. "http://foo.com")
+  * @param backend  The underlying backend to use
+  * @tparam R       The monad wrapping the response. It is defined by the backend
+  */
+class Endpoints[R[_]](host: String, val backend: sttp.SttpBackend[R, Nothing]) extends algebra.Endpoints with Urls with Methods {
+
+  /**
+    * A function that, given an `A` and a request model, returns an updated request
+    * containing additional headers
+    */
+  type RequestHeaders[A] = (A, sttp.Request[_, Nothing]) => sttp.Request[_, Nothing]
+
+  /** Does not modify the request */
+  lazy val emptyHeaders: RequestHeaders[Unit] = (_, request) => request
+
+  /**
+    * A function that takes an `A` information and returns a `sttp.Request`
+    */
+  type Request[A] = A => sttp.Request[_, Nothing]
+
+  /**
+    * A function that, given an `A` information and a `sttp.Request`, eventually returns a `sttp.Request`
+    */
+  type RequestEntity[A] = (A, sttp.Request[_, Nothing]) => sttp.Request[_, Nothing]
+
+  lazy val emptyRequest: RequestEntity[Unit] = { case (_, req) => req }
+
+  def request[A, B, C, AB](
+    method: Method, url: Url[A],
+    entity: RequestEntity[B], headers: RequestHeaders[C]
+  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
+    (abc: tuplerABC.Out) => {
+      val (ab, c) = tuplerABC.unapply(abc)
+      val (a, b) = tuplerAB.unapply(ab)
+
+      val uri: sttp.Id[sttp.Uri] = sttp.Uri(new URI(s"${host}${url.encode(a)}"))
+      val reqId: sttp.Request[_, Nothing] = method(sttp.sttp.get(uri = uri))
+      entity(b, headers(c, reqId))
+    }
+
+  /**
+    * Trait that indicates how a response should be interpreted
+    */
+  trait SttpResponse[A] {
+    /**
+      * The type of the received body from the server
+      */
+    type RB
+
+    /**
+      * To read the response body
+      */
+    def responseAs: sttp.ResponseAs[RB, Nothing]
+
+    /**
+      * Function to validate the response (headers, code). This can also modify the type of the received body
+      */
+    def validateResponse(response: sttp.Response[RB]): Either[String, A]
+  }
+
+  type Response[A] = SttpResponse[A]
+
+  /** Successfully decodes no information from a response */
+  val emptyResponse: Response[Unit] = new SttpResponse[Unit] {
+    type RB = Unit
+    override def responseAs = sttp.ignore
+    override def validateResponse(response: sttp.Response[Unit]) = {
+      if (response.isSuccess) response.body
+      else Left(s"Unexpected status code: ${response.code}")
+    }
+  }
+
+  /** Successfully decodes string information from a response */
+  val textResponse: Response[String] = new SttpResponse[String] {
+    type RB = String
+    override def responseAs = sttp.asString
+    override def validateResponse(response: sttp.Response[String]) = {
+      if (response.isSuccess) response.body
+      else Left(s"Unexpected status code: ${response.code}")
+    }
+  }
+
+  /**
+    * A function that, given an `A`, eventually attempts to decode the `B` response.
+    */
+  type Endpoint[A, B] = A => R[Either[String, B]]
+
+  def endpoint[A, B](request: Request[A], response: Response[B]): Endpoint[A, B] =
+    a => {
+      val req: sttp.Request[response.RB, Nothing] = request(a).response(response.responseAs)
+
+      val result = backend.send(req)
+      backend.responseMonad.map(result)(response.validateResponse)
+    }
+
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
@@ -15,9 +15,9 @@ trait JsonEntitiesFromCodec[R[_]] extends endpoints.algebra.JsonEntitiesFromCode
   }
 
   def jsonResponse[A](implicit codec: Codec[String, A]): Response[A] = new SttpResponse[A] {
-    override type RB = Either[Exception, A]
+    override type ReceivedBody = Either[Exception, A]
     override def responseAs = sttp.asString.map(str => codec.decode(str))
-    override def validateResponse(response: sttp.Response[RB]): R[A] = {
+    override def validateResponse(response: sttp.Response[ReceivedBody]): R[A] = {
       response.unsafeBody match {
         case Right(a) => backend.responseMonad.unit(a)
         case Left(exception) => backend.responseMonad.error(exception)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
@@ -1,0 +1,28 @@
+package endpoints.sttp.client
+
+import endpoints.algebra.Codec
+import com.softwaremill.sttp
+
+import scala.language.higherKinds
+
+/**
+  * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that encodes JSON request
+  */
+trait JsonEntitiesFromCodec[R[_]] extends endpoints.algebra.JsonEntitiesFromCodec { self: Endpoints[R] =>
+
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
+    req.body(codec.encode(a)).contentType("application/json")
+  }
+
+  def jsonResponse[A](implicit codec: Codec[String, A]): Response[A] = new SttpResponse[A] {
+    override type RB = Either[Exception, A]
+    override def responseAs = sttp.asString.map(str => codec.decode(str))
+    override def validateResponse(response: sttp.Response[RB]): Either[String, A] = {
+      response.body.right.flatMap {
+        case Right(a) => Right(a)
+        case Left(exception) => Left(s"Could not decode entity: $exception")
+      }
+    }
+  }
+
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Methods.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Methods.scala
@@ -1,0 +1,25 @@
+package endpoints.sttp.client
+
+import endpoints.algebra
+import com.softwaremill.sttp
+
+/**
+  * [[algebra.Methods]] interpreter that builds URLs.
+  */
+trait Methods extends algebra.Methods {
+
+  type Method = sttp.Request[_, Nothing] => sttp.Request[_, Nothing]
+
+  private def setMethod(method: sttp.Method): Method = _.copy(method = method: sttp.Id[sttp.Method])
+
+  def Get = setMethod(sttp.Method.GET)
+
+  def Post = setMethod(sttp.Method.POST)
+
+  def Put = setMethod(sttp.Method.PUT)
+
+  def Delete = setMethod(sttp.Method.DELETE)
+
+  def Patch = setMethod(sttp.Method.PATCH)
+
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
@@ -1,0 +1,28 @@
+package endpoints
+package sttp.client
+
+import com.softwaremill.sttp
+import endpoints.algebra.{Decoder, Encoder, MuxRequest}
+
+import scala.language.higherKinds
+
+trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: Endpoints[R] =>
+
+  class MuxEndpoint[Req <: algebra.MuxRequest, Resp, Transport](request: Request[Transport], response: Response[Transport]) {
+
+    def apply(req: Req)(implicit encoder: Encoder[Req, Transport], decoder: Decoder[Transport, Resp]): R[Either[String, req.Response]] = {
+      val sttpRequest: sttp.Request[response.RB, Nothing] = request(encoder.encode(req)).response(response.responseAs)
+      val result = self.backend.send(sttpRequest)
+      self.backend.responseMonad.map(result)(res => response.validateResponse(res).right.flatMap { t =>
+        decoder.decode(t).left.map(ex => s"Could not decode transport: $ex").asInstanceOf[Either[String, req.Response]]
+      })
+    }
+  }
+
+  def muxEndpoint[Req <: MuxRequest, Resp, Transport](
+    request: Request[Transport],
+    response: Response[Transport]
+  ): MuxEndpoint[Req, Resp, Transport] =
+    new MuxEndpoint[Req, Resp, Transport](request, response)
+
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
@@ -11,7 +11,7 @@ trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: Endpoints[R] =>
   class MuxEndpoint[Req <: algebra.MuxRequest, Resp, Transport](request: Request[Transport], response: Response[Transport]) {
 
     def apply(req: Req)(implicit encoder: Encoder[Req, Transport], decoder: Decoder[Transport, Resp]): R[req.Response] = {
-      val sttpRequest: sttp.Request[response.RB, Nothing] = request(encoder.encode(req)).response(response.responseAs)
+      val sttpRequest: sttp.Request[response.ReceivedBody, Nothing] = request(encoder.encode(req)).response(response.responseAs)
       val result = self.backend.send(sttpRequest)
       self.backend.responseMonad.flatMap(result) { res =>
         val transportR: R[Transport] = response.validateResponse(res)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/OptionalResponses.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/OptionalResponses.scala
@@ -9,9 +9,9 @@ trait OptionalResponses[R[_]] extends endpoints.algebra.OptionalResponses { self
     def option[A](inner: Response[A]): Response[Option[A]] = new SttpResponse[Option[A]] {
       override type RB = inner.RB
       override def responseAs = inner.responseAs
-      override def validateResponse(response: sttp.Response[inner.RB]): Either[String, Option[A]] = {
-        if (response.code == 404) Right(None)
-        else inner.validateResponse(response).right.map(Some(_))
+      override def validateResponse(response: sttp.Response[inner.RB]): R[Option[A]] = {
+        if (response.code == 404) backend.responseMonad.unit(None)
+        else backend.responseMonad.map(inner.validateResponse(response))(Some(_))
       }
     }
 }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/OptionalResponses.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/OptionalResponses.scala
@@ -7,9 +7,9 @@ import scala.language.higherKinds
 trait OptionalResponses[R[_]] extends endpoints.algebra.OptionalResponses { self: Endpoints[R] =>
 
     def option[A](inner: Response[A]): Response[Option[A]] = new SttpResponse[Option[A]] {
-      override type RB = inner.RB
+      override type ReceivedBody = inner.ReceivedBody
       override def responseAs = inner.responseAs
-      override def validateResponse(response: sttp.Response[inner.RB]): R[Option[A]] = {
+      override def validateResponse(response: sttp.Response[inner.ReceivedBody]): R[Option[A]] = {
         if (response.code == 404) backend.responseMonad.unit(None)
         else backend.responseMonad.map(inner.validateResponse(response))(Some(_))
       }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/OptionalResponses.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/OptionalResponses.scala
@@ -1,0 +1,17 @@
+package endpoints.sttp.client
+
+import com.softwaremill.sttp
+
+import scala.language.higherKinds
+
+trait OptionalResponses[R[_]] extends endpoints.algebra.OptionalResponses { self: Endpoints[R] =>
+
+    def option[A](inner: Response[A]): Response[Option[A]] = new SttpResponse[Option[A]] {
+      override type RB = inner.RB
+      override def responseAs = inner.responseAs
+      override def validateResponse(response: sttp.Response[inner.RB]): Either[String, Option[A]] = {
+        if (response.code == 404) Right(None)
+        else inner.validateResponse(response).right.map(Some(_))
+      }
+    }
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
@@ -1,0 +1,81 @@
+package endpoints.sttp.client
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+import endpoints.{Tupler, algebra}
+
+trait Urls extends algebra.Urls {
+  val utf8Name = UTF_8.name()
+
+  trait QueryString[A] {
+    def encodeQueryString(a: A): Option[String]
+  }
+
+  def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
+    (ab: tupler.Out) => {
+      val (a, b) = tupler.unapply(ab)
+
+      (first.encodeQueryString(a), second.encodeQueryString(b)) match {
+        case (Some(left), Some(right)) => Some(s"$left&$right")
+        case (Some(left), None) => Some(left)
+        case (None, Some(right)) => Some(right)
+        case (None, None) => None
+      }
+    }
+
+  def qs[A](name: String)(implicit value: QueryStringParam[A]): QueryString[A] =
+    a => Some(s"$name=${value.apply(a)}")
+
+  def optQs[A](name: String)(implicit value: QueryStringParam[A]): QueryString[Option[A]] = {
+    case Some(a) => qs[A](name).encodeQueryString(a)
+    case None => None
+  }
+
+  type QueryStringParam[A] = A => String
+
+  implicit lazy val stringQueryString: QueryStringParam[String] = s => URLEncoder.encode(s, utf8Name)
+
+  implicit lazy val intQueryString: QueryStringParam[Int] = i => i.toString
+
+  implicit lazy val longQueryString: QueryStringParam[Long] = i => i.toString
+
+
+  trait Segment[A] {
+    def encode(a: A): String
+  }
+
+  implicit lazy val stringSegment: Segment[String] = (s: String) => URLEncoder.encode(s, utf8Name)
+
+  implicit lazy val intSegment: Segment[Int] = (i: Int) => i.toString
+
+  implicit lazy val longSegment: Segment[Long] = (i: Long) => i.toString
+
+
+  trait Path[A] extends Url[A]
+
+  def staticPathSegment(segment: String) = (_: Unit) => segment
+
+  def segment[A](implicit s: Segment[A]): Path[A] = a => s.encode(a)
+
+  def chainPaths[A, B](first: Path[A], second: Path[B])(implicit tupler: Tupler[A, B]): Path[tupler.Out] =
+    (ab: tupler.Out) => {
+      val (a, b) = tupler.unapply(ab)
+      first.encode(a) ++ "/" ++ second.encode(b)
+    }
+
+
+  trait Url[A] {
+    def encode(a: A): String
+  }
+
+  def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] =
+    (ab: tupler.Out) => {
+      val (a, b) = tupler.unapply(ab)
+
+      qs.encodeQueryString(b) match {
+        case Some(q) => s"${path.encode(a)}?$q"
+        case None => path.encode(a)
+      }
+    }
+}

--- a/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
+++ b/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
@@ -1,16 +1,16 @@
 package endpoints.sttp.client
 
 import com.softwaremill.sttp
+import com.softwaremill.sttp.TryHttpURLConnectionBackend
 import com.softwaremill.sttp.akkahttp.AkkaHttpBackend
-import com.softwaremill.sttp.{HttpURLConnectionBackend, Id}
-import endpoints.testsuite.{BasicAuthTestApi, JsonFromPlayJsonCodecTestApi, OptionalResponsesTestApi, SimpleTestApi}
 import endpoints.testsuite.client.{BasicAuthTestSuite, JsonFromCodecTestSuite, OptionalResponsesTestSuite, SimpleTestSuite}
+import endpoints.testsuite.{BasicAuthTestApi, JsonFromPlayJsonCodecTestApi, OptionalResponsesTestApi, SimpleTestApi}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
+import scala.util.Try
 
 class TestClient[R[_]](address: String, backend: sttp.SttpBackend[R, _])
-                (implicit EC: ExecutionContext)
   extends Endpoints(address, backend)
     with BasicAuthentication[R]
     with OptionalResponses[R]
@@ -21,21 +21,17 @@ class TestClient[R[_]](address: String, backend: sttp.SttpBackend[R, _])
     with JsonFromPlayJsonCodecTestApi
 
 class EndpointsTestSync
-  extends SimpleTestSuite[TestClient[Id]]
-    with BasicAuthTestSuite[TestClient[Id]]
-    with OptionalResponsesTestSuite[TestClient[Id]]
-    with JsonFromCodecTestSuite[TestClient[Id]] {
+  extends SimpleTestSuite[TestClient[Try]]
+    with BasicAuthTestSuite[TestClient[Try]]
+    with OptionalResponsesTestSuite[TestClient[Try]]
+    with JsonFromCodecTestSuite[TestClient[Try]] {
+  
+  val backend = TryHttpURLConnectionBackend()
 
-  import ExecutionContext.Implicits.global
-  val backend = HttpURLConnectionBackend()
-
-  val client: TestClient[Id] = new TestClient(s"http://localhost:$wiremockPort", backend)
+  val client: TestClient[Try] = new TestClient(s"http://localhost:$wiremockPort", backend)
 
   def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req) = {
-    endpoint(args) match {
-      case Right(res) => Future.successful(res)
-      case Left(error) => Future.failed(new Throwable(error))
-    }
+    Future.fromTry(endpoint(args))
   }
 
   clientTestSuite()
@@ -55,12 +51,7 @@ class EndpointsTestAkka
 
   val client: TestClient[Future] = new TestClient(s"http://localhost:$wiremockPort", backend)
 
-  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req) = {
-    endpoint(args).flatMap {
-      case Right(res) => Future.successful(res)
-      case Left(error) => Future.failed(new Throwable(error))
-    }
-  }
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req) = endpoint(args)
 
   clientTestSuite()
   basicAuthSuite()

--- a/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
+++ b/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
@@ -1,0 +1,70 @@
+package endpoints.sttp.client
+
+import com.softwaremill.sttp
+import com.softwaremill.sttp.akkahttp.AkkaHttpBackend
+import com.softwaremill.sttp.{HttpURLConnectionBackend, Id}
+import endpoints.testsuite.{BasicAuthTestApi, JsonFromPlayJsonCodecTestApi, OptionalResponsesTestApi, SimpleTestApi}
+import endpoints.testsuite.client.{BasicAuthTestSuite, JsonFromCodecTestSuite, OptionalResponsesTestSuite, SimpleTestSuite}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.higherKinds
+
+class TestClient[R[_]](address: String, backend: sttp.SttpBackend[R, _])
+                (implicit EC: ExecutionContext)
+  extends Endpoints(address, backend)
+    with BasicAuthentication[R]
+    with OptionalResponses[R]
+    with JsonEntitiesFromCodec[R]
+    with BasicAuthTestApi
+    with SimpleTestApi
+    with OptionalResponsesTestApi
+    with JsonFromPlayJsonCodecTestApi
+
+class EndpointsTestSync
+  extends SimpleTestSuite[TestClient[Id]]
+    with BasicAuthTestSuite[TestClient[Id]]
+    with OptionalResponsesTestSuite[TestClient[Id]]
+    with JsonFromCodecTestSuite[TestClient[Id]] {
+
+  import ExecutionContext.Implicits.global
+  val backend = HttpURLConnectionBackend()
+
+  val client: TestClient[Id] = new TestClient(s"http://localhost:$wiremockPort", backend)
+
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req) = {
+    endpoint(args) match {
+      case Right(res) => Future.successful(res)
+      case Left(error) => Future.failed(new Throwable(error))
+    }
+  }
+
+  clientTestSuite()
+  basicAuthSuite()
+  optionalResponsesSuite()
+  jsonFromCodecTestSuite()
+}
+
+class EndpointsTestAkka
+  extends SimpleTestSuite[TestClient[Future]]
+    with BasicAuthTestSuite[TestClient[Future]]
+    with OptionalResponsesTestSuite[TestClient[Future]]
+    with JsonFromCodecTestSuite[TestClient[Future]] {
+
+  import ExecutionContext.Implicits.global
+  val backend = AkkaHttpBackend()
+
+  val client: TestClient[Future] = new TestClient(s"http://localhost:$wiremockPort", backend)
+
+  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req) = {
+    endpoint(args).flatMap {
+      case Right(res) => Future.successful(res)
+      case Left(error) => Future.failed(new Throwable(error))
+    }
+  }
+
+  clientTestSuite()
+  basicAuthSuite()
+  optionalResponsesSuite()
+  jsonFromCodecTestSuite()
+}
+

--- a/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
+++ b/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
@@ -25,7 +25,7 @@ class EndpointsTestSync
     with BasicAuthTestSuite[TestClient[Try]]
     with OptionalResponsesTestSuite[TestClient[Try]]
     with JsonFromCodecTestSuite[TestClient[Try]] {
-  
+
   val backend = TryHttpURLConnectionBackend()
 
   val client: TestClient[Try] = new TestClient(s"http://localhost:$wiremockPort", backend)


### PR DESCRIPTION
This pull request adds support for the [sttp](https://github.com/softwaremill/sttp) client (#70)

The code is mostly similar to play-ws and akka-http clients (`Urls.scala` is the same).

The differences are:
- A backend defines a monad `R[_]` that wraps the responses, this shows in the api.
- `sttp` requires that we define the expected response type when creating a request (with `ResponseAs`). This means that we cannot send the request in `def request` since we don't know yet the response type. In consequence, we send the request in `def endpoint` where we know the response
- an `Endpoint` will return a type `R[Either[String, B]]` whereas the other clients simply returns a `Future[B]`

Otherwise it was quite easy to implement this new backend and to add tests for it 👍 