### PR TITLE
[WIP] Add documentation support for generic schema derivation

### DIFF
--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
@@ -79,7 +79,7 @@ trait JsonSchemas extends algebra.JsonSchemas {
     implicit def consRecord[L <: Symbol, H, T <: HList](implicit
       labelHead: Witness.Aux[L],
       jsonSchemaHead: JsonSchema[H],
-      jsonSchemaTail: GenericRecord[T],
+      jsonSchemaTail: GenericRecord[T]
     ): GenericRecord[FieldType[L, H] :: T] =
       new GenericRecord[FieldType[L, H] :: T] {
         def jsonSchema(docs: List[Option[documentation]]): Record[FieldType[L, H] :: T] =
@@ -90,7 +90,7 @@ trait JsonSchemas extends algebra.JsonSchemas {
     implicit def consOptRecord[L <: Symbol, H, T <: HList](implicit
       labelHead: Witness.Aux[L],
       jsonSchemaHead: JsonSchema[H],
-      jsonSchemaTail: GenericRecord[T],
+      jsonSchemaTail: GenericRecord[T]
     ): GenericRecord[FieldType[L, Option[H]] :: T] =
       new GenericRecord[FieldType[L, Option[H]] :: T] {
         def jsonSchema(docs: List[Option[documentation]]): Record[FieldType[L, Option[H]] :: T] =

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/documentation.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/documentation.scala
@@ -1,0 +1,4 @@
+package endpoints.generic
+
+case class documentation(text: String) extends scala.annotation.Annotation
+

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -38,7 +38,7 @@ class JsonSchemasTest extends FreeSpec {
         s"'$name'!($schema)".asInstanceOf[S[A]]
 
       def emptyRecord: String =
-        "$"
+        "%"
 
       def field[A](name: String, docs: Option[String])(implicit tpe: String): String =
         s"$name:$tpe"
@@ -79,13 +79,23 @@ class JsonSchemasTest extends FreeSpec {
                                             ): String = s"[$jsonSchema]"
   }
 
+  val ns = "endpoints.generic.JsonSchemasTest.GenericSchemas"
+
   "case class" in {
-    val expectedSchema = "'endpoints.generic.JsonSchemasTest.GenericSchemas.Foo'!('endpoints.generic.JsonSchemasTest.GenericSchemas.Foo'!(bar:string,baz:integer,qux:boolean?,$))"
+    val expectedSchema = s"'$ns.Foo'!('$ns.Foo'!(bar:string,baz:integer,qux:boolean?,%))"
     assert(FakeAlgebraJsonSchemas.Foo.schema == expectedSchema)
   }
 
   "sealed trait" in {
-    val expectedSchema = "'endpoints.generic.JsonSchemasTest.GenericSchemas.Quux'!('endpoints.generic.JsonSchemasTest.GenericSchemas.Quux'!('endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxA'!(ss:[string],$)@QuuxA|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxB'!(i:integer,$)@QuuxB|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxC'!(b:boolean,$)@QuuxC|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxD'!($)@QuuxD|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxE'!($)@QuuxE))"
+    val expectedSchema = s"'$ns.Quux'!('$ns.Quux'!(${
+      List(
+        s"'$ns.QuuxA'!(ss:[string],%)@QuuxA",
+        s"'$ns.QuuxB'!(i:integer,%)@QuuxB",
+        s"'$ns.QuuxC'!(b:boolean,%)@QuuxC",
+        s"'$ns.QuuxD'!(%)@QuuxD",
+        s"'$ns.QuuxE'!(%)@QuuxE"
+      ).mkString("|")
+    }))"
     assert(FakeAlgebraJsonSchemas.Quux.schema == expectedSchema)
   }
 

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -117,7 +117,7 @@ class JsonSchemasTest extends FreeSpec {
       List(
         s"'$ns.DocA'!(i:integer{fieldDocI},%)@DocA",
         s"'$ns.DocB'!(a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%)@DocB",
-        s"'$ns.DocC'!(%)@DocC",
+        s"'$ns.DocC'!(%)@DocC"
       ).mkString("|")
     }))"
     println(expectedSchema)


### PR DESCRIPTION
This commits allows to add field documentations using annotation.

example:
```scala
case class User(
  @documentation("The name of the user") name: String,
  @documentation("The age of the user") age: Int
)
object User {
  implicit val schema: JsonSchema[User] = genericJsonSchema[User]
}
```

It doesn't support coproducts yet. Maybe we can add `docs` parameter to  `JsonSchema#taggedField`?