### PR TITLE
Fix decoder for empty object

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -56,7 +56,7 @@ trait  JsonSchemas
   def emptyRecord: Record[Unit] =
     JsonSchema(
       io.circe.Encoder.encodeUnit,
-      io.circe.Decoder.decodeUnit
+      io.circe.Decoder.decodeJsonObject.map(_ => ())
     )
 
   def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A] =

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -22,6 +22,9 @@ class JsonSchemasTest extends FreeSpec {
 
     assert(User.schema.decoder.decodeJson(userJson).right.exists(_ == user))
     assert(User.schema.encoder.apply(user) == userJson)
+
+    assert(User.schema2.decoder.decodeJson(userJson).right.exists(_ == user))
+    assert(User.schema2.encoder.apply(user) == userJson)
   }
 
   "sealed trait" in {

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -16,6 +16,14 @@ trait JsonSchemasTest extends JsonSchemas {
       field[String]("name", Some("Name of the user")) zip
       field[Int]("age")
     ).invmap((User.apply _).tupled)(Function.unlift(User.unapply))
+
+    val schema2: JsonSchema[User] = (
+      emptyRecord zip
+      field[String]("name", Some("Name of the user")) zip
+      field[Int]("age")
+    )
+      .invmap[(String, Int)](p => (p._1._2, p._2))(p => (((), p._1), p._2))
+      .invmap((User.apply _).tupled)(Function.unlift(User.unapply))
   }
 
   sealed trait Foo


### PR DESCRIPTION
This PR is follow up to https://github.com/julienrf/endpoints/pull/107

* I defined circe decoder for `emptyRecord` that was using `io.circe.Decoder.decodeUnit` which actually expects empty object as an input and fails otherwise (in case it was given object with few fields)
* As we use this decoder instance in [base case](https://github.com/julienrf/endpoints/blob/master/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala#L55) of generic derivation, using such derived decoder was failing to decode any non-empty record
* This PR introduces decoder that is a bit more liberal - it accepts any json object, not necessarily empty which seems to fix the problem
