### PR TITLE
#132 Add `format` property to OpenAPI primitive schema

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -121,6 +121,8 @@ trait  JsonSchemas
 
   implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal] = JsonSchema(implicitly, implicitly)
 
+  implicit def floatJsonSchema: JsonSchema[Float] = JsonSchema(implicitly, implicitly)
+
   implicit def doubleJsonSchema: JsonSchema[Double] = JsonSchema(implicitly, implicitly)
 
   implicit def booleanJsonSchema: JsonSchema[Boolean] = JsonSchema(implicitly, implicitly)

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -69,6 +69,8 @@ class JsonSchemasTest extends FreeSpec {
 
       lazy val bigdecimalJsonSchema: String = "number"
 
+      lazy val floatJsonSchema: String = "number"
+
       lazy val doubleJsonSchema: String = "number"
 
       lazy val booleanJsonSchema: String = "boolean"

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -65,6 +65,8 @@ trait JsonSchemas
 
   implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal] = JsonSchema(implicitly, implicitly)
 
+  implicit def floatJsonSchema: JsonSchema[Float] = JsonSchema(implicitly, implicitly)
+
   implicit def doubleJsonSchema: JsonSchema[Double] = JsonSchema(implicitly, implicitly)
 
   implicit def booleanJsonSchema: JsonSchema[Boolean] = JsonSchema(implicitly, implicitly)

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -129,6 +129,9 @@ trait JsonSchemas {
   /** A JSON schema for type `BigDecimal` */
   implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal]
 
+  /** A JSON schema for type `Float` */
+  implicit def floatJsonSchema: JsonSchema[Float]
+
   /** A JSON schema for type `Double` */
   implicit def doubleJsonSchema: JsonSchema[Double]
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -116,7 +116,7 @@ trait Endpoints
         properties.map(_.schema).flatMap(captureReferencedSchemasRec)
       case Schema.Array(elementType) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Primitive(_) =>
+      case Schema.Primitive(_, _) =>
         Nil
       case Schema.OneOf(alternatives, _) =>
         alternatives.flatMap(captureReferencedSchemasRec)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -30,8 +30,8 @@ trait JsonSchemaEntities
         Schema.Reference(name, expandCoproductSchema(coprod))
       case coprod @ DocumentedCoProd(_, None) =>
         expandCoproductSchema(coprod)
-      case Primitive(name) =>
-        Schema.Primitive(name)
+      case Primitive(name, format) =>
+        Schema.Primitive(name, format)
       case Array(elementType) =>
         Schema.Array(toSchema(elementType))
     }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -77,6 +77,8 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   lazy val bigdecimalJsonSchema: DocumentedJsonSchema = Primitive("number")
 
+  lazy val floatJsonSchema: DocumentedJsonSchema = Primitive("number", format = Some("float"))
+
   lazy val doubleJsonSchema: DocumentedJsonSchema = Primitive("number", format = Some("double"))
 
   lazy val booleanJsonSchema: DocumentedJsonSchema = Primitive("boolean")

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -28,7 +28,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
     case class DocumentedCoProd(alternatives: List[(String, DocumentedRecord)],
                                 name: Option[String] = None) extends DocumentedJsonSchema
 
-    case class Primitive(name: String) extends DocumentedJsonSchema
+    case class Primitive(name: String, format: Option[String] = None) extends DocumentedJsonSchema
 
     case class Array(elementType: DocumentedJsonSchema) extends DocumentedJsonSchema
   }
@@ -71,13 +71,13 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   lazy val stringJsonSchema: DocumentedJsonSchema = Primitive("string")
 
-  lazy val intJsonSchema: DocumentedJsonSchema = Primitive("integer")
+  lazy val intJsonSchema: DocumentedJsonSchema = Primitive("integer", format = Some("int32"))
 
-  lazy val longJsonSchema: DocumentedJsonSchema = Primitive("integer")
+  lazy val longJsonSchema: DocumentedJsonSchema = Primitive("integer", format = Some("int64"))
 
   lazy val bigdecimalJsonSchema: DocumentedJsonSchema = Primitive("number")
 
-  lazy val doubleJsonSchema: DocumentedJsonSchema = Primitive("number")
+  lazy val doubleJsonSchema: DocumentedJsonSchema = Primitive("number", format = Some("double"))
 
   lazy val booleanJsonSchema: DocumentedJsonSchema = Primitive("boolean")
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -50,7 +50,7 @@ trait Requests
   def emptyRequest = None
 
   override def textRequest(docs: Documentation): Option[DocumentedRequestEntity] = Some(
-    DocumentedRequestEntity(docs, Map("text/plain" -> MediaType(Some(Schema.Primitive("string")))))
+    DocumentedRequestEntity(docs, Map("text/plain" -> MediaType(Some(Schema.simpleString))))
   )
 
   def request[A, B, C, AB](

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
@@ -197,18 +197,25 @@ object Schema {
 
   case class Property(name: String, schema: Schema, isRequired: Boolean, description: Option[String])
 
-  case class Primitive(name: String) extends Schema
+  case class Primitive(name: String, format: Option[String]) extends Schema
 
   case class OneOf(alternatives: List[Schema], description: Option[String]) extends Schema
 
   case class Reference(name: String, original: Schema) extends Schema
 
-  val simpleString = Primitive("string")
-  val simpleInteger = Primitive("integer")
+  val simpleString = Primitive("string", None)
+  val simpleInteger = Primitive("integer", None)
 
   implicit val jsonEncoder: ObjectEncoder[Schema] =
     ObjectEncoder.instance {
-      case Primitive(name) => JsonObject.singleton("type", Json.fromString(name))
+      case Primitive(name, None) =>
+        JsonObject.singleton("type", Json.fromString(name))
+      case Primitive(name, Some(format)) =>
+        JsonObject.fromIterable(
+          "type" -> Json.fromString(name) ::
+            "format" -> Json.fromString(format) ::
+            Nil
+        )
       case Array(elementType) =>
         JsonObject.fromIterable(
           "type" -> Json.fromString("array") ::

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -30,8 +30,8 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
     "be exposed in JSON schema" in {
       val expectedSchema =
         Schema.Object(
-          Schema.Property("name", Schema.Primitive("string"), isRequired = true, description = Some("Name of the user")) ::
-          Schema.Property("age", Schema.Primitive("integer"), isRequired = true, description = None) ::
+          Schema.Property("name", Schema.Primitive("string", None), isRequired = true, description = Some("Name of the user")) ::
+          Schema.Property("age", Schema.Primitive("integer", Some("int32")), isRequired = true, description = None) ::
           Nil,
           None
         )
@@ -45,7 +45,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
       reqBody shouldBe defined
       reqBody.value.description.value shouldEqual "Text Req"
-      reqBody.value.content("text/plain").schema.value shouldEqual Schema.Primitive("string")
+      reqBody.value.content("text/plain").schema.value shouldEqual Schema.Primitive("string", None)
     }
   }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -44,7 +44,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |        "type" : "object",
           |        "properties" : {
           |          "id" : {
-          |            "type" : "integer"
+          |            "type" : "integer",
+          |            "format" : "int32"
           |          },
           |          "title" : {
           |            "type" : "string"


### PR DESCRIPTION
This commit adds preliminary support for OpenAPI `format` property [1]
with a few default values for `Int`, `Long` and `Double`.

[1] https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#data-types