### PR TITLE
Support for empty objects in JsonSchemas

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -53,6 +53,12 @@ trait  JsonSchemas
       }
   }
 
+  def emptyRecord: Record[Unit] =
+    JsonSchema(
+      io.circe.Encoder.encodeUnit,
+      io.circe.Decoder.decodeUnit
+    )
+
   def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A] =
     JsonSchema(
       io.circe.Encoder.instance[A](a => Json.obj(name -> tpe.encoder.apply(a))),

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
@@ -1,7 +1,6 @@
 package endpoints
 package generic
 
-import endpoints.algebra
 import shapeless.labelled.{FieldType, field => shapelessField}
 import shapeless.ops.hlist.Tupler
 import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, LabelledGeneric, Witness}
@@ -50,14 +49,10 @@ trait JsonSchemas extends algebra.JsonSchemas {
 
   object GenericJsonSchema extends GenericJsonSchemaLowPriority {
 
-    implicit def singletonRecord[L <: Symbol, A](implicit
-      labelSingleton: Witness.Aux[L],
-      jsonSchemaSingleton: JsonSchema[A]
-    ): GenericRecord[FieldType[L, A] :: HNil] =
-      new GenericRecord[FieldType[L, A] :: HNil] {
-        def jsonSchema: Record[FieldType[L, A] :: HNil] =
-          field(labelSingleton.value.name)(jsonSchemaSingleton)
-            .invmap[FieldType[L, A] :: HNil](a => shapelessField[L](a) :: HNil)(_.head)
+    implicit def emptyRecordCase: GenericRecord[HNil] =
+      new GenericRecord[HNil] {
+        def jsonSchema: Record[HNil] =
+          emptyRecord.invmap[HNil](_ => HNil)(_ => ())
       }
 
     implicit def singletonCoproduct[L <: Symbol, A](implicit

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -17,6 +17,8 @@ class JsonSchemasTest extends FreeSpec {
     case class QuuxA(s: String) extends Quux
     case class QuuxB(i: Int) extends Quux
     case class QuuxC(b: Boolean) extends Quux
+    case class QuuxD() extends Quux
+    case object QuuxE extends Quux
 
     object Quux {
       implicit val schema: JsonSchema[Quux] = genericJsonSchema[Quux]
@@ -43,6 +45,8 @@ class JsonSchemasTest extends FreeSpec {
         ("QuuxA", DocumentedRecord(Field("s", DocumentedGenericSchemas.stringJsonSchema, isOptional = false, documentation = None) :: Nil)) ::
         ("QuuxB", DocumentedRecord(Field("i", DocumentedGenericSchemas.intJsonSchema, isOptional = false, documentation = None) :: Nil)) ::
         ("QuuxC", DocumentedRecord(Field("b", DocumentedGenericSchemas.booleanJsonSchema, isOptional = false, documentation = None) :: Nil)) ::
+        ("QuuxD", DocumentedRecord(Nil)) ::
+        ("QuuxE", DocumentedRecord(Nil)) ::
         Nil
       )
     assert(DocumentedGenericSchemas.Quux.schema == expectedSchema)

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -70,6 +70,9 @@ trait JsonSchemas {
     */
   type Tagged[A] <: JsonSchema[A]
 
+  /** The JSON schema of a record with no fields */
+  def emptyRecord: Record[Unit]
+
   /** The JSON schema of a record with a single field `name` of type `A` */
   def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A]
 

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -21,19 +21,27 @@ trait JsonSchemasTest extends JsonSchemas {
   sealed trait Foo
   case class Bar(s: String) extends Foo
   case class Baz(i: Int) extends Foo
+  case class Bax() extends Foo
+  case object Qux extends Foo
 
   object Foo {
     implicit val schema: JsonSchema[Foo] = {
       val barSchema: Record[Bar] = field[String]("s").invmap(Bar)(_.s)
       val bazSchema: Record[Baz] = field[Int]("i").invmap(Baz)(_.i)
+      val baxSchema: Record[Bax] = emptyRecord.invmap(_ => Bax())(_ => ())
+      val quxSchema: Record[Qux.type] = emptyRecord.invmap(_ => Qux)(_ => ())
 
-      (barSchema.tagged("Bar") orElse bazSchema.tagged("Baz"))
+      (barSchema.tagged("Bar") orElse bazSchema.tagged("Baz") orElse baxSchema.tagged("Bax") orElse quxSchema.tagged("Qux"))
         .invmap[Foo] {
-          case Left(bar) => bar
-          case Right(baz) => baz
+          case Left(Left(Left(bar))) => bar
+          case Left(Left(Right(baz))) => baz
+          case Left(Right(bax)) => bax
+          case Right(qux) => qux
         } {
-          case bar: Bar => Left(bar)
-          case baz: Baz => Right(baz)
+          case bar: Bar => Left(Left(Left(bar)))
+          case baz: Baz => Left(Left(Right(baz)))
+          case bax: Bax => Left(Right(bax))
+          case qux: Qux.type => Right(qux)
         }
     }
   }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -33,6 +33,9 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   }
 
+  def emptyRecord: DocumentedRecord =
+    DocumentedRecord(Nil)
+
   def field[A](name: String, docs: Documentation)(implicit tpe: DocumentedJsonSchema): DocumentedRecord =
     DocumentedRecord(Field(name, tpe, isOptional = false, docs) :: Nil)
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -1,8 +1,6 @@
 package endpoints
 package openapi
 
-import java.nio.charset.Charset
-
 import endpoints.algebra.Documentation
 import endpoints.openapi.model.{MediaType, Schema}
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -27,6 +27,8 @@ class JsonSchemasTest extends FreeSpec {
       DocumentedCoProd(
         ("Bar", DocumentedRecord(Field("s", DocumentedJsonSchemas.stringJsonSchema, isOptional = false, documentation = None) :: Nil)) ::
         ("Baz", DocumentedRecord(Field("i", DocumentedJsonSchemas.intJsonSchema, isOptional = false, documentation = None) :: Nil)) ::
+        ("Bax", DocumentedRecord(Nil)) ::
+        ("Qux", DocumentedRecord(Nil)) ::
         Nil
       )
     assert(DocumentedJsonSchemas.Foo.schema == expectedSchema)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17


### PR DESCRIPTION
This PR is follow up to discussion on gitter: https://gitter.im/julienrf/endpoints?at=5b6eac942a8e6c6083aaf21e

* added `emptyRecord` JSON schemas dsl primitive
* generic JSON schema derivation for both singleton objects and case classes with no parameters should be supported
