### PR TITLE
Urls.scala changed according to discussion in #63

### DIFF
--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -49,4 +49,9 @@ trait EndpointsTestApi extends algebra.Endpoints {
     textResponse()
   )
 
+  val optQsEndpoint = endpoint(
+    get(path / "user" / segment[String]() / "whatever" /? (qs[String]("name") & optQs[Int]("age"))),
+    textResponse()
+  )
+
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
@@ -30,6 +30,30 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
 
       }
 
+
+      "return correct url with optional parameter" in {
+
+        val response = "wiremockeResponse"
+
+        wireMockServer.stubFor(get(urlEqualTo("/user/userId/whatever?name=name1"))
+          .willReturn(aResponse()
+            .withStatus(200)
+            .withBody(response)))
+
+        wireMockServer.stubFor(get(urlEqualTo("/user/userId/whatever?name=name1&age=18"))
+          .willReturn(aResponse()
+            .withStatus(200)
+            .withBody(response)))
+
+        whenReady(call(client.optQsEndpoint, ("userId", "name1", None))) {
+          _ shouldEqual response
+        }
+        whenReady(call(client.optQsEndpoint, ("userId", "name1", Some(18)))) {
+          _ shouldEqual response
+        }
+
+      }
+
       "throw exception when 5xx is returned from server" in {
         wireMockServer.stubFor(get(urlEqualTo("/user/userId/description?name=name1&age=18"))
           .willReturn(aResponse()

--- a/play/client/src/main/scala/endpoints/play/client/Urls.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Urls.scala
@@ -14,21 +14,27 @@ trait Urls extends algebra.Urls {
   val utf8Name = UTF_8.name()
 
   trait QueryString[A] {
-    def encodeQueryString(a: A): String
+    def encodeQueryString(a: A): Option[String]
   }
 
   def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
     (ab: tupler.Out) => {
       val (a, b) = tupler.unapply(ab)
-      s"${first.encodeQueryString(a)}&${second.encodeQueryString(b)}"
+
+      (first.encodeQueryString(a), second.encodeQueryString(b)) match {
+        case (Some(left), Some(right)) => Some(s"$left&$right")
+        case (Some(left), None) => Some(left)
+        case (None, Some(right)) => Some(right)
+        case (None, None) => None
+      }
     }
 
   def qs[A](name: String, docs: Documentation)(implicit value: QueryStringParam[A]): QueryString[A] =
-    a => s"$name=${value.apply(a)}"
+    a => Some(s"$name=${value.apply(a)}")
 
-  def optQs[A](name: String, docs: Documentation)(implicit value: A => String): QueryString[Option[A]] = {
-    case Some(a) => qs[A](name).encodeQueryString(a)
-    case None => ""
+  def optQs[A](name: String, docs: Documentation)(implicit value: QueryStringParam[A]): QueryString[Option[A]] = {
+    case Some(a) => qs[A](name, docs).encodeQueryString(a)
+    case None => None
   }
 
   type QueryStringParam[A] = A => String
@@ -53,7 +59,7 @@ trait Urls extends algebra.Urls {
 
   trait Path[A] extends Url[A]
 
-  def staticPathSegment(segment: String) = (_: Unit) => segment
+  def staticPathSegment(segment: String): Path[Unit] = (_: Unit) => segment
 
   def segment[A](name: String, docs: Documentation)(implicit s: Segment[A]): Path[A] = a => s.encode(a)
 
@@ -71,7 +77,11 @@ trait Urls extends algebra.Urls {
   def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] =
     (ab: tupler.Out) => {
       val (a, b) = tupler.unapply(ab)
-      s"${path.encode(a)}?${qs.encodeQueryString(b)}"
+
+      qs.encodeQueryString(b) match {
+        case Some(q) => s"${path.encode(a)}?$q"
+        case None => path.encode(a)
+      }
     }
 
   implicit lazy val urlInvFunctor: InvariantFunctor[Url] = new InvariantFunctor[Url] {

--- a/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
+++ b/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
@@ -4,7 +4,6 @@ import endpoints.algebra.client
 import endpoints.algebra
 import endpoints.algebra.circe
 import play.api.libs.ws.WSClient
-import play.api.test
 import play.api.test.WsTestClient
 
 import scala.concurrent.{ExecutionContext, Future}


### PR DESCRIPTION
added test which checks if the optional parameter works correctly, changed play-client Urls.scala implementation, for scalaj it looks it's not required(it is being resolved by the lib)