### PR TITLE
Interpreter for Play JSON based on schema definition

### DIFF
--- a/documentation/manual/src/ornate/interfaces-and-interpreters.md
+++ b/documentation/manual/src/ornate/interfaces-and-interpreters.md
@@ -49,3 +49,4 @@ navigate through the algebra interfaces hierarchy.
 |[endpoints-openapi](https://index.scala-lang.org/julienrf/endpoints/endpoints-openapi)|Interpreter that creates OpenAPI json from endpoints description |
 |[endpoints-json-schema-generic](https://index.scala-lang.org/julienrf/endpoints/endpoints-json-schema-generic)|Interpreter that allows generic derivation of json-schema|
 |[endpoints-json-schema-circe](https://index.scala-lang.org/julienrf/endpoints/endpoints-json-schema-circe)|Interpreter that produces circe codec based on schema definition|
+|[endpoints-json-schema-playjson](https://index.scala-lang.org/julienrf/endpoints/endpoints-json-schema-playjson)|Interpreter that produces Play JSON Reads and Writes based on schema definition|

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -39,3 +39,16 @@ lazy val `json-schema-circe` =
 
 lazy val `json-schema-circe-js` = `json-schema-circe`.js
 lazy val `json-schema-circe-jvm` = `json-schema-circe`.jvm
+
+lazy val `json-schema-playjson` =
+  crossProject.crossType(CrossType.Pure).in(file("json-schema-playjson"))
+    .settings(publishSettings ++ `scala 2.10 to 2.12`: _*)
+    .settings(
+      name := "endpoints-json-schema-playjson",
+      libraryDependencies += "com.typesafe.play" %%% "play-json" % playjsonVersion
+    )
+    .jsConfigure(_.dependsOn(`json-schema-js` % "test->test;compile->compile"))
+    .jvmConfigure(_.dependsOn(`json-schema-jvm` % "test->test;compile->compile"))
+
+lazy val `json-schema-playjson-js` = `json-schema-playjson`.js
+lazy val `json-schema-playjson-jvm` = `json-schema-playjson`.jvm

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -1,0 +1,163 @@
+package endpoints.playjson
+
+import endpoints.algebra
+import play.api.libs.json._
+
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
+import scala.util.Try
+
+/**
+  * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces Play JSON [[play.api.libs.json.Reads]]
+  * and [[play.api.libs.json.Writes]].
+  */
+trait JsonSchemas
+  extends algebra.JsonSchemas {
+
+  trait JsonSchema[A] {
+    def reads: Reads[A]
+    def writes: Writes[A]
+  }
+
+  object JsonSchema {
+    def apply[A](_reads: Reads[A], _writes: Writes[A]): JsonSchema[A] = new JsonSchema[A] {
+      def reads: Reads[A] = _reads
+      def writes: Writes[A] = _writes
+    }
+    implicit def toPlayJsonFormat[A](implicit jsonSchema: JsonSchema[A]): Format[A] =
+      Format(jsonSchema.reads, jsonSchema.writes)
+  }
+
+  type Record[A] = JsonSchema[A]
+
+  def emptyRecord: Record[Unit] =
+    JsonSchema(
+      new Reads[Unit] {
+        override def reads(json: JsValue): JsResult[Unit] = json match {
+          case JsObject(_) => JsSuccess(())
+          case _ => JsError("expected JSON object, but found: " + json)
+        }
+      },
+      new Writes[Unit] {
+        override def writes(o: Unit): JsValue = Json.obj()
+      }
+    )
+
+  def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A] =
+    JsonSchema(
+      (__ \ name).read(tpe.reads),
+      (__ \ name).write(tpe.writes)
+    )
+
+  def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]] =
+    JsonSchema(
+      (__ \ name).readNullable(tpe.reads),
+      (__ \ name).writeNullable(tpe.writes)
+    )
+
+  implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)
+
+  implicit def intJsonSchema: JsonSchema[Int] = JsonSchema(implicitly, implicitly)
+
+  implicit def longJsonSchema: JsonSchema[Long] = JsonSchema(implicitly, implicitly)
+
+  implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal] = JsonSchema(implicitly, implicitly)
+
+  implicit def doubleJsonSchema: JsonSchema[Double] = JsonSchema(implicitly, implicitly)
+
+  implicit def booleanJsonSchema: JsonSchema[Boolean] = JsonSchema(implicitly, implicitly)
+
+  implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit jsonSchema: JsonSchema[A], cbf: CanBuildFrom[_, A, C[A]]): JsonSchema[C[A]] =
+    JsonSchema(
+      new Reads[C[A]] {
+        override def reads(json: JsValue): JsResult[C[A]] = json match {
+          case JsArray(values) =>
+            val builder = cbf()
+            builder.sizeHint(values)
+
+            Try {
+              values.foldLeft(builder) { case (acc, value) =>
+                acc += value.as[A](jsonSchema.reads)
+              }
+            }.transform(
+              builder => Try(JsSuccess(builder.result())),
+              error => Try(JsError(error.getMessage))
+            ).get
+          case other => JsError("expected JsArray, but was: " + other)
+        }
+      },
+      Writes.traversableWrites(jsonSchema.writes)
+    )
+
+  def zipRecords[A, B](recordA: Record[A], recordB: Record[B]): Record[(A, B)] = {
+    val reads = {
+      import play.api.libs.functional.syntax._
+      (recordA.reads and recordB.reads).tupled
+    }
+    val writes = new Writes[(A, B)] {
+      override def writes(o: (A, B)): JsValue = o match {
+        case (a, b) => recordA.writes.writes(a).asInstanceOf[JsObject] deepMerge recordB.writes.writes(b).asInstanceOf[JsObject]
+      }
+    }
+    JsonSchema(reads, writes)
+  }
+
+  def invmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] = invmapJsonSchema(record, f, g)
+
+  def invmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B] =
+    JsonSchema(
+      new Reads[B] {
+        override def reads(json: JsValue): JsResult[B] = jsonSchema.reads.reads(json).map(f)
+      },
+      new Writes[B] {
+        override def writes(b: B): JsValue = jsonSchema.writes.writes(g(b))
+      }
+    )
+
+  trait Tagged[A] extends Record[A] {
+    def tagAndJson(a: A): (String, JsValue)
+    def findReads(tagName: String): Option[Reads[A]]
+
+    def reads: Reads[A] = new Reads[A] {
+      override def reads(json: JsValue): JsResult[A] = json match {
+        case JsObject(kvs) => if (kvs.size == 1) {
+          val (key, value) = kvs.toList.head
+          findReads(key) match {
+            case Some(reads) => reads.reads(value)
+            case None => JsError(s"no Reads for tag '$key': $json")
+          }
+        } else JsError(s"expected exactly one tag, but found ${kvs.size}: $json")
+        case _ => JsError(s"expected JSON object for tagged type, but found: $json")
+      }
+    }
+
+    def writes: Writes[A] = new Writes[A] {
+      override def writes(a: A): JsValue = {
+        val (tag, json) = tagAndJson(a)
+        Json.obj(tag -> json)
+      }
+    }
+  }
+
+  def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A] = new Tagged[A] {
+    def tagAndJson(a: A): (String, JsValue) = (tag, recordA.writes.writes(a))
+    def findReads(tagName: String): Option[Reads[A]] = if (tag == tagName) Some(recordA.reads) else None
+  }
+
+  def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]] = new Tagged[Either[A, B]] {
+    def tagAndJson(aOrB: Either[A, B]): (String, JsValue) = aOrB match {
+      case Left(a) => taggedA.tagAndJson(a)
+      case Right(b) => taggedB.tagAndJson(b)
+    }
+
+    def findReads(tagName: String): Option[Reads[Either[A, B]]] =
+      taggedA.findReads(tagName).map(_.map[Either[A, B]](Left(_))) orElse
+        taggedB.findReads(tagName).map(_.map[Either[A, B]](Right(_)))
+  }
+
+  def invmapTagged[A, B](tagged: Tagged[A], f: A => B, g: B => A): Tagged[B] = new Tagged[B] {
+    def tagAndJson(b: B): (String, JsValue) = tagged.tagAndJson(g(b))
+    def findReads(tag: String): Option[Reads[B]] = tagged.findReads(tag).map(_.map(f))
+  }
+
+}

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -1,0 +1,326 @@
+package endpoints.playjson
+
+import org.scalatest.FreeSpec
+import play.api.libs.json._
+
+class JsonSchemasTest extends FreeSpec {
+
+  object JsonSchemasCodec
+    extends endpoints.algebra.JsonSchemasTest
+      with endpoints.playjson.JsonSchemas
+
+  import JsonSchemasCodec.{JsonSchemaOps => _, _} // importing JsonSchemaOps would create ambiguity with RecordOps
+
+  "empty record" in {
+    testRoundtrip(
+      emptyRecord,
+      Json.obj(),
+      ()
+    )
+  }
+
+  "invalid empty record" in {
+    val jsonSchema = emptyRecord
+    val json = Json.arr()
+
+    assertError(jsonSchema, json, "expected JSON object, but found: []")
+  }
+
+  "single record" in {
+    testRoundtrip(
+      field[String]("field1"),
+      Json.obj("field1" -> "string1"),
+      "string1"
+    )
+  }
+
+  "ignore record" in {
+    val jsonSchema = field[Int]("relevant")
+    val input = Json.obj("relevant" -> JsNumber(1), "irrelevant" -> JsNumber(0))
+
+    val deserialized = jsonSchema.reads.reads(input).get
+    assert(deserialized == 1)
+
+    val output = jsonSchema.writes.writes(deserialized)
+    assert(output == Json.obj("relevant" -> JsNumber(1)))
+  }
+
+  "invalid json" in {
+    val jsonSchema = field[Int]("relevant")
+    val json = Json.obj("irrelevant" -> JsNumber(0))
+
+    assertError(jsonSchema, json, "error.path.missing")
+  }
+
+  "missing optional field" in {
+    testRoundtrip(
+      optField[Int]("relevant"),
+      Json.obj(),
+      None
+    )
+  }
+
+  "optional field" in {
+    testRoundtrip(
+      optField[Int]("relevant"),
+      Json.obj("relevant" -> JsNumber(123)),
+      Some(123)
+    )
+  }
+
+  "optional field null" in {
+    val jsonSchema = optField[Int]("relevant")
+    val input = Json.obj("relevant" -> JsNull)
+
+    val deserialized = jsonSchema.reads.reads(input).get
+    assert(deserialized == None)
+
+    val output = jsonSchema.writes.writes(deserialized)
+    assert(output == Json.obj())
+  }
+
+  "nested optional field" in {
+    testRoundtrip(
+      optField[Int]("level1")(field[Int]("level2")),
+      Json.obj("level1" -> Json.obj("level2" -> JsNumber(123))),
+      Some(123)
+    )
+  }
+
+  "missing nested optional field" in {
+    testRoundtrip(
+      optField[Int]("level1")(field[Int]("level2")),
+      Json.obj(),
+      None
+    )
+  }
+
+  "nested record" in {
+    testRoundtrip(
+      field("level1")(field[Int]("level2")),
+      Json.obj("level1" -> Json.obj("level2" -> JsNumber(123))),
+      123
+    )
+  }
+
+  "two records" in {
+    testRoundtrip(
+      field[Long]("foo") zip field[Boolean]("bar"),
+      Json.obj("foo" -> JsNumber(123L), "bar" -> JsBoolean(true)),
+      (123L, true)
+    )
+  }
+
+  "three records" in {
+    testRoundtrip(
+      field[BigDecimal]("foo") zip field[Boolean]("bar") zip field[Double]("pi"),
+      Json.obj("foo" -> JsNumber(BigDecimal(123.456)), "bar" -> JsBoolean(true), "pi" -> JsNumber(3.1416)),
+      ((BigDecimal(123.456), true), 3.1416)
+    )
+  }
+
+  "case class with one field" in {
+    case class IntClass(i: Int)
+    val jsonSchemaTestClass = field[Int]("i").invmap[IntClass](i => IntClass(i))(_.i)
+
+    testRoundtrip(
+      jsonSchemaTestClass,
+      Json.obj("i" -> JsNumber(1)),
+      IntClass(1)
+    )
+  }
+
+  "case class with two fields" in {
+    case class TestClass(i: Int, s: String)
+    val jsonSchemaTestClass = (field[Int]("i") zip field[String]("s"))
+      .invmap[TestClass](tuple => TestClass(tuple._1, tuple._2))(test => (test.i, test.s))
+
+    testRoundtrip(
+      jsonSchemaTestClass,
+      Json.obj("i" -> JsNumber(1), "s" -> JsString("one")),
+      TestClass(1, "one")
+    )
+  }
+
+  "case class" in {
+    testRoundtrip(
+      User.schema,
+      Json.obj("age" -> JsNumber(42), "name" -> JsString("John")),
+      User("John", 42)
+    )
+  }
+
+  "array" in {
+    testRoundtrip(
+      field[List[String]]("names"),
+      Json.obj("names" -> Json.arr(JsString("Ernie"), JsString("Bert"))),
+      List("Ernie", "Bert")
+    )
+  }
+
+  "long array" in {
+    val numbers: Seq[Int] = 0 until 10000
+    val jsNumbers: Seq[JsNumber] = numbers.map(JsNumber(_))
+
+    testRoundtrip(
+      field[Seq[Int]]("numbers"),
+      Json.obj("numbers" -> JsArray(jsNumbers)),
+      numbers
+    )
+  }
+
+  "empty array" in {
+    testRoundtrip(
+      field[Seq[Int]]("coords"),
+      Json.obj("coords" -> Json.arr()),
+      Seq()
+    )
+  }
+
+  "heterogeneous array" in {
+    val jsonSchema = field[String]("relevant")
+    val input = Json.obj("relevant" -> Json.arr(JsString("hi"), JsBoolean(false)))
+
+    assertError(jsonSchema, input, "error.expected.jsstring")
+  }
+
+  "tagged single record" in {
+    testRoundtrip(
+      field[Double]("x").tagged("Rectangle"),
+      Json.obj("Rectangle" -> Json.obj("x" -> JsNumber(1.5))),
+      1.5
+    )
+  }
+
+  "two tagged choices" in {
+    val schema = field[Int]("i").tagged("I") orElse
+      field[String]("s").tagged("S")
+
+    testRoundtrip(
+      schema,
+      Json.obj("I" -> Json.obj("i" -> JsNumber(2))),
+      Left(2)
+    )
+    testRoundtrip(
+      schema,
+      Json.obj("S" -> Json.obj("s" -> JsString("string"))),
+      Right("string")
+    )
+  }
+
+  "three tagged choices" in {
+    val schema = field[Int]("i").tagged("I") orElse
+      field[String]("s").tagged("S") orElse
+      field[Boolean]("b").tagged("B")
+
+    testRoundtrip(
+      schema,
+      Json.obj("I" -> Json.obj("i" -> JsNumber(2))),
+      Left(Left(2))
+    )
+    testRoundtrip(
+      schema,
+      Json.obj("B" -> Json.obj("b" -> JsBoolean(true))),
+      Right(true)
+    )
+  }
+
+  "tagged and zipped" in {
+    val schema = field[Double]("r").tagged("Circle") orElse (field[Int]("w") zip field[Int]("h")).tagged("Rect")
+
+    testRoundtrip(
+      schema,
+      Json.obj("Circle" -> Json.obj("r" -> JsNumber(2.0))),
+      Left(2.0)
+    )
+    testRoundtrip(
+      schema,
+      Json.obj("Rect" -> Json.obj("w" -> JsNumber(3), "h" -> JsNumber(4))),
+      Right((3, 4))
+    )
+  }
+
+  "sealed trait" in {
+    sealed trait Shape
+    case class Circle(r: Double) extends Shape
+    case class Rect(w: Int, h: Int) extends Shape
+
+    val schema = field[Double]("r").tagged("Circle").invmap(Circle)(_.r) orElse
+      (field[Int]("w") zip field[Int]("h")).tagged("Rect").invmap(Rect.tupled)(rect => (rect.w, rect.h))
+
+    testRoundtrip(
+      schema,
+      Json.obj("Circle" -> Json.obj("r" -> JsNumber(2.0))),
+      Left(Circle(2.0))
+    )
+    testRoundtrip(
+      schema,
+      Json.obj("Rect" -> Json.obj("w" -> JsNumber(3), "h" -> JsNumber(4))),
+      Right(Rect(3, 4))
+    )
+  }
+
+  "sealed trait with invmap and tagged swapped" in {
+    sealed trait Shape
+    case class Circle(r: Double) extends Shape
+    case class Rect(w: Int, h: Int) extends Shape
+
+    val schema = field[Double]("r").invmap(Circle)(_.r).tagged("Circle") orElse
+      (field[Int]("w") zip field[Int]("h")).invmap(Rect.tupled)(rect => (rect.w, rect.h)).tagged("Rect")
+
+    testRoundtrip(
+      schema,
+      Json.obj("Circle" -> Json.obj("r" -> JsNumber(2.0))),
+      Left(Circle(2.0))
+    )
+    testRoundtrip(
+      schema,
+      Json.obj("Rect" -> Json.obj("w" -> JsNumber(3), "h" -> JsNumber(4))),
+      Right(Rect(3, 4))
+    )
+  }
+
+  "sealed trait errors" in {
+    sealed trait Shape
+    case class Circle(r: Double) extends Shape
+    case class Rect(w: Int, h: Int) extends Shape
+
+    val schema = field[Double]("r").invmap(Circle)(_.r).tagged("Circle") orElse
+      (field[Int]("w") zip field[Int]("h")).invmap(Rect.tupled)(rect => (rect.w, rect.h)).tagged("Rect")
+
+    assertError(
+      schema,
+      Json.arr(),
+      "expected JSON object for tagged type, but found: []"
+    )
+    assertError(
+      schema,
+      Json.obj("Circle" -> Json.obj(), "Rect" -> Json.obj()),
+      """expected exactly one tag, but found 2: {"Circle":{},"Rect":{}}"""
+    )
+    assertError(
+      schema,
+      Json.obj("Square" -> Json.obj()),
+      """no Reads for tag 'Square': {"Square":{}}"""
+    )
+  }
+
+  private def testRoundtrip[A](jsonSchema: JsonSchema[A], json: JsValue, expected: A) = {
+    val result = jsonSchema.reads.reads(json)
+    assert(result.isSuccess, result)
+    val deserialized: A = result.get
+    assert(deserialized == expected)
+
+    val serialized: JsValue = jsonSchema.writes.writes(deserialized)
+    assert(serialized == json)
+  }
+
+  private def assertError[A](jsonSchema: JsonSchema[A], json: JsValue, expectedError: String) = {
+    val jsResult = jsonSchema.reads.reads(json)
+    assert(jsResult.isError)
+
+    val errorMessages: Seq[String] = jsResult.asEither.left.get.flatMap(_._2).flatMap(_.messages) // ignoring JsPath
+    assert(errorMessages.head == expectedError)
+  }
+
+}

--- a/play/build.sbt
+++ b/play/build.sbt
@@ -4,6 +4,7 @@ val `algebra-jvm` = LocalProject("algebraJVM")
 val `algebra-circe-jvm` = LocalProject("algebra-circeJVM")
 val `testsuite-jvm` = LocalProject("testsuiteJVM")
 val `json-schema-circe-jvm` = LocalProject("json-schema-circeJVM")
+val `json-schema-playjson-jvm` = LocalProject("json-schema-playjsonJVM")
 
 val `play-server` =
   project.in(file("server"))
@@ -25,6 +26,15 @@ val `play-server-circe` =
       libraryDependencies += "io.circe" %% "circe-parser" % circeVersion
     )
     .dependsOn(`play-server`, `algebra-circe-jvm`, `json-schema-circe-jvm`)
+
+val `play-server-playjson` =
+  project.in(file("server-playjson"))
+    .settings(publishSettings ++ `scala 2.11 to 2.12`: _*)
+    .settings(
+      name := "endpoints-play-server-playjson",
+      libraryDependencies += "com.typesafe.play" %% "play-json" % playjsonVersion
+    )
+    .dependsOn(`play-server`, `json-schema-playjson-jvm`)
 
 val `play-client` =
   project.in(file("client"))

--- a/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
+++ b/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
@@ -1,0 +1,26 @@
+package endpoints.play.server.playjson
+
+import endpoints.algebra
+import endpoints.algebra.Documentation
+import endpoints.play.server.Endpoints
+import play.api.libs.json.Json
+import play.api.mvc.Results
+
+/**
+  * Interpreter for [[algebra.JsonSchemaEntities]] that uses Play JSON [[play.api.libs.json.Reads]] to decode
+  * JSON entities in HTTP requests, and [[play.api.libs.json.Writes]] to build JSON entities in HTTP responses.
+  */
+trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.playjson.JsonSchemas {
+
+  import playComponents.executionContext
+
+  def jsonRequest[A: JsonSchema](docs: Documentation): RequestEntity[A] =
+    playComponents.playBodyParsers.tolerantText.validate { text =>
+      Json.parse(text).validate(implicitly[JsonSchema[A]].reads).asEither
+        .left.map(ignoredError => Results.BadRequest)
+    }
+
+  def jsonResponse[A: JsonSchema](docs: Documentation): Response[A] =
+    a => Results.Ok(implicitly[JsonSchema[A]].writes.writes(a))
+
+}

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -73,6 +73,7 @@ object EndpointsSettings {
   // --- Common dependencies
 
   val circeVersion = "0.9.3"
+  val playjsonVersion = "2.6.9"
   val playVersion = "2.6.15"
 
   val scalaTestVersion = "3.0.4"


### PR DESCRIPTION
Open questions:

1. Which parts of the documentation and/or examples should be adapted?
2. I did not implement `JsonEntities` (only `JsonSchemaEntities`). Right now it seems that the `documented` example relies on Circe to render the OpenAPI documentation. Some users might want to avoid having two JSON libraries. Not sure how to implement `JsonEntities` though.
3. Play JSON does not seem to make a difference between non-existing JSON fields and fields with a `null` value. Is this behavior desired? The algebra does not support mapping a mandatory (but nullable) field to `Option`, for example.
4. The difference between `JsonSchema` and `type Record[A] <: JsonSchema[A]` is not clear to me. A code comment suggests that records are case classes, but (as a counter-example) the Record type is used for `zip` which is independent of case classes and just maps to tuples. Also, Circe just aliases Records to JsonSchema. I did the same.