### PR TITLE
Rewrite the “Overview” documentation page

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -119,6 +119,11 @@ val `example-overview-play-client` =
     .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
     .dependsOn(`example-overview-endpoints-jvm`, `play-client`)
 
+val `example-overview-documentation` =
+  project.in(file("examples/overview/documentation"))
+    .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
+    .dependsOn(`example-overview-endpoints-jvm`, `openapi-jvm`)
+
 // Basic example
 val `example-basic-shared` = {
   val assetsDirectory = (base: File) => base / "src" / "main" / "assets"

--- a/documentation/examples/overview/documentation/src/main/scala/overview/CounterDocumentation.scala
+++ b/documentation/examples/overview/documentation/src/main/scala/overview/CounterDocumentation.scala
@@ -1,0 +1,28 @@
+package overview
+
+//#relevant-code
+import endpoints.openapi
+import endpoints.openapi.model.{Info, OpenApi}
+
+/**
+  * Generates OpenAPI documentation for the endpoints described in the `CounterEndpoints` trait.
+  */
+object CounterDocumentation
+  extends CounterEndpoints
+    with openapi.Endpoints
+    with openapi.JsonEntities {
+
+  val api: OpenApi =
+    openApi(
+      Info(title = "API to manipulate a counter", version = "1.0.0")
+    )(currentValue, increment)
+
+}
+//#relevant-code
+
+object UsageExample {
+  //#export
+  import io.circe.syntax._
+  println(CounterDocumentation.api.asJson)
+  //#export
+}

--- a/documentation/examples/overview/server/src/main/scala/overview/CounterServer.scala
+++ b/documentation/examples/overview/server/src/main/scala/overview/CounterServer.scala
@@ -5,9 +5,11 @@ import endpoints.play.server
 import endpoints.play.server.PlayComponents
 
 import scala.concurrent.stm.Ref
+import play.api.routing.Router
 
 /**
-  * Defines a Play router (and reverse router) for the endpoints described in the `CounterAlg` trait.
+  * Defines a Play router (and reverse router) for the endpoints described
+  * in the `CounterEndpoints` trait.
   */
 class CounterServer(protected val playComponents: PlayComponents)
   extends CounterEndpoints
@@ -17,7 +19,7 @@ class CounterServer(protected val playComponents: PlayComponents)
   /** Simple implementation of an in-memory counter */
   val counter = Ref(0)
 
-  val routes = routesFromEndpoints(
+  val routes: Router.Routes = routesFromEndpoints(
 
     /** Implements the `currentValue` endpoint */
     currentValue.implementedBy(_ => Counter(counter.single.get)),

--- a/documentation/manual/src/ornate.conf
+++ b/documentation/manual/src/ornate.conf
@@ -1,8 +1,8 @@
 global {
   toc = [
     { title = "Introduction", url = "index.md" }
-    overview.md
     use-cases.md
+    overview.md
     installation.md
     tutorial.md
     tutorial-openapi.md

--- a/documentation/manual/src/ornate/overview.md
+++ b/documentation/manual/src/ornate/overview.md
@@ -1,43 +1,33 @@
 # Overview
 
-Typically, a project is broken down into several sub-projects:
+The central idea of the *endpoints* library is that you first describe your communication endpoints
+and then the library provides you:
 
-~~~ mermaid
-graph BT
-  endpoints
-  server -.-> endpoints
-  client -.-> endpoints
-~~~
-
-The `endpoints` sub-project contains the *description* of the communication
-protocol. The `server` sub-project *implements* this communication protocol.
-The `client` sub-project *uses* the protocol to communicate with the `server`.
+- a server implementation decoding requests and building responses,
+- a client implementation building requests and decoding responses,
+- a machine readable documentation (OpenAPI document).
 
 ## Description of the HTTP endpoints
 
-Let’s define a first artifact, cross-compiled for Scala.js, and containing a description of the
-endpoints of a web service.
+As an example, here is a `CounterEndpoints` trait describing two endpoints, one for getting a counter value and one for
+incrementing :
 
 ~~~ scala src=../../../examples/overview/endpoints/src/main/scala/overview/CounterEndpoints.scala#relevant-code
 ~~~
 
-Note that the example above uses Circe's `@JsonCodec` macro annotation, so you’ll also need to include the Macro Paradise compiler plugin in your `build.sbt` file.
+(Note that the example above uses Circe's `@JsonCodec` macro annotation, so you’ll need to include the Macro Paradise
+compiler plugin to your [`build.sbt` file](https://github.com/julienrf/endpoints/blob/ca58dabbc544dd28464db1aa0eb4cf72f59489d0/documentation/build.sbt#L92))
 
-```
-addCompilerPlugin(
-  "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
-)
-```
+## Client implementation
 
-## JavaScript (Scala.js) client
-
-The following code, located in the `client` sub-project, defines a Scala.js
-client for the web service.
+A client implementation of the endpoints can be obtained by mixing so-called “interpreters” to the `CounterEndpoints`
+trait defined above. In this example, we get a JavaScript (Scala.js) client that uses `XMLHttpRequest` under
+the hood:
 
 ~~~ scala src=../../../examples/overview/client/src/main/scala/overview/CounterClient.scala#relevant-code
 ~~~
 
-And then, this client can be used as follows:
+And then, the `CounterClient` object can be used as follows:
 
 ~~~ scala src=../../../examples/overview/client/src/main/scala/overview/Usage.scala#current-value
 ~~~
@@ -47,25 +37,80 @@ And also:
 ~~~ scala src=../../../examples/overview/client/src/main/scala/overview/Usage.scala#increment
 ~~~
 
-## Service implementation (backed by Play framework)
+As you can see, invoking an endpoint is as easy as calling a method on the `CounterClient` object.
+The *endpoints* library then builds an HTTP request (according to the endpoint description), sends
+it to the server, and eventually decodes the HTTP response (according to the endpoint description).
 
-The following code, located in the `server` sub-project, defines the implementation of
-the web service.
+## Server implementation
+
+Similarly, a server implementation of the endpoints can be obtained by mixing the appropriate
+interpreters to the `CounterEndpoints` trait. In this example, we get a JVM server that uses
+Play framework under the hood:
 
 ~~~ scala src=../../../examples/overview/server/src/main/scala/overview/CounterServer.scala#relevant-code
 ~~~
 
-The `CounterServer.routes` value is just a `play.api.routing.Router.Routes`.
-To get an executable Web server we need to setup a “main” like the following:
+The `CounterServer.routes` value produced by the *endpoints* library is a `Routes` value directly
+usable by Play framework. To get an executable Web server we can setup a “main” like the following:
 
 ~~~ scala src=../../../examples/overview/server/src/main/scala/overview/Main.scala#relevant-code
 ~~~
 
-## What else?
+The routes implementations provided by *endpoints* decode the incoming HTTP requests, call the corresponding logic
+(here, incrementing the counter or getting its current value), and build the HTTP responses.
 
-You can also get a Scala/JVM client (which uses `play-ws` under the hood) as follows:
+## Documentation generation
 
-~~~ scala src=../../../examples/overview/play-client/src/main/scala/overview/CounterClient.scala#relevant-code
+We conclude this overview by showing how to generate documentation for the endpoints, again by mixing the appropriate
+interpreters:
+
+~~~ scala src=../../../examples/overview/documentation/src/main/scala/overview/CounterDocumentation.scala#relevant-code
 ~~~
 
-Thus, you can distribute a (fully working) JVM client, which is independent of your implementation.
+This code defines a `CounterDocumentation` object with an `api` member containing an OpenAPI object documenting
+the `currentValue` and `increment` endpoints.
+
+We can then render the documentation, for instance in JSON:
+
+~~~ scala src=../../../examples/overview/documentation/src/main/scala/overview/CounterDocumentation.scala#export
+~~~
+
+This prints the following OpenAPI document:
+
+~~~ javascript
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "title" : "API to manipulate a counter",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/increment" : {
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : ""
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {}
+          }
+        }
+      }
+    },
+    "/current-value" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {}
+            }
+          }
+        }
+      }
+    }
+  }
+}
+~~~ 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -32,59 +32,6 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
       Fixtures.openApi.asJson.spaces2 shouldBe
         """{
-          |  "openapi" : "3.0.0",
-          |  "info" : {
-          |    "title" : "TestFixturesOpenApi",
-          |    "version" : "0.0.0"
-          |  },
-          |  "paths" : {
-          |    "/books" : {
-          |      "get" : {
-          |        "parameters" : [
-          |        ],
-          |        "responses" : {
-          |          "200" : {
-          |            "description" : "Books list",
-          |            "content" : {
-          |              "application/json" : {
-          |                "schema" : {
-          |                  "type" : "array",
-          |                  "items" : {
-          |                    "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
-          |                  }
-          |                }
-          |              }
-          |            }
-          |          }
-          |        },
-          |        "tags" : [
-          |          "Books"
-          |        ]
-          |      },
-          |      "post" : {
-          |        "parameters" : [
-          |        ],
-          |        "responses" : {
-          |          "200" : {
-          |            "description" : ""
-          |          }
-          |        },
-          |        "requestBody" : {
-          |          "description" : "Books list",
-          |          "content" : {
-          |            "application/json" : {
-          |              "schema" : {
-          |                "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
-          |              }
-          |            }
-          |          }
-          |        },
-          |        "tags" : [
-          |          "Books"
-          |        ]
-          |      }
-          |    }
-          |  },
           |  "components" : {
           |    "schemas" : {
           |      "endpoints.openapi.ReferencedSchemaTest.Book" : {
@@ -112,6 +59,55 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |            }
           |          }
           |        }
+          |      }
+          |    }
+          |  },
+          |  "openapi" : "3.0.0",
+          |  "info" : {
+          |    "title" : "TestFixturesOpenApi",
+          |    "version" : "0.0.0"
+          |  },
+          |  "paths" : {
+          |    "/books" : {
+          |      "get" : {
+          |        "responses" : {
+          |          "200" : {
+          |            "description" : "Books list",
+          |            "content" : {
+          |              "application/json" : {
+          |                "schema" : {
+          |                  "type" : "array",
+          |                  "items" : {
+          |                    "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
+          |                  }
+          |                }
+          |              }
+          |            }
+          |          }
+          |        },
+          |        "tags" : [
+          |          "Books"
+          |        ]
+          |      },
+          |      "post" : {
+          |        "responses" : {
+          |          "200" : {
+          |            "description" : ""
+          |          }
+          |        },
+          |        "requestBody" : {
+          |          "description" : "Books list",
+          |          "content" : {
+          |            "application/json" : {
+          |              "schema" : {
+          |                "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
+          |              }
+          |            }
+          |          }
+          |        },
+          |        "tags" : [
+          |          "Books"
+          |        ]
           |      }
           |    }
           |  }


### PR DESCRIPTION
I think the previous version was going a little bit too much into irrelevant technical details (like how to configure the build). Also, we were not demonstrating OpenAPI documentation generation.

I’ve also inverted the order of the “Use cases” and “Overview” pages: if readers follow the left menu, I think it makes more sense to start with the “Use case” page, which gives a really high-level view of what *endpoints* does, and then go to the “Overview” page, which shows more precisely what the programming experience look like.

I think I should eventually give more pointers on how to go further on some specific things (like adding more descriptions to the generated documentation, using another HTTP library than Play, implementing a custom part in an endpoint encoding/decoding), but I will first overhaul more parts of the documentation (in a separate PR).