### PR TITLE
[Experiment] Compose algebras via composition instead of inheritance

### DIFF
--- a/algebras/algebra-circe/src/test/scala/endpoints/algebra/circe/JsonFromCirceCodecTestApi.scala
+++ b/algebras/algebra-circe/src/test/scala/endpoints/algebra/circe/JsonFromCirceCodecTestApi.scala
@@ -3,8 +3,9 @@ package endpoints.algebra.circe
 import endpoints.algebra.{Address, JsonFromCodecTestApi, User}
 
 trait JsonFromCirceCodecTestApi
-  extends JsonFromCodecTestApi
-    with endpoints.algebra.circe.JsonEntitiesFromCodec {
+  extends JsonFromCodecTestApi {
+
+  val entities: endpoints.algebra.circe.JsonEntitiesFromCodec
 
   import io.circe._
   import io.circe.generic.semiauto._
@@ -14,7 +15,7 @@ trait JsonFromCirceCodecTestApi
   implicit lazy val addressDecoder: Decoder[Address] = deriveDecoder[Address]
   implicit lazy val addressEncoder: Encoder[Address] = deriveEncoder[Address]
 
-  def userCodec: JsonCodec[User] = implicitly
-  def addressCodec: JsonCodec[Address] = implicitly
+  def userCodec: entities.JsonCodec[User] = implicitly
+  def addressCodec: entities.JsonCodec[Address] = implicitly
 
 }

--- a/algebras/algebra-playjson/src/test/scala/endpoints/algebra/playjson/JsonFromPlayJsonCodecTestApi.scala
+++ b/algebras/algebra-playjson/src/test/scala/endpoints/algebra/playjson/JsonFromPlayJsonCodecTestApi.scala
@@ -1,13 +1,13 @@
 package endpoints.algebra.playjson
 
-import endpoints.algebra
 import endpoints.algebra.{Address, JsonFromCodecTestApi, User}
 import play.api.libs.json.{Format, Json}
 
 
 trait JsonFromPlayJsonCodecTestApi
-  extends JsonFromCodecTestApi
-    with algebra.playjson.JsonEntitiesFromCodec {
+  extends JsonFromCodecTestApi {
+
+  override val entities: JsonEntitiesFromCodec
 
   implicit lazy val addressCodec: Format[Address] = Json.format[Address]
   implicit lazy val userCodec: Format[User] = Json.format[User]

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Assets.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Assets.scala
@@ -1,7 +1,9 @@
 package endpoints.algebra
 
 /** Describes endpoints related to static assets (e.g. medias, scripts, stylesheets, etc.) */
-trait Assets extends Endpoints {
+trait Assets {
+
+  val endpoints: Endpoints
 
   /** An HTTP request to retrieve an asset */
   type AssetRequest
@@ -11,7 +13,7 @@ trait Assets extends Endpoints {
   type AssetResponse
 
   /**
-    * A [[Path]] that extracts an [[AssetPath]] from all the path segments.
+    * A [[endpoints.requests.urls.Path]] that extracts an [[AssetPath]] from all the path segments.
     *
     * Consider the following definition:
     * {{{
@@ -22,7 +24,7 @@ trait Assets extends Endpoints {
     * - `/assets/foo` => `foo`
     * - `/assets/foo/bar` => `foo/bar`
     */
-  def assetSegments(name: String = "", docs: Documentation = None): Path[AssetPath]
+  def assetSegments(name: String = "", docs: Documentation = None): endpoints.requests.urls.Path[AssetPath]
 
   /**
     * @param url URL description
@@ -30,7 +32,7 @@ trait Assets extends Endpoints {
     * @param notFoundDocs description of a not found asset response. Required by openapi
     * @return An HTTP endpoint serving assets
     */
-  def assetsEndpoint(url: Url[AssetPath], docs: Documentation = None, notFoundDocs: Documentation = None): Endpoint[AssetRequest, AssetResponse]
+  def assetsEndpoint(url: endpoints.requests.urls.Url[AssetPath], docs: Documentation = None, notFoundDocs: Documentation = None): endpoints.Endpoint[AssetRequest, AssetResponse]
 
   /** The digests of the assets */
   def digests: Map[String, String]

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -9,7 +9,15 @@ import endpoints.algebra.BasicAuthentication.Credentials
   * This trait works fine, but developers are likely to implement their own
   * authentication mechanism, specific to their application.
   */
-trait BasicAuthentication extends Endpoints {
+trait BasicAuthentication {
+
+  val endpoints: Endpoints
+
+  import endpoints._
+  import requests._
+  import urls._
+  import responses._
+  import methods._
 
   /**
     * Credentials encoded as HTTP Basic Auth header

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
@@ -17,7 +17,14 @@ import scala.language.higherKinds
   *   val example = endpoint(get(path / "foo"), emptyResponse)
   * }}}
   */
-trait Endpoints extends Requests with Responses {
+trait Endpoints {
+
+  val requests: Requests
+
+  val responses: Responses
+
+  import requests._
+  import responses._
 
   /**
     * Information carried by an HTTP endpoint

--- a/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
@@ -15,19 +15,21 @@ import scala.language.higherKinds
   *   val example = endpoint(get(path / "user" / segment[UUID]), jsonResponse[User])
   * }}}
   */
-trait JsonEntities extends Endpoints {
+trait JsonEntities {
+
+  val endpoints: Endpoints
 
   /** Type class defining how to represent the `A` information as a JSON request entity */
   type JsonRequest[A]
 
   /** Defines a `RequestEntity[A]` given an implicit `JsonRequest[A]` */
-  def jsonRequest[A : JsonRequest](docs: Documentation = None): RequestEntity[A]
+  def jsonRequest[A : JsonRequest](docs: Documentation = None): endpoints.requests.RequestEntity[A]
 
   /** Type class defining how to represent the `A` information as a JSON response entity */
   type JsonResponse[A]
 
   /** Defines a `Response[A]` given an implicit `JsonResponse[A]` */
-  def jsonResponse[A : JsonResponse](docs: Documentation = None): Response[A]
+  def jsonResponse[A : JsonResponse](docs: Documentation = None): endpoints.responses.Response[A]
 }
 
 /**

--- a/algebras/algebra/src/main/scala/endpoints/algebra/LowLevelEndpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/LowLevelEndpoints.scala
@@ -29,16 +29,18 @@ package endpoints.algebra
   *     .map(response => println(response.responseText))
   * }}}
   */
-trait LowLevelEndpoints extends Endpoints {
+trait LowLevelEndpoints {
+
+  val endpoints: Endpoints
 
   /** Low-level request entity */
   type RawRequestEntity
 
-  def rawRequestEntity: RequestEntity[RawRequestEntity]
+  def rawRequestEntity: endpoints.requests.RequestEntity[RawRequestEntity]
 
   /** Low-level request response */
   type RawResponseEntity
 
-  def rawResponseEntity: Response[RawResponseEntity]
+  def rawResponseEntity: endpoints.responses.Response[RawResponseEntity]
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/MuxEndpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/MuxEndpoints.scala
@@ -6,7 +6,9 @@ import scala.language.higherKinds
   * Algebra interface for describing endpoints such that one endpoint can
   * handle several types of requests and responses.
   */
-trait MuxEndpoints extends Endpoints {
+trait MuxEndpoints {
+
+  val endpoints: Endpoints
 
   /**
     * Information carried by a multiplexed HTTP endpoint.
@@ -28,8 +30,8 @@ trait MuxEndpoints extends Endpoints {
     * @tparam Transport The data type used to transport the requests and responses
     */
   def muxEndpoint[Req <: MuxRequest, Resp, Transport](
-    request: Request[Transport],
-    response: Response[Transport]
+    request: endpoints.requests.Request[Transport],
+    response: endpoints.responses.Response[Transport]
   ): MuxEndpoint[Req, Resp, Transport]
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -4,7 +4,11 @@ import endpoints._
 
 import scala.language.higherKinds
 
-trait Requests extends Urls with Methods with InvariantFunctorSyntax with SemigroupalSyntax {
+trait Requests extends InvariantFunctorSyntax with SemigroupalSyntax {
+
+  val urls: Urls
+
+  val methods: Methods
 
   /** Information carried by requests’ headers */
   type RequestHeaders[A]
@@ -57,8 +61,8 @@ trait Requests extends Urls with Methods with InvariantFunctorSyntax with Semigr
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
     */
   def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled](
-    method: Method,
-    url: Url[UrlP],
+    method: methods.Method,
+    url: urls.Url[UrlP],
     entity: RequestEntity[BodyP] = emptyRequest,
     headers: RequestHeaders[HeadersP] = emptyHeaders
   )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out]
@@ -69,9 +73,9 @@ trait Requests extends Urls with Methods with InvariantFunctorSyntax with Semigr
     * @tparam HeadersP Payload carried by headers
     */
   final def get[UrlP, HeadersP](
-    url: Url[UrlP],
+    url: urls.Url[UrlP],
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerAC: Tupler[UrlP, HeadersP]): Request[tuplerAC.Out] = request(Get, url, headers = headers)
+  )(implicit tuplerAC: Tupler[UrlP, HeadersP]): Request[tuplerAC.Out] = request(methods.Get, url, headers = headers)
 
   /**
     * Helper method to perform POST request
@@ -81,10 +85,10 @@ trait Requests extends Urls with Methods with InvariantFunctorSyntax with Semigr
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
     */
   final def post[UrlP, BodyP, HeadersP, UrlAndBodyPTupled](
-    url: Url[UrlP],
+    url: urls.Url[UrlP],
     entity: RequestEntity[BodyP],
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out] = request(Post, url, entity, headers)
+  )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out] = request(methods.Post, url, entity, headers)
 
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/BasicAuthTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/BasicAuthTestApi.scala
@@ -1,11 +1,14 @@
 package endpoints.algebra
 
-import endpoints.algebra
+trait BasicAuthTestApi {
 
-trait BasicAuthTestApi extends algebra.Endpoints with algebra.BasicAuthentication {
+  val basicAuth: BasicAuthentication
+  import basicAuth.endpoints.requests.methods._
+  import basicAuth.endpoints.requests.urls._
+  import basicAuth.endpoints.responses._
 
 
-  val protectedEndpoint = authenticatedEndpoint(
+  val protectedEndpoint = basicAuth.authenticatedEndpoint(
     Get,
     path / "users",
     textResponse()

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -1,11 +1,16 @@
 package endpoints.algebra
 
-import java.time.format.DateTimeFormatter
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
-import endpoints.algebra
+trait EndpointsTestApi {
 
-trait EndpointsTestApi extends algebra.Endpoints {
+  val endpoints: Endpoints
+
+  import endpoints._
+  import requests._
+  import responses._
+  import urls._
 
 
   val smokeEndpoint = endpoint(

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonFromCodecTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonFromCodecTestApi.scala
@@ -1,15 +1,18 @@
 package endpoints.algebra
 
-import endpoints.algebra
+trait JsonFromCodecTestApi {
 
-trait JsonFromCodecTestApi
-  extends algebra.Endpoints
-    with algebra.JsonEntitiesFromCodec {
+  val entities: JsonEntitiesFromCodec
 
-  implicit def userCodec: JsonCodec[User]
-  implicit def addressCodec: JsonCodec[Address]
+  import entities._
+  import endpoints._
+  import requests._
+  import urls._
 
-  val jsonCodecEndpoint = endpoint(
+  implicit def userCodec: entities.JsonCodec[User]
+  implicit def addressCodec: entities.JsonCodec[Address]
+
+  lazy val jsonCodecEndpoint = endpoint(
     post(path / "user-json-codec", jsonRequest[User]()),
     jsonResponse[Address]()
   )

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonTestApi.scala
@@ -1,8 +1,13 @@
 package endpoints.algebra
 
-import endpoints.algebra
+trait JsonTestApi {
 
-trait JsonTestApi extends algebra.Endpoints with algebra.JsonEntities {
+  val entities: JsonEntities
+
+  import entities._
+  import endpoints._
+  import requests._
+  import urls._
 
   implicit def userCodec: JsonRequest[User]
   implicit def addresCodec: JsonResponse[Address]

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/BasicAuthTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/BasicAuthTestSuite.scala
@@ -3,7 +3,10 @@ package endpoints.algebra.client
 import com.github.tomakehurst.wiremock.client.WireMock._
 import endpoints.algebra.{BasicAuthTestApi, BasicAuthentication}
 
-trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
+trait BasicAuthTestSuite extends ClientTestBase {
+
+  val api: BasicAuthTestApi
+  override type Endpoint[Req, Resp] = api.basicAuth.endpoints.Endpoint[Req, Resp]
 
   def basicAuthSuite() = {
 
@@ -20,7 +23,7 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        whenReady(call(client.protectedEndpoint, credentials))(_ shouldEqual Some(response))
+        whenReady(call(api.protectedEndpoint, credentials))(_ shouldEqual Some(response))
 
       }
 
@@ -33,7 +36,7 @@ trait BasicAuthTestSuite[T <: BasicAuthTestApi] extends ClientTestBase[T] {
             .withStatus(403)
             .withBody("")))
 
-        whenReady(call(client.protectedEndpoint, credentials))(_ shouldEqual None)
+        whenReady(call(api.protectedEndpoint, credentials))(_ shouldEqual None)
 
       }
     }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/ClientTestBase.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/ClientTestBase.scala
@@ -4,14 +4,14 @@ import java.net.ServerSocket
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
-import endpoints.algebra
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpec}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.language.higherKinds
 
-trait ClientTestBase[T <: algebra.Endpoints] extends WordSpec
+trait ClientTestBase extends WordSpec
   with Matchers
   with ScalaFutures
   with BeforeAndAfterAll
@@ -36,8 +36,8 @@ trait ClientTestBase[T <: algebra.Endpoints] extends WordSpec
     finally if (socket != null) socket.close()
   }
 
-  val client: T
+  type Endpoint[Req, Resp]
 
-  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp]
+  def call[Req, Resp](endpoint: Endpoint[Req, Resp], args: Req): Future[Resp]
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
@@ -6,7 +6,11 @@ import java.util.UUID
 import com.github.tomakehurst.wiremock.client.WireMock._
 import endpoints.algebra.EndpointsTestApi
 
-trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
+trait EndpointsTestSuite extends ClientTestBase {
+
+  val api: EndpointsTestApi
+
+  override type Endpoint[Req, Resp] = api.endpoints.Endpoint[Req, Resp]
 
   def clientTestSuite() = {
 
@@ -21,10 +25,10 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        whenReady(call(client.smokeEndpoint, ("userId", "name1", 18))) {
+        whenReady(call(api.smokeEndpoint, ("userId", "name1", 18))) {
           _ shouldEqual response
         }
-        whenReady(call(client.emptyResponseSmokeEndpoint, ("userId", "name1", 18))) {
+        whenReady(call(api.emptyResponseSmokeEndpoint, ("userId", "name1", 18))) {
           _ shouldEqual (())
         }
 
@@ -36,8 +40,8 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
             .withStatus(501)
             .withBody("")))
 
-        whenReady(call(client.smokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
-        whenReady(call(client.emptyResponseSmokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
+        whenReady(call(api.smokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
+        whenReady(call(api.emptyResponseSmokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected status code: 501")
       }
 
       "properly handle joined headers" in {
@@ -49,7 +53,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        whenReady(call(client.joinedHeadersEndpoint, ("a", "b")))(x => x shouldEqual (response))
+        whenReady(call(api.joinedHeadersEndpoint, ("a", "b")))(x => x shouldEqual (response))
       }
 
       "properly handle xmaped headers" in {
@@ -60,7 +64,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        whenReady(call(client.xmapHeadersEndpoint, 11))(x => x shouldEqual (response))
+        whenReady(call(api.xmapHeadersEndpoint, 11))(x => x shouldEqual (response))
       }
 
       "properly handle xmaped url" in {
@@ -70,7 +74,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        whenReady(call(client.xmapUrlEndpoint, "11"))(x => x shouldEqual (response))
+        whenReady(call(api.xmapUrlEndpoint, "11"))(x => x shouldEqual (response))
       }
 
       "properly handle xmaped request entites" in {
@@ -83,7 +87,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(response)))
 
-        whenReady(call(client.xmapReqBodyEndpoint, date))(x => x shouldEqual (response))
+        whenReady(call(api.xmapReqBodyEndpoint, date))(x => x shouldEqual (response))
       }
 
       "in case of optional response" should {
@@ -97,7 +101,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
               .withStatus(200)
               .withBody(response)))
 
-          whenReady(call(client.optionalEndpoint, ()))(_ shouldEqual Some(response))
+          whenReady(call(api.optionalEndpoint, ()))(_ shouldEqual Some(response))
 
         }
 
@@ -108,7 +112,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
               .withStatus(404)
               .withBody("")))
 
-          whenReady(call(client.optionalEndpoint, ()))(_ shouldEqual None)
+          whenReady(call(api.optionalEndpoint, ()))(_ shouldEqual None)
 
         }
       }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/JsonFromCodecTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/JsonFromCodecTestSuite.scala
@@ -1,10 +1,13 @@
 package endpoints.algebra.client
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import endpoints.algebra.JsonFromCodecTestApi
 import endpoints.algebra.{Address, JsonFromCodecTestApi, User}
 
-trait JsonFromCodecTestSuite[T <: JsonFromCodecTestApi] extends ClientTestBase[T] {
+trait JsonFromCodecTestSuite extends ClientTestBase {
+
+  val api: JsonFromCodecTestApi
+
+  override type Endpoint[Req, Resp] = api.entities.endpoints.Endpoint[Req, Resp]
 
   def jsonFromCodecTestSuite() = {
 
@@ -13,9 +16,9 @@ trait JsonFromCodecTestSuite[T <: JsonFromCodecTestApi] extends ClientTestBase[T
       "encode JSON requests and decode JSON responses" in {
 
         val user = User("name2", 19)
-        val userStr = client.jsonCodec(client.userCodec).encode(user)
+        val userStr = api.entities.jsonCodec(api.userCodec).encode(user)
         val address = Address("avenue1", "NY")
-        val addressStr = client.jsonCodec(client.addressCodec).encode(address)
+        val addressStr = api.entities.jsonCodec(api.addressCodec).encode(address)
 
         wireMockServer.stubFor(
           post(urlEqualTo("/user-json-codec"))
@@ -27,7 +30,7 @@ trait JsonFromCodecTestSuite[T <: JsonFromCodecTestApi] extends ClientTestBase[T
             )
         )
 
-        whenReady(call(client.jsonCodecEndpoint, user))(_ shouldEqual address)
+        whenReady(call(api.jsonCodecEndpoint, user))(_ shouldEqual address)
 
       }
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/JsonTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/JsonTestSuite.scala
@@ -4,7 +4,11 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import endpoints.algebra.{Address, JsonTestApi, User}
 
 
-trait JsonTestSuite[T <: JsonTestApi] extends ClientTestBase[T] {
+trait JsonTestSuite extends ClientTestBase {
+
+  val api: JsonTestApi
+
+  override type Endpoint[Req, Resp] = api.entities.endpoints.Endpoint[Req, Resp]
 
   def clientTestSuite() = {
 
@@ -21,7 +25,7 @@ trait JsonTestSuite[T <: JsonTestApi] extends ClientTestBase[T] {
             .withStatus(200)
             .withBody(addressStr)))
 
-        whenReady(call(client.smokeEndpoint, user))(_ shouldEqual address)
+        whenReady(call(api.smokeEndpoint, user))(_ shouldEqual address)
 
       }
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,20 +3,17 @@ import EndpointsSettings._
 // Algebra interfaces
 val algebras = project.in(file("algebras"))
 val jsonSchema = project.in(file("json-schema"))
-val openapi = project.in(file("openapi"))
+//val openapi = project.in(file("openapi"))
 
 // Interpreters
-val xhr = project.in(file("xhr"))
-val play = project.in(file("play"))
-val `akka-http` = project.in(file("akka-http"))
+//val xhr = project.in(file("xhr"))
+//val play = project.in(file("play"))
+//val `akka-http` = project.in(file("akka-http"))
 val scalaj = project.in(file("scalaj"))
-val sttp = project.in(file("sttp"))
-
-// Test kit
-val testsuite = project.in(file("testsuite"))
+//val sttp = project.in(file("sttp"))
 
 // Documentation and examples
-val documentation = project.in(file("documentation"))
+//val documentation = project.in(file("documentation"))
 
 import ReleaseTransformations._
 

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -1,335 +1,335 @@
-import EndpointsSettings._
-import LocalCrossProject._
-import org.scalajs.sbtplugin.cross.CrossProject
-
-val `algebra-jvm` = LocalProject("algebraJVM")
-val `algebra-circe-jvm` = LocalProject("algebra-circeJVM")
-val `algebra-playjson-jvm` = LocalProject("algebra-playjsonJVM")
-
-val `play-client` = LocalProject("play-client")
-val `play-server` = LocalProject("play-server")
-val `play-server-circe` = LocalProject("play-server-circe")
-
-val `akka-http-server` = LocalProject("akka-http-server")
-
-val `xhr-client` = LocalProject("xhr-client")
-val `xhr-client-circe` = LocalProject("xhr-client-circe")
-val `xhr-client-faithful` = LocalProject("xhr-client-faithful")
-
-val `scalaj-client` = LocalProject("scalaj-client")
-
-val `openapi-jvm` = LocalProject("openapiJVM")
-
-val `json-schema-jvm` = LocalProject("json-schemaJVM")
-val `json-schema-circe-jvm` = LocalProject("json-schema-circeJVM")
-val `json-schema-generic-jvm` = LocalProject("json-schema-genericJVM")
-
-import sbtunidoc.Plugin.UnidocKeys.unidoc
-
-val apiDoc =
-  project.in(file("api-doc"))
-    .settings(noPublishSettings ++ `scala 2.11` ++ unidocSettings: _*)
-    .settings(
-      coverageEnabled := false,
-      scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
-        "-diagrams",
-        "-groups",
-        "-doc-source-url", s"https://github.com/julienrf/endpoints/blob/v${version.value}€{FILE_PATH}.scala",
-        "-sourcepath", (baseDirectory in ThisBuild).value.absolutePath
-      ),
-      sbtunidoc.Plugin.UnidocKeys.unidocProjectFilter in(ScalaUnidoc, unidoc) := inProjects(
-        `algebra-jvm`, `algebra-circe-jvm`, `algebra-playjson-jvm`,
-        `play-client`,
-        `play-server`, `play-server-circe`,
-        `xhr-client`, `xhr-client-circe`, `xhr-client-faithful`,
-        `scalaj-client`,
-        `openapi-jvm`, `json-schema-jvm`, `json-schema-circe-jvm`, `json-schema-generic-jvm`
-      )
-    )
-
-val ornateTarget = Def.setting(target.value / "ornate")
-
-val manual =
-  project.in(file("manual"))
-    .enablePlugins(OrnatePlugin, GhpagesPlugin)
-    .settings(
-      coverageEnabled := false,
-      scalaVersion := "2.11.8",
-      git.remoteRepo := "git@github.com:julienrf/endpoints.git",
-      ornateSourceDir := Some(sourceDirectory.value / "ornate"),
-      ornateTargetDir := Some(ornateTarget.value),
-      ornateSettings := Map("version" -> version.value),
-      siteSubdirName in ornate := "",
-      addMappingsToSiteDir(mappings in ornate, siteSubdirName in ornate),
-      mappings in ornate := {
-        val _ = ornate.value
-        val output = ornateTarget.value
-        output ** AllPassFilter --- output pair relativeTo(output)
-      },
-      siteSubdirName in packageDoc := s"api/${version.value}",
-      addMappingsToSiteDir(mappings in ScalaUnidoc in packageDoc in apiDoc, siteSubdirName in packageDoc),
-      previewLaunchBrowser := false
-    )
-
-
-// Example for the “Overview” page of the documentation
-val `example-overview-endpoints` =
-  crossProject.crossType(CrossType.Pure)
-    .in(file("examples/overview/endpoints"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`: _*)
-    .jsSettings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
-    )
-    .jvmSettings(coverageEnabled := true)
-    .settings(
-      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
-    )
-    .dependsOnLocalCrossProjects("algebra-circe")
-
-val `example-overview-endpoints-jvm` = `example-overview-endpoints`.jvm
-
-val `example-overview-endpoints-js` = `example-overview-endpoints`.js
-
-val `example-overview-client` =
-  project.in(file("examples/overview/client"))
-    .enablePlugins(ScalaJSPlugin)
-    .settings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false,
-      noPublishSettings ++ `scala 2.11 to 2.12`
-    )
-    .dependsOn(`example-overview-endpoints-js`, `xhr-client-circe`)
-
-val `example-overview-server` =
-  project.in(file("examples/overview/server"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(libraryDependencies += "org.scala-stm" %% "scala-stm" % "0.8")
-    .dependsOn(`example-overview-endpoints-jvm`, `play-server-circe`)
-
-val `example-overview-play-client` =
-  project.in(file("examples/overview/play-client"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .dependsOn(`example-overview-endpoints-jvm`, `play-client`)
-
-// Basic example
-val `example-basic-shared` = {
-  val assetsDirectory = (base: File) => base / "src" / "main" / "assets"
-  CrossProject("example-basic-shared-jvm", "example-basic-shared-js", file("examples/basic/shared"), CrossType.Pure)
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-      (sourceGenerators in Compile) += Def.task {
-        assets.AssetsTasks.generateDigests(
-          baseDirectory = baseDirectory.value.getParentFile,
-          targetDirectory = (sourceManaged in Compile).value,
-          generatedObjectName = "AssetsDigests",
-          generatedPackage = Some("sample")
-        )
-      }.taskValue,
-      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
-    )
-    .jsSettings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
-    )
-    .jvmSettings(
-      coverageEnabled := true,
-      (resourceGenerators in Compile) += Def.task {
-        assets.AssetsTasks.gzipAssets(
-          baseDirectory = baseDirectory.value.getParentFile,
-          targetDirectory = (target in Compile).value
-        )
-      }.taskValue,
-      unmanagedResourceDirectories in Compile += assetsDirectory(baseDirectory.value.getParentFile)
-    )
-    .enablePlugins(ScalaJSPlugin)
-    .dependsOnLocalCrossProjects("algebra", "algebra-circe", "openapi")
-}
-
-val `example-basic-shared-jvm` = `example-basic-shared`.jvm
-
-val `example-basic-shared-js` = `example-basic-shared`.js
-
-val `example-basic-client` =
-  project.in(file("examples/basic/client"))
-    .enablePlugins(ScalaJSPlugin)
-    .settings(
-      noPublishSettings ++ `scala 2.11 to 2.12`,
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
-    )
-    .dependsOn(`example-basic-shared-js`, `xhr-client-circe`)
-
-val `example-basic-play-server` =
-  project.in(file("examples/basic/play-server"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      unmanagedResources in Compile += (fastOptJS in(`example-basic-client`, Compile)).map(_.data).value,
-      libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.6.2",
-      libraryDependencies += "com.typesafe.play" %% "play" % playVersion
-    )
-    .dependsOn(`example-basic-shared-jvm`, `play-server-circe`)
-
-val `example-basic-akkahttp-server` =
-  project.in(file("examples/basic/akkahttp-server"))
-    .settings(commonSettings: _*)
-    .settings(`scala 2.11 to 2.12`)
-    .settings(
-      publishArtifact := false
-    )
-    .dependsOn(`example-basic-shared-jvm`, `akka-http-server`)
-
-
-// CQRS Example
-// public endpoints definitions
-val `example-cqrs-public-endpoints` =
-  CrossProject("example-cqrs-public-endpoints-jvm", "example-cqrs-public-endpoints-js", file("examples/cqrs/public-endpoints"), CrossType.Pure)
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .jsSettings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
-    )
-    .jvmSettings(coverageEnabled := true)
-    .settings(
-      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
-    )
-    .dependsOnLocalCrossProjects("example-cqrs-circe-instant", "json-schema-generic", "algebra-circe")
-
-val `example-cqrs-public-endpoints-jvm` = `example-cqrs-public-endpoints`.jvm
-
-val `example-cqrs-public-endpoints-js` = `example-cqrs-public-endpoints`.js
-
-// web-client, *uses* the public endpoints’ definitions
-val `example-cqrs-web-client` =
-  project.in(file("examples/cqrs/web-client"))
-    .enablePlugins(ScalaJSPlugin)
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false,
-      libraryDependencies ++= Seq(
-        "in.nvilla" %%% "monadic-html" % "0.2.2",
-        "in.nvilla" %%% "monadic-rx-cats" % "0.2.2",
-        "org.julienrf" %%% "faithful-cats" % "1.1.0",
-        "org.scala-js" %%% "scalajs-java-time" % "0.2.0"
-      ),
-      scalaJSUseMainModuleInitializer := true
-    )
-    .dependsOn(`xhr-client-faithful`, `xhr-client-circe`)
-    .dependsOn(`example-cqrs-public-endpoints-js`)
-
-// public server implementation, *implements* the public endpoints’ definitions and *uses* the commands and queries definitions
-val `example-cqrs-public-server` =
-  project.in(file("examples/cqrs/public-server"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      unmanagedResources in Compile += (fastOptJS in (`example-cqrs-web-client`, Compile)).map(_.data).value,
-      (sourceGenerators in Compile) += Def.task {
-        assets.AssetsTasks.generateDigests(
-          baseDirectory = (crossTarget in fastOptJS in `example-cqrs-web-client`).value,
-          targetDirectory = (sourceManaged in Compile).value,
-          generatedObjectName = "BootstrapDigests",
-          generatedPackage = Some("cqrs.publicserver"),
-          assetsPath = identity
-        )
-      }.dependsOn(fastOptJS in Compile in `example-cqrs-web-client`).taskValue
-    )
-    .dependsOn(`play-server-circe`, `play-client`, `openapi-jvm`)
-    .dependsOn(`example-cqrs-public-endpoints-jvm`, `example-cqrs-commands-endpoints`, `example-cqrs-queries-endpoints`)
-
-// commands endpoints definitions
-lazy val `example-cqrs-commands-endpoints` =
-  project.in(file("examples/cqrs/commands-endpoints"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      libraryDependencies ++= Seq(
-        "org.scala-stm" %% "scala-stm" % "0.8",
-        "io.circe" %% "circe-generic" % circeVersion
-      )
-    )
-    .dependsOn(`algebra-circe-jvm`, `circe-instant-jvm`)
-
-// commands implementation
-val `example-cqrs-commands` =
-  project.in(file("examples/cqrs/commands"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
-        scalaTestDependency
-      )
-    )
-    .dependsOn(`play-server-circe`, `play-client` % Test)
-    .dependsOn(`example-cqrs-commands-endpoints`)
-
-// queries endpoints definitions
-lazy val `example-cqrs-queries-endpoints` =
-  project.in(file("examples/cqrs/queries-endpoints"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .dependsOn(`algebra-circe-jvm`, `example-cqrs-public-endpoints-jvm` /* because we reuse the DTOs */)
-
-// queries implementation
-val `example-cqrs-queries` =
-  project.in(file("examples/cqrs/queries"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .dependsOn(`play-server-circe`, `play-client`)
-    .dependsOn(`example-cqrs-queries-endpoints`, `example-cqrs-commands-endpoints`)
-
-// this one exists only for the sake of simplifying the infrastructure: it runs all the HTTP services
-val `example-cqrs` =
-  project.in(file("examples/cqrs/infra"))
-    //cant update to 2.12 because it depends on faithful
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      cancelable in Global := true,
-      libraryDependencies ++= Seq(
-        "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
-        scalaTestDependency
-      )
-    )
-    .dependsOn(`example-cqrs-queries`, `example-cqrs-commands`, `example-cqrs-public-server`, `example-cqrs-web-client`/*, `circe-instant-js`*/ /*, `circe-instant-jvm`*/)
-
-lazy val `circe-instant` =
-  CrossProject("example-cqrs-circe-instantJVM", "example-cqrs-circe-instantJS", file("examples/cqrs/circe-instant"), CrossType.Pure)
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .jsSettings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
-    )
-    .jvmSettings(coverageEnabled := true)
-    .settings(
-      libraryDependencies += "io.circe" %%% "circe-core" % circeVersion
-    )
-
-lazy val `circe-instant-js` = `circe-instant`.js
-lazy val `circe-instant-jvm` = `circe-instant`.jvm
-
-val `example-documented` =
-  project.in(file("examples/documented"))
-    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
-    .settings(
-      herokuAppName in Compile := "documented-counter",
-      herokuFatJar in Compile := Some((assemblyOutputPath in assembly).value),
-      herokuSkipSubProjects in Compile := false,
-      herokuProcessTypes in Compile := Map(
-        "web" -> ("java -Dhttp.port=$PORT -jar " ++ (crossTarget.value / s"${name.value}-assembly-${version.value}.jar").relativeTo(baseDirectory.value).get.toString)
-      ),
-      assemblyMergeStrategy in assembly := {
-        case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
-        case x =>
-          val oldStrategy = (assemblyMergeStrategy in assembly).value
-          oldStrategy(x)
-      },
-      (sourceGenerators in Compile) += Def.task {
-        assets.AssetsTasks.generateDigests(
-          baseDirectory = baseDirectory.value,
-          targetDirectory = (sourceManaged in Compile).value,
-          generatedObjectName = "AssetsDigests",
-          generatedPackage = Some("counter"),
-          assetsPath = _ / "src" / "main" / "resources" / "public"
-        )
-      }.taskValue
-    )
-    .dependsOn(`play-server-circe`, `json-schema-generic-jvm`, `openapi-jvm`)
+//import EndpointsSettings._
+//import LocalCrossProject._
+//import org.scalajs.sbtplugin.cross.CrossProject
+//
+//val `algebra-jvm` = LocalProject("algebraJVM")
+//val `algebra-circe-jvm` = LocalProject("algebra-circeJVM")
+//val `algebra-playjson-jvm` = LocalProject("algebra-playjsonJVM")
+//
+//val `play-client` = LocalProject("play-client")
+//val `play-server` = LocalProject("play-server")
+//val `play-server-circe` = LocalProject("play-server-circe")
+//
+//val `akka-http-server` = LocalProject("akka-http-server")
+//
+//val `xhr-client` = LocalProject("xhr-client")
+//val `xhr-client-circe` = LocalProject("xhr-client-circe")
+//val `xhr-client-faithful` = LocalProject("xhr-client-faithful")
+//
+//val `scalaj-client` = LocalProject("scalaj-client")
+//
+//val `openapi-jvm` = LocalProject("openapiJVM")
+//
+//val `json-schema-jvm` = LocalProject("json-schemaJVM")
+//val `json-schema-circe-jvm` = LocalProject("json-schema-circeJVM")
+//val `json-schema-generic-jvm` = LocalProject("json-schema-genericJVM")
+//
+//import sbtunidoc.Plugin.UnidocKeys.unidoc
+//
+//val apiDoc =
+//  project.in(file("api-doc"))
+//    .settings(noPublishSettings ++ `scala 2.11` ++ unidocSettings: _*)
+//    .settings(
+//      coverageEnabled := false,
+//      scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
+//        "-diagrams",
+//        "-groups",
+//        "-doc-source-url", s"https://github.com/julienrf/endpoints/blob/v${version.value}€{FILE_PATH}.scala",
+//        "-sourcepath", (baseDirectory in ThisBuild).value.absolutePath
+//      ),
+//      sbtunidoc.Plugin.UnidocKeys.unidocProjectFilter in(ScalaUnidoc, unidoc) := inProjects(
+//        `algebra-jvm`, `algebra-circe-jvm`, `algebra-playjson-jvm`,
+//        `play-client`,
+//        `play-server`, `play-server-circe`,
+//        `xhr-client`, `xhr-client-circe`, `xhr-client-faithful`,
+//        `scalaj-client`,
+//        `openapi-jvm`, `json-schema-jvm`, `json-schema-circe-jvm`, `json-schema-generic-jvm`
+//      )
+//    )
+//
+//val ornateTarget = Def.setting(target.value / "ornate")
+//
+//val manual =
+//  project.in(file("manual"))
+//    .enablePlugins(OrnatePlugin, GhpagesPlugin)
+//    .settings(
+//      coverageEnabled := false,
+//      scalaVersion := "2.11.8",
+//      git.remoteRepo := "git@github.com:julienrf/endpoints.git",
+//      ornateSourceDir := Some(sourceDirectory.value / "ornate"),
+//      ornateTargetDir := Some(ornateTarget.value),
+//      ornateSettings := Map("version" -> version.value),
+//      siteSubdirName in ornate := "",
+//      addMappingsToSiteDir(mappings in ornate, siteSubdirName in ornate),
+//      mappings in ornate := {
+//        val _ = ornate.value
+//        val output = ornateTarget.value
+//        output ** AllPassFilter --- output pair relativeTo(output)
+//      },
+//      siteSubdirName in packageDoc := s"api/${version.value}",
+//      addMappingsToSiteDir(mappings in ScalaUnidoc in packageDoc in apiDoc, siteSubdirName in packageDoc),
+//      previewLaunchBrowser := false
+//    )
+//
+//
+//// Example for the “Overview” page of the documentation
+//val `example-overview-endpoints` =
+//  crossProject.crossType(CrossType.Pure)
+//    .in(file("examples/overview/endpoints"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`: _*)
+//    .jsSettings(
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false
+//    )
+//    .jvmSettings(coverageEnabled := true)
+//    .settings(
+//      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+//      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
+//    )
+//    .dependsOnLocalCrossProjects("algebra-circe")
+//
+//val `example-overview-endpoints-jvm` = `example-overview-endpoints`.jvm
+//
+//val `example-overview-endpoints-js` = `example-overview-endpoints`.js
+//
+//val `example-overview-client` =
+//  project.in(file("examples/overview/client"))
+//    .enablePlugins(ScalaJSPlugin)
+//    .settings(
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false,
+//      noPublishSettings ++ `scala 2.11 to 2.12`
+//    )
+//    .dependsOn(`example-overview-endpoints-js`, `xhr-client-circe`)
+//
+//val `example-overview-server` =
+//  project.in(file("examples/overview/server"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(libraryDependencies += "org.scala-stm" %% "scala-stm" % "0.8")
+//    .dependsOn(`example-overview-endpoints-jvm`, `play-server-circe`)
+//
+//val `example-overview-play-client` =
+//  project.in(file("examples/overview/play-client"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .dependsOn(`example-overview-endpoints-jvm`, `play-client`)
+//
+//// Basic example
+//val `example-basic-shared` = {
+//  val assetsDirectory = (base: File) => base / "src" / "main" / "assets"
+//  CrossProject("example-basic-shared-jvm", "example-basic-shared-js", file("examples/basic/shared"), CrossType.Pure)
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+//      (sourceGenerators in Compile) += Def.task {
+//        assets.AssetsTasks.generateDigests(
+//          baseDirectory = baseDirectory.value.getParentFile,
+//          targetDirectory = (sourceManaged in Compile).value,
+//          generatedObjectName = "AssetsDigests",
+//          generatedPackage = Some("sample")
+//        )
+//      }.taskValue,
+//      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
+//    )
+//    .jsSettings(
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false
+//    )
+//    .jvmSettings(
+//      coverageEnabled := true,
+//      (resourceGenerators in Compile) += Def.task {
+//        assets.AssetsTasks.gzipAssets(
+//          baseDirectory = baseDirectory.value.getParentFile,
+//          targetDirectory = (target in Compile).value
+//        )
+//      }.taskValue,
+//      unmanagedResourceDirectories in Compile += assetsDirectory(baseDirectory.value.getParentFile)
+//    )
+//    .enablePlugins(ScalaJSPlugin)
+//    .dependsOnLocalCrossProjects("algebra", "algebra-circe", "openapi")
+//}
+//
+//val `example-basic-shared-jvm` = `example-basic-shared`.jvm
+//
+//val `example-basic-shared-js` = `example-basic-shared`.js
+//
+//val `example-basic-client` =
+//  project.in(file("examples/basic/client"))
+//    .enablePlugins(ScalaJSPlugin)
+//    .settings(
+//      noPublishSettings ++ `scala 2.11 to 2.12`,
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false
+//    )
+//    .dependsOn(`example-basic-shared-js`, `xhr-client-circe`)
+//
+//val `example-basic-play-server` =
+//  project.in(file("examples/basic/play-server"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      unmanagedResources in Compile += (fastOptJS in(`example-basic-client`, Compile)).map(_.data).value,
+//      libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.6.2",
+//      libraryDependencies += "com.typesafe.play" %% "play" % playVersion
+//    )
+//    .dependsOn(`example-basic-shared-jvm`, `play-server-circe`)
+//
+//val `example-basic-akkahttp-server` =
+//  project.in(file("examples/basic/akkahttp-server"))
+//    .settings(commonSettings: _*)
+//    .settings(`scala 2.11 to 2.12`)
+//    .settings(
+//      publishArtifact := false
+//    )
+//    .dependsOn(`example-basic-shared-jvm`, `akka-http-server`)
+//
+//
+//// CQRS Example
+//// public endpoints definitions
+//val `example-cqrs-public-endpoints` =
+//  CrossProject("example-cqrs-public-endpoints-jvm", "example-cqrs-public-endpoints-js", file("examples/cqrs/public-endpoints"), CrossType.Pure)
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .jsSettings(
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false
+//    )
+//    .jvmSettings(coverageEnabled := true)
+//    .settings(
+//      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
+//    )
+//    .dependsOnLocalCrossProjects("example-cqrs-circe-instant", "json-schema-generic", "algebra-circe")
+//
+//val `example-cqrs-public-endpoints-jvm` = `example-cqrs-public-endpoints`.jvm
+//
+//val `example-cqrs-public-endpoints-js` = `example-cqrs-public-endpoints`.js
+//
+//// web-client, *uses* the public endpoints’ definitions
+//val `example-cqrs-web-client` =
+//  project.in(file("examples/cqrs/web-client"))
+//    .enablePlugins(ScalaJSPlugin)
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false,
+//      libraryDependencies ++= Seq(
+//        "in.nvilla" %%% "monadic-html" % "0.2.2",
+//        "in.nvilla" %%% "monadic-rx-cats" % "0.2.2",
+//        "org.julienrf" %%% "faithful-cats" % "1.1.0",
+//        "org.scala-js" %%% "scalajs-java-time" % "0.2.0"
+//      ),
+//      scalaJSUseMainModuleInitializer := true
+//    )
+//    .dependsOn(`xhr-client-faithful`, `xhr-client-circe`)
+//    .dependsOn(`example-cqrs-public-endpoints-js`)
+//
+//// public server implementation, *implements* the public endpoints’ definitions and *uses* the commands and queries definitions
+//val `example-cqrs-public-server` =
+//  project.in(file("examples/cqrs/public-server"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      unmanagedResources in Compile += (fastOptJS in (`example-cqrs-web-client`, Compile)).map(_.data).value,
+//      (sourceGenerators in Compile) += Def.task {
+//        assets.AssetsTasks.generateDigests(
+//          baseDirectory = (crossTarget in fastOptJS in `example-cqrs-web-client`).value,
+//          targetDirectory = (sourceManaged in Compile).value,
+//          generatedObjectName = "BootstrapDigests",
+//          generatedPackage = Some("cqrs.publicserver"),
+//          assetsPath = identity
+//        )
+//      }.dependsOn(fastOptJS in Compile in `example-cqrs-web-client`).taskValue
+//    )
+//    .dependsOn(`play-server-circe`, `play-client`, `openapi-jvm`)
+//    .dependsOn(`example-cqrs-public-endpoints-jvm`, `example-cqrs-commands-endpoints`, `example-cqrs-queries-endpoints`)
+//
+//// commands endpoints definitions
+//lazy val `example-cqrs-commands-endpoints` =
+//  project.in(file("examples/cqrs/commands-endpoints"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      libraryDependencies ++= Seq(
+//        "org.scala-stm" %% "scala-stm" % "0.8",
+//        "io.circe" %% "circe-generic" % circeVersion
+//      )
+//    )
+//    .dependsOn(`algebra-circe-jvm`, `circe-instant-jvm`)
+//
+//// commands implementation
+//val `example-cqrs-commands` =
+//  project.in(file("examples/cqrs/commands"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      libraryDependencies ++= Seq(
+//        "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
+//        scalaTestDependency
+//      )
+//    )
+//    .dependsOn(`play-server-circe`, `play-client` % Test)
+//    .dependsOn(`example-cqrs-commands-endpoints`)
+//
+//// queries endpoints definitions
+//lazy val `example-cqrs-queries-endpoints` =
+//  project.in(file("examples/cqrs/queries-endpoints"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .dependsOn(`algebra-circe-jvm`, `example-cqrs-public-endpoints-jvm` /* because we reuse the DTOs */)
+//
+//// queries implementation
+//val `example-cqrs-queries` =
+//  project.in(file("examples/cqrs/queries"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .dependsOn(`play-server-circe`, `play-client`)
+//    .dependsOn(`example-cqrs-queries-endpoints`, `example-cqrs-commands-endpoints`)
+//
+//// this one exists only for the sake of simplifying the infrastructure: it runs all the HTTP services
+//val `example-cqrs` =
+//  project.in(file("examples/cqrs/infra"))
+//    //cant update to 2.12 because it depends on faithful
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      cancelable in Global := true,
+//      libraryDependencies ++= Seq(
+//        "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
+//        scalaTestDependency
+//      )
+//    )
+//    .dependsOn(`example-cqrs-queries`, `example-cqrs-commands`, `example-cqrs-public-server`, `example-cqrs-web-client`/*, `circe-instant-js`*/ /*, `circe-instant-jvm`*/)
+//
+//lazy val `circe-instant` =
+//  CrossProject("example-cqrs-circe-instantJVM", "example-cqrs-circe-instantJS", file("examples/cqrs/circe-instant"), CrossType.Pure)
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .jsSettings(
+//      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
+//      coverageEnabled := false
+//    )
+//    .jvmSettings(coverageEnabled := true)
+//    .settings(
+//      libraryDependencies += "io.circe" %%% "circe-core" % circeVersion
+//    )
+//
+//lazy val `circe-instant-js` = `circe-instant`.js
+//lazy val `circe-instant-jvm` = `circe-instant`.jvm
+//
+//val `example-documented` =
+//  project.in(file("examples/documented"))
+//    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+//    .settings(
+//      herokuAppName in Compile := "documented-counter",
+//      herokuFatJar in Compile := Some((assemblyOutputPath in assembly).value),
+//      herokuSkipSubProjects in Compile := false,
+//      herokuProcessTypes in Compile := Map(
+//        "web" -> ("java -Dhttp.port=$PORT -jar " ++ (crossTarget.value / s"${name.value}-assembly-${version.value}.jar").relativeTo(baseDirectory.value).get.toString)
+//      ),
+//      assemblyMergeStrategy in assembly := {
+//        case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
+//        case x =>
+//          val oldStrategy = (assemblyMergeStrategy in assembly).value
+//          oldStrategy(x)
+//      },
+//      (sourceGenerators in Compile) += Def.task {
+//        assets.AssetsTasks.generateDigests(
+//          baseDirectory = baseDirectory.value,
+//          targetDirectory = (sourceManaged in Compile).value,
+//          generatedObjectName = "AssetsDigests",
+//          generatedPackage = Some("counter"),
+//          assetsPath = _ / "src" / "main" / "resources" / "public"
+//        )
+//      }.taskValue
+//    )
+//    .dependsOn(`play-server-circe`, `json-schema-generic-jvm`, `openapi-jvm`)

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -12,19 +12,19 @@ val `json-schema` =
 val `json-schema-js` = `json-schema`.js
 val `json-schema-jvm` = `json-schema`.jvm
 
-lazy val `json-schema-generic` =
-  crossProject.crossType(CrossType.Pure).in(file("json-schema-generic"))
-    .settings(publishSettings ++ `scala 2.11 to 2.12`: _*)
-    .settings(
-      name := "endpoints-json-schema-generic",
-      libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.2",
-      addScalaTestCrossDependency
-    )
-    .dependsOnLocalCrossProjects("json-schema")
-    .dependsOnLocalCrossProjectsWithScope("openapi" -> "test")
-
-lazy val `json-schema-generic-js` = `json-schema-generic`.js
-lazy val `json-schema-generic-jvm` = `json-schema-generic`.jvm
+//lazy val `json-schema-generic` =
+//  crossProject.crossType(CrossType.Pure).in(file("json-schema-generic"))
+//    .settings(publishSettings ++ `scala 2.11 to 2.12`: _*)
+//    .settings(
+//      name := "endpoints-json-schema-generic",
+//      libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.2",
+//      addScalaTestCrossDependency
+//    )
+//    .dependsOnLocalCrossProjects("json-schema")
+//    .dependsOnLocalCrossProjectsWithScope("openapi" -> "test")
+//
+//lazy val `json-schema-generic-js` = `json-schema-generic`.js
+//lazy val `json-schema-generic-jvm` = `json-schema-generic`.jvm
 
 lazy val `json-schema-circe` =
   crossProject.crossType(CrossType.Pure).in(file("json-schema-circe"))

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
@@ -6,7 +6,13 @@ import endpoints.algebra
 import endpoints.algebra.BasicAuthentication.Credentials
 import endpoints.algebra.Documentation
 
-trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
+trait BasicAuthentication extends algebra.BasicAuthentication {
+
+  override val endpoints: Endpoints
+
+  import endpoints._
+  import requests._
+  import responses._
 
   /**
     * Supplies the credential into the request headers

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
@@ -5,9 +5,13 @@ import endpoints.algebra.Documentation
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Endpoints extends algebra.Endpoints with Requests with Responses {
+trait Endpoints extends algebra.Endpoints {
 
-  type MuxEndpoint[A, B, Transport] = Nothing
+  override val requests: Requests
+  override val responses: Responses
+
+  import requests._
+  import responses._
 
   def endpoint[A, B](
     request: Request[A],

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
@@ -5,7 +5,13 @@ import endpoints.algebra.{Codec, Documentation}
   * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that encodes JSON requests
   * and decodes JSON responses.
   */
-trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
+trait JsonEntitiesFromCodec extends endpoints.algebra.JsonEntitiesFromCodec {
+
+  override val endpoints: Endpoints
+
+  import endpoints._
+  import requests._
+  import responses._
 
   def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] = (data, request) => {
     request.header("Content-Type", "application/json")

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -5,7 +5,13 @@ import endpoints.algebra.Documentation
 
 import scalaj.http.HttpRequest
 
-trait Requests extends algebra.Requests with Urls with Methods {
+trait Requests extends algebra.Requests {
+
+  override val urls: Urls
+  override val methods: Methods
+
+  import methods.Method
+  import urls.Url
 
 
    type RequestHeaders[A] = A => Seq[(String, String)]

--- a/scalaj/client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
+++ b/scalaj/client/src/test/scala/endpoints/scalaj/client/EndpointsTest.scala
@@ -1,30 +1,48 @@
 package endpoints.scalaj.client
 
+import endpoints.algebra
 import endpoints.algebra.client.{BasicAuthTestSuite, EndpointsTestSuite}
 import endpoints.algebra.{BasicAuthTestApi, EndpointsTestApi}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class TestClient(val address: String)
+class TestClient(val _address: String)
   extends EndpointsTestApi
-  with BasicAuthTestApi
-  with Endpoints
-  with BasicAuthentication
+  with BasicAuthTestApi {
+  override val endpoints: Endpoints = new Endpoints {
+    override val requests: Requests = new Requests {
+      override val urls: Urls = new Urls {
+        override def address: String = _address
+      }
+      override val methods: Methods = new Methods {}
+    }
+    override val responses: Responses = new Responses {}
+  }
+  override val basicAuth: algebra.BasicAuthentication = new BasicAuthentication {
+    override val endpoints: Endpoints = TestClient.this.endpoints
+  }
+}
 
-class EndpointsTest
-  extends EndpointsTestSuite[TestClient]
-    with BasicAuthTestSuite[TestClient] {
-
-  val client: TestClient = new TestClient(s"localhost:$wiremockPort")
-
-  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp] =
-    endpoint.callAsync(args)
+class EndpointsTest {
 
 
-  clientTestSuite()
+  val endpointsSuite = new EndpointsTestSuite {
+    val api: TestClient = new TestClient(s"localhost:$wiremockPort")
 
-  basicAuthSuite()
+    def call[Req, Resp](endpoint: Endpoint[Req, Resp], args: Req): Future[Resp] =
+      endpoint.asInstanceOf[api.endpoints.Endpoint[Req, Resp]].callAsync(args)
+  }
+  val  basicAuthSuite = new BasicAuthTestSuite {
+    val api: TestClient = new TestClient(s"localhost:$wiremockPort")
+
+    def call[Req, Resp](endpoint: Endpoint[Req, Resp], args: Req): Future[Resp] =
+      endpoint.asInstanceOf[api.endpoints.Endpoint[Req, Resp]].callAsync(args)
+  }
+
+  endpointsSuite.clientTestSuite()
+
+  basicAuthSuite.basicAuthSuite()
 
 
 }

--- a/scalaj/client/src/test/scala/endpoints/scalaj/client/JsonEntitiesFromCodecTest.scala
+++ b/scalaj/client/src/test/scala/endpoints/scalaj/client/JsonEntitiesFromCodecTest.scala
@@ -7,23 +7,29 @@ import endpoints.algebra.client.JsonFromCodecTestSuite
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class TestJsonClient(val address: String )
-  extends Endpoints
-    with JsonEntitiesFromCodec
-    with circe.JsonEntitiesFromCodec
-    with algebra.JsonFromCodecTestApi
+class TestJsonClient(val _address: String )
+  extends algebra.JsonFromCodecTestApi
     with circe.JsonFromCirceCodecTestApi {
-
-
+  override val entities: JsonEntitiesFromCodec with circe.JsonEntitiesFromCodec = new JsonEntitiesFromCodec with circe.JsonEntitiesFromCodec {
+    override val endpoints: Endpoints = new Endpoints {
+      override val requests: Requests = new Requests {
+        override val urls: Urls = new Urls {
+          override def address: String = _address
+        }
+        override val methods: Methods = new Methods {}
+      }
+      override val responses: Responses = new Responses {}
+    }
+  }
 }
 
-class JsonEntitiesFromCodecTest extends JsonFromCodecTestSuite[TestJsonClient] {
+class JsonEntitiesFromCodecTest extends JsonFromCodecTestSuite {
 
-  val client: TestJsonClient = new TestJsonClient(s"localhost:$wiremockPort")
+  override val api: TestJsonClient = new TestJsonClient(s"localhost:$wiremockPort")
   implicit val ec = ExecutionContext.Implicits.global
 
-  def call[Req, Resp](endpoint: client.Endpoint[Req, Resp], args: Req): Future[Resp] =
-    endpoint.callAsync(args)
+  def call[Req, Resp](endpoint: Endpoint[Req, Resp], args: Req): Future[Resp] =
+    endpoint.asInstanceOf[api.entities.endpoints.Endpoint[Req, Resp]].callAsync(args)
 
   jsonFromCodecTestSuite()
 


### PR DESCRIPTION
I wanted to check if this would work and it seems that it would indeed. 

The biggest benefit for me is a clear distinction between base algebra of an interpreter and dependent algebras. It becomes much easier to reason about the interpreters and to create such. The confusion about which traits need to be mixed in should be much smaller with this approach.

The user still has all the power to extend/override the implementation. The biggest drawback I see is the necessity of importing contents of all the algebras separately.

The consistency between interpreters can be enforced by type refinements if needed.

In general, I'm in favour of this encoding if there would be no other problems. I believe that being able to easily reason about algebras pays the cost of some additional boilerplate.

One unknown is: should interpreter instantiate the dependent interpreters or leave it to the end user? It already needs to override the type of those, so creating an instance wouldn't change much. (rephrase: should `Endpoints` instantiate `Requests`)?