### PR TITLE
Fix codecov call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ jobs:
     - stage: coverage
       script: sbt "wow 2.11.11" coverage test coverageReport coverageAggregate
       after_success:
-        - codecov
+        - bash <(curl -s https://codecov.io/bash)

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/ClientTestBase.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/ClientTestBase.scala
@@ -17,7 +17,7 @@ trait ClientTestBase[T <: algebra.Endpoints] extends WordSpec
   with BeforeAndAfterAll
   with BeforeAndAfter {
 
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(10.seconds, 10.millisecond)
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(15.seconds, 10.millisecond)
 
   val wiremockPort = findOpenPort
   val wireMockServer = new WireMockServer(options().port(wiremockPort))


### PR DESCRIPTION
The `codecov` call had no effect because there is no such command on Travis. Instead, this PR uses the bash codecov script as shown in [this example](https://github.com/codecov/example-scala/blob/master/.travis.yml)