### PR TITLE
Support for OAS3 discriminator

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -24,18 +24,40 @@ trait JsonSchemas
 
     implicit def toCirceCodec[A](implicit jsonSchema: JsonSchema[A]): CirceCodec[A] =
       CirceCodec.fromEncoderAndDecoder(jsonSchema.encoder, jsonSchema.decoder)
+
+    implicit def toCirceEncoder[A](implicit jsonSchema: JsonSchema[A]): Encoder[A] =
+      jsonSchema.encoder
+
+    implicit def toCirceDecoder[A](implicit jsonSchema: JsonSchema[A]): Decoder[A] =
+      jsonSchema.decoder
   }
 
-  type Record[A] = JsonSchema[A]
+  trait Record[A] extends JsonSchema[A] {
+    override def encoder: ObjectEncoder[A]
+  }
+
+  object Record {
+    def apply[A](_encoder: ObjectEncoder[A], _decoder: Decoder[A]): Record[A] =
+      new Record[A] { def encoder = _encoder; def decoder = _decoder }
+
+    implicit def toCirceCodec[A](implicit record: Record[A]): CirceCodec[A] =
+      CirceCodec.fromEncoderAndDecoder(record.encoder, record.decoder)
+
+    implicit def toCirceObjectEncoder[A](implicit record: Record[A]): ObjectEncoder[A] =
+      record.encoder
+
+    implicit def toCirceDecoder[A](implicit record: Record[A]): Decoder[A] =
+      record.decoder
+  }
 
   trait Tagged[A] extends Record[A] {
     def discriminator: String = defaultDiscriminatorName
-    def taggedEncoded(a: A): (String, Json)
+    def taggedEncoded(a: A): (String, JsonObject)
     def taggedDecoder(tag: String): Option[Decoder[A]]
-    def encoder: Encoder[A] =
-      Encoder.instance { a =>
+    def encoder: ObjectEncoder[A] =
+      ObjectEncoder.instance { a =>
         val (tag, json) = taggedEncoded(a)
-        json.deepMerge(Json.obj(discriminator -> Json.fromString(tag)))
+        (discriminator -> Json.fromString(tag)) +: json
       }
     def decoder: Decoder[A] =
       Decoder.instance { cursor =>
@@ -56,34 +78,34 @@ trait JsonSchemas
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
 
   def emptyRecord: Record[Unit] =
-    JsonSchema(
+    Record(
       io.circe.Encoder.encodeUnit,
       io.circe.Decoder.decodeJsonObject.map(_ => ())
     )
 
   def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A] =
-    JsonSchema(
-      io.circe.Encoder.instance[A](a => Json.obj(name -> tpe.encoder.apply(a))),
+    Record(
+      io.circe.ObjectEncoder.instance[A](a => JsonObject.singleton(name, tpe.encoder.apply(a))),
       io.circe.Decoder.instance[A](cursor => tpe.decoder.tryDecode(cursor.downField(name)))
     )
 
   // FIXME Check that this is the correct way to model optional fields with circe
   def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]] =
-    JsonSchema(
-      io.circe.Encoder.instance[Option[A]](a => Json.obj(name -> io.circe.Encoder.encodeOption(tpe.encoder).apply(a))),
+    Record(
+      io.circe.ObjectEncoder.instance[Option[A]](a => JsonObject.singleton(name, io.circe.Encoder.encodeOption(tpe.encoder).apply(a))),
       io.circe.Decoder.instance[Option[A]](cursor => io.circe.Decoder.decodeOption(tpe.decoder).tryDecode(cursor.downField(name)))
     )
 
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A] =
     new Tagged[A] {
-      def taggedEncoded(a: A) = (tag, recordA.encoder.apply(a))
+      def taggedEncoded(a: A) = (tag, recordA.encoder.encodeObject(a))
       def taggedDecoder(tagName: String) = if (tag == tagName) Some(recordA.decoder) else None
     }
 
   def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
     new Tagged[A] {
       override def discriminator: String = discriminatorName
-      def taggedEncoded(a: A): (String, Json) = tagged.taggedEncoded(a)
+      def taggedEncoded(a: A): (String, JsonObject) = tagged.taggedEncoded(a)
       def taggedDecoder(tag: String): Option[Decoder[A]] = tagged.taggedDecoder(tag)
     }
 
@@ -100,20 +122,21 @@ trait JsonSchemas
 
   def zipRecords[A, B](recordA: Record[A], recordB: Record[B]): Record[(A, B)] = {
     val encoder =
-      io.circe.Encoder.instance[(A, B)] { case (a, b) =>
-        recordA.encoder.apply(a).deepMerge(recordB.encoder.apply(b))
+      io.circe.ObjectEncoder.instance[(A, B)] { case (a, b) =>
+        recordA.encoder.apply(a).deepMerge(recordB.encoder.apply(b)).asObject.get
       }
     val decoder = new io.circe.Decoder[(A, B)] {
       def apply(c: HCursor) = recordA.decoder.product(recordB.decoder).apply(c)
     }
-    JsonSchema(encoder, decoder)
+    Record(encoder, decoder)
   }
 
-  def invmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] = invmapJsonSchema(record, f, g)
+  def invmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] =
+    Record(record.encoder.contramapObject(g), record.decoder.map(f))
 
   def invmapTagged[A, B](tagged: Tagged[A], f: A => B, g: B => A): Tagged[B] =
     new Tagged[B] {
-      def taggedEncoded(b: B): (String, Json) = tagged.taggedEncoded(g(b))
+      def taggedEncoded(b: B): (String, JsonObject) = tagged.taggedEncoded(g(b))
       def taggedDecoder(tag: String): Option[Decoder[B]] = tagged.taggedDecoder(tag).map(_.map(f))
     }
 

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -1,7 +1,6 @@
 package endpoints
 package circe
 
-import endpoints.algebra.JsonSchemas
 import endpoints.algebra.circe.CirceCodec
 import io.circe._
 
@@ -30,7 +29,7 @@ trait JsonSchemas
   type Record[A] = JsonSchema[A]
 
   trait Tagged[A] extends Record[A] {
-    def discriminator: String = JsonSchemas.defaultDiscriminatorName
+    def discriminator: String = defaultDiscriminatorName
     def taggedEncoded(a: A): (String, Json)
     def taggedDecoder(tag: String): Option[Decoder[A]]
     def encoder: Encoder[A] =

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -30,17 +30,16 @@ class JsonSchemasTest extends FreeSpec {
   "sealed trait" in {
     val barJson =
       Json.obj(
-        "Bar" -> Json.obj(
-          "s" -> Json.fromString("foo")
-        )
+        "type" -> Json.fromString("Bar"),
+        "s" -> Json.fromString("foo")
       )
     val bar = Bar("foo")
     assert(Foo.schema.decoder.decodeJson(barJson).right.exists(_ == bar))
     assert(Foo.schema.encoder.apply(bar) == barJson)
 
-    assert(Foo.schema.decoder.decodeJson(Json.obj()).swap.right.exists(_ == DecodingFailure("Missing type tag field", Nil)))
-    val wrongJson = Json.obj("Unknown" -> Json.obj("s" -> Json.fromString("foo")))
-    assert(Foo.schema.decoder.decodeJson(wrongJson).swap.right.exists(_ == DecodingFailure("No decoder for type tag Unknown", Nil)))
+    assert(Foo.schema.decoder.decodeJson(Json.obj()).swap.right.exists(_ == DecodingFailure("Missing type discriminator field 'type'!", Nil)))
+    val wrongJson = Json.obj("type" -> Json.fromString("Unknown"), "s" -> Json.fromString("foo"))
+    assert(Foo.schema.decoder.decodeJson(wrongJson).swap.right.exists(_ == DecodingFailure("No decoder for discriminator 'Unknown'!", Nil)))
   }
 
 }

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -49,6 +49,9 @@ class JsonSchemasTest extends FreeSpec {
       def taggedRecord[A](recordA: String, tag: String): String =
         s"$recordA@$tag"
 
+      def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
+        s"$tagged#$discriminatorName"
+
       def choiceTagged[A, B](taggedA: String, taggedB: String): String =
         s"$taggedA|$taggedB"
 

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -1,7 +1,6 @@
 package endpoints.playjson
 
 import endpoints.algebra
-import endpoints.algebra.JsonSchemas
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -111,7 +110,7 @@ trait JsonSchemas
     JsonSchema(jsonSchema.reads.map(f), jsonSchema.writes.contramap(g))
 
   trait Tagged[A] extends Record[A] {
-    def discriminator: String = JsonSchemas.defaultDiscriminatorName
+    def discriminator: String = defaultDiscriminatorName
     def tagAndJson(a: A): (String, JsObject)
     def findReads(tagName: String): Option[Reads[A]]
 

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -133,7 +133,7 @@ trait JsonSchemas
     def writes: OWrites[A] = new OWrites[A] {
       override def writes(a: A): JsObject = {
         val (tag, json) = tagAndJson(a)
-        Json.obj(discriminator -> tag).deepMerge(json)
+        json + (discriminator -> JsString(tag))
       }
     }
   }

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -187,7 +187,7 @@ class JsonSchemasTest extends FreeSpec {
   "tagged single record" in {
     testRoundtrip(
       field[Double]("x").tagged("Rectangle"),
-      Json.obj("Rectangle" -> Json.obj("x" -> JsNumber(1.5))),
+      Json.obj("type" -> JsString("Rectangle"), "x" -> JsNumber(1.5)),
       1.5
     )
   }
@@ -198,12 +198,12 @@ class JsonSchemasTest extends FreeSpec {
 
     testRoundtrip(
       schema,
-      Json.obj("I" -> Json.obj("i" -> JsNumber(2))),
+      Json.obj("type" -> JsString("I"), "i" -> JsNumber(2)),
       Left(2)
     )
     testRoundtrip(
       schema,
-      Json.obj("S" -> Json.obj("s" -> JsString("string"))),
+      Json.obj("type" -> JsString("S"), "s" -> JsString("string")),
       Right("string")
     )
   }
@@ -215,12 +215,12 @@ class JsonSchemasTest extends FreeSpec {
 
     testRoundtrip(
       schema,
-      Json.obj("I" -> Json.obj("i" -> JsNumber(2))),
+      Json.obj("type" -> JsString("I"), "i" -> JsNumber(2)),
       Left(Left(2))
     )
     testRoundtrip(
       schema,
-      Json.obj("B" -> Json.obj("b" -> JsBoolean(true))),
+      Json.obj("type" -> JsString("B"), "b" -> JsBoolean(true)),
       Right(true)
     )
   }
@@ -230,12 +230,12 @@ class JsonSchemasTest extends FreeSpec {
 
     testRoundtrip(
       schema,
-      Json.obj("Circle" -> Json.obj("r" -> JsNumber(2.0))),
+      Json.obj("type" -> JsString("Circle"), "r" -> JsNumber(2.0)),
       Left(2.0)
     )
     testRoundtrip(
       schema,
-      Json.obj("Rect" -> Json.obj("w" -> JsNumber(3), "h" -> JsNumber(4))),
+      Json.obj("type" -> JsString("Rect"), "w" -> JsNumber(3), "h" -> JsNumber(4)),
       Right((3, 4))
     )
   }
@@ -250,12 +250,12 @@ class JsonSchemasTest extends FreeSpec {
 
     testRoundtrip(
       schema,
-      Json.obj("Circle" -> Json.obj("r" -> JsNumber(2.0))),
+      Json.obj("type" -> JsString("Circle"), "r" -> JsNumber(2.0)),
       Left(Circle(2.0))
     )
     testRoundtrip(
       schema,
-      Json.obj("Rect" -> Json.obj("w" -> JsNumber(3), "h" -> JsNumber(4))),
+      Json.obj("type" -> JsString("Rect"), "w" -> JsNumber(3), "h" -> JsNumber(4)),
       Right(Rect(3, 4))
     )
   }
@@ -270,12 +270,12 @@ class JsonSchemasTest extends FreeSpec {
 
     testRoundtrip(
       schema,
-      Json.obj("Circle" -> Json.obj("r" -> JsNumber(2.0))),
+      Json.obj("type" -> JsString("Circle"), "r" -> JsNumber(2.0)),
       Left(Circle(2.0))
     )
     testRoundtrip(
       schema,
-      Json.obj("Rect" -> Json.obj("w" -> JsNumber(3), "h" -> JsNumber(4))),
+      Json.obj("type" -> JsString("Rect"), "w" -> JsNumber(3), "h" -> JsNumber(4)),
       Right(Rect(3, 4))
     )
   }
@@ -296,12 +296,12 @@ class JsonSchemasTest extends FreeSpec {
     assertError(
       schema,
       Json.obj("Circle" -> Json.obj(), "Rect" -> Json.obj()),
-      """expected exactly one tag, but found 2: {"Circle":{},"Rect":{}}"""
+      """expected discriminator field 'type', but not found in: {"Circle":{},"Rect":{}}"""
     )
     assertError(
       schema,
-      Json.obj("Square" -> Json.obj()),
-      """no Reads for tag 'Square': {"Square":{}}"""
+      Json.obj("type" -> JsString("Square")),
+      """no Reads for tag 'Square': {"type":"Square"}"""
     )
   }
 

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -85,6 +85,9 @@ trait JsonSchemas {
   /** Tags a schema for type `A` with the given tag name */
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A]
 
+  /** Default discriminator field name for sum types */
+  def defaultDiscriminatorName: String = "type"
+
   /** Allows to specify name of discriminator field for sum type */
   def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A]
 
@@ -147,9 +150,4 @@ trait JsonSchemas {
     cbf: CanBuildFrom[_, A, C[A]]
   ): JsonSchema[C[A]]
 
-}
-
-object JsonSchemas {
-
-  val defaultDiscriminatorName: String = "type"
 }

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -82,6 +82,9 @@ trait JsonSchemas {
   /** The JSON schema of a record with a single optional field `name` of type `A` */
   def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]]
 
+  /** Name of the field that acts as discriminator for sum types (coproducts) */
+  def discriminatorName: String = "type"
+
   /** Tags a schema for type `A` with the given tag name */
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A]
 

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -85,7 +85,12 @@ trait JsonSchemas {
   /** Tags a schema for type `A` with the given tag name */
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A]
 
-  /** Default discriminator field name for sum types */
+  /** Default discriminator field name for sum types.
+    *
+    * It defaults to "type", but you can override it twofold:
+    * - by overriding this field you can change default discriminator name algebra-wide
+    * - by using `withDiscriminator` you can specify discriminator field name for specific sum type
+    * */
   def defaultDiscriminatorName: String = "type"
 
   /** Allows to specify name of discriminator field for sum type */

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -82,11 +82,11 @@ trait JsonSchemas {
   /** The JSON schema of a record with a single optional field `name` of type `A` */
   def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]]
 
-  /** Name of the field that acts as discriminator for sum types (coproducts) */
-  def discriminatorName: String = "type"
-
   /** Tags a schema for type `A` with the given tag name */
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A]
+
+  /** Allows to specify name of discriminator field for sum type */
+  def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A]
 
   /** The JSON schema of a coproduct made of the given alternative tagged records */
   def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]]
@@ -147,4 +147,9 @@ trait JsonSchemas {
     cbf: CanBuildFrom[_, A, C[A]]
   ): JsonSchema[C[A]]
 
+}
+
+object JsonSchemas {
+
+  val defaultDiscriminatorName: String = "type"
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -18,16 +18,16 @@ trait JsonSchemaEntities
   def jsonResponse[A](docs: Documentation)(implicit codec: JsonSchema[A]): List[DocumentedResponse] =
     DocumentedResponse(200, docs.getOrElse(""), Map("application/json" -> MediaType(Some(toSchema(codec))))) :: Nil
 
-  def toSchema(documentedCodec: DocumentedJsonSchema): Schema = {
+  def toSchema(documentedCodec: DocumentedJsonSchema, coprodName: Option[String] = None): Schema = {
     import DocumentedJsonSchema._
 
     documentedCodec match {
       case record @ DocumentedRecord(_, Some(name)) =>
-        Schema.Reference(name, expandRecordSchema(record))
+        Schema.Reference(name, Some(expandRecordSchema(record, coprodName)))
       case record @ DocumentedRecord(_, None) =>
         expandRecordSchema(record)
       case coprod @ DocumentedCoProd(_, Some(name)) =>
-        Schema.Reference(name, expandCoproductSchema(coprod))
+        Schema.Reference(name, Some(expandCoproductSchema(coprod)))
       case coprod @ DocumentedCoProd(_, None) =>
         expandCoproductSchema(coprod)
       case Primitive(name, format) =>
@@ -37,17 +37,26 @@ trait JsonSchemaEntities
     }
   }
 
-  private def expandRecordSchema(record: DocumentedJsonSchema.DocumentedRecord): Schema = {
+  private def expandRecordSchema(record: DocumentedJsonSchema.DocumentedRecord, coprodName: Option[String] = None): Schema = {
     val fieldsSchema = record.fields
       .map(f => Schema.Property(f.name, toSchema(f.tpe), !f.isOptional, f.documentation))
-    Schema.Object(fieldsSchema, None)
+
+    coprodName.fold[Schema] {
+      Schema.Object(fieldsSchema, None)
+    } { coproductName =>
+      val discriminatorField =
+        Schema.Property(discriminatorName, Schema.simpleString, isRequired = true, description = None)
+      Schema.AllOf(
+        schemas = List(
+          Schema.Reference(coproductName, None),
+          Schema.Object(discriminatorField :: fieldsSchema, None)
+        )
+      )
+    }
   }
 
   private def expandCoproductSchema(coprod: DocumentedJsonSchema.DocumentedCoProd): Schema = {
-    val alternativesSchemas = coprod.alternatives.map { case (tag, record) =>
-        Schema.Object(Schema.Property(tag, toSchema(record), isRequired = true, description = None) :: Nil, None)
-      }
-    Schema.OneOf(alternativesSchemas, None)
+    val alternativesSchemas = coprod.alternatives.map { case (tag, record) => tag -> toSchema(record, coprod.name) }
+    Schema.OneOf(discriminatorName, alternativesSchemas, None)
   }
-
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -13,7 +13,6 @@ import scala.language.higherKinds
 trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   import DocumentedJsonSchema._
-  import endpoints.algebra.JsonSchemas
 
   type JsonSchema[+A] = DocumentedJsonSchema
   type Record[+A] = DocumentedRecord
@@ -28,7 +27,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
     case class DocumentedCoProd(alternatives: List[(String, DocumentedRecord)],
                                 name: Option[String] = None,
-                                discriminatorName: String = JsonSchemas.defaultDiscriminatorName) extends DocumentedJsonSchema
+                                discriminatorName: String = defaultDiscriminatorName) extends DocumentedJsonSchema
 
     case class Primitive(name: String, format: Option[String] = None) extends DocumentedJsonSchema
 
@@ -92,5 +91,4 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
     jsonSchema: JsonSchema[A],
     cbf: CanBuildFrom[_, A, C[A]]
   ): JsonSchema[C[A]] = Array(jsonSchema)
-
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -13,6 +13,7 @@ import scala.language.higherKinds
 trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   import DocumentedJsonSchema._
+  import endpoints.algebra.JsonSchemas
 
   type JsonSchema[+A] = DocumentedJsonSchema
   type Record[+A] = DocumentedRecord
@@ -26,7 +27,8 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
     case class Field(name: String, tpe: DocumentedJsonSchema, isOptional: Boolean, documentation: Option[String])
 
     case class DocumentedCoProd(alternatives: List[(String, DocumentedRecord)],
-                                name: Option[String] = None) extends DocumentedJsonSchema
+                                name: Option[String] = None,
+                                discriminatorName: String = JsonSchemas.defaultDiscriminatorName) extends DocumentedJsonSchema
 
     case class Primitive(name: String, format: Option[String] = None) extends DocumentedJsonSchema
 
@@ -56,6 +58,9 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   def taggedRecord[A](recordA: DocumentedRecord, tag: String): DocumentedCoProd =
     DocumentedCoProd(List(tag -> recordA))
+
+  def withDiscriminator[A](tagged: DocumentedCoProd, discriminatorName: String): DocumentedCoProd =
+    tagged.copy(discriminatorName = discriminatorName)
 
   def choiceTagged[A, B](taggedA: DocumentedCoProd, taggedB: DocumentedCoProd): DocumentedCoProd =
     DocumentedCoProd(taggedA.alternatives ++ taggedB.alternatives)

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -24,7 +24,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
   trait Fixtures extends algebra.Endpoints with algebra.JsonSchemaEntities with generic.JsonSchemas {
 
-    implicit private val schemaStorage: JsonSchema[Storage] = genericJsonSchema[Storage]
+    implicit private val schemaStorage: JsonSchema[Storage] =
+      withDiscriminator(genericJsonSchema[Storage].asInstanceOf[Tagged[Storage]], "storageType")
 
     implicit private val schemaBook: JsonSchema[Book] = genericJsonSchema[Book]
 
@@ -84,7 +85,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |          }
           |        ],
           |        "discriminator" : {
-          |          "propertyName" : "type",
+          |          "propertyName" : "storageType",
           |          "mapping" : {
           |            "Library" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Library",
           |            "Online" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Online"
@@ -98,13 +99,13 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |          },
           |          {
           |            "required" : [
-          |              "type",
+          |              "storageType",
           |              "room",
           |              "shelf"
           |            ],
           |            "type" : "object",
           |            "properties" : {
-          |              "type" : {
+          |              "storageType" : {
           |                "type" : "string"
           |              },
           |              "room" : {
@@ -125,12 +126,12 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |          },
           |          {
           |            "required" : [
-          |              "type",
+          |              "storageType",
           |              "link"
           |            ],
           |            "type" : "object",
           |            "properties" : {
-          |              "type" : {
+          |              "storageType" : {
           |                "type" : "string"
           |              },
           |              "link" : {

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -111,7 +111,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |                "type" : "string"
           |              },
           |              "shelf" : {
-          |                "type" : "integer"
+          |                "type" : "integer",
+          |                "format" : "int32"
           |              }
           |            }
           |          }


### PR DESCRIPTION
This PR addresses #134:

- added `discriminatorName` to `JsonSchemas` algebra
  * do we need more fine-grained granularity of specifying discriminator name (i.e. per union type) or is it just fine?
  * does default value (`"type"`) at algebra level make sense in this case? user has ability to override it, but we don't require defining this value, especially if sum types are not used
- changed encoding of coproducts from `{ "InstanceName": { <instance encoding> }}` to `{<discriminatorName>: "InstanceName", <instance encoding>}`
   * this is now reflected in both circe and play json schema interpreters
   * such encoding is not resistant to border cases where instance case class contains field with the same name as `discriminatorName` value
- coproduct instances are now encoded using `allOf` + reference to base coproduct type
  * semantically this shouldn't change anything, but enables [openapi-generator](https://github.com/openapitools/openapi-generator) to correctly generate code for coproducts, as it [doesn't seem to support `oneOf`](https://github.com/openapitools/openapi-generator/issues/15)

- when fixing Play Json codecs, I also explicitly modeled `Record` to have `def writes: OWrites[A]` instead of `def writes: Writes[A]` which let me avoid few ugly `.asInstanceOf[JsObject]`
