### PR TITLE
Make it possible to write explicit result types of endpoint constructors

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -70,11 +70,11 @@ class Endpoints(val settings: EndpointsSettings)
     (body, request) => request.copy(entity = HttpEntity(body))
 
 
-  def request[A, B, C, AB](
+  def request[A, B, C, AB, Out](
     method: Method, url: Url[A],
     entity: RequestEntity[B], headers: RequestHeaders[C]
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
-    (abc: tuplerABC.Out) => {
+  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
+    (abc: Out) => {
       val (ab, c) = tuplerABC.unapply(abc)
       val (a, b) = tuplerAB.unapply(ab)
       val uri =

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -79,12 +79,12 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
   }
 
 
-  def request[A, B, C, AB](
+  def request[A, B, C, AB, Out](
     method: Method,
     url: Url[A],
     entity: RequestEntity[B] = emptyRequest,
     headers: RequestHeaders[C] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] = {
+  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] = {
     val methodDirective = convToDirective1(Directives.method(method))
     // we use Directives.pathPrefix to construct url directives, so now we close it
     val urlDirective = joinDirectives(url.directive, convToDirective1(Directives.pathEndOrSingleSlash))

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
@@ -24,7 +24,7 @@ class EndpointsTest extends WordSpec with Matchers with ScalatestRouteTest {
 
   val testRoutes = new Endpoints {
     val singleStaticGetSegment = endpoint[Unit, Unit](
-      get[Unit, Unit](path / "segment1"),
+      get(path / "segment1"),
       (_: Unit) => complete("Ok")
     ).implementedBy(_ => ())
   }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -29,7 +29,7 @@ trait BasicAuthentication extends Endpoints {
   /**
     * Describes an endpoint protected by Basic HTTP authentication
     */
-  def authenticatedEndpoint[U, E, R, H, UE, DCred](
+  def authenticatedEndpoint[U, E, R, H, UE, HCred, Out](
     method: Method,
     url: Url[U],
     response: Response[R],
@@ -39,10 +39,10 @@ trait BasicAuthentication extends Endpoints {
     summary: Documentation = None,
     description: Documentation = None
   )(implicit
-    tuplerAB: Tupler.Aux[U, E, UE],
-    tuplerDCred: Tupler.Aux[H, Credentials, DCred],
-    tuplerABDCred: Tupler[UE, DCred]
-  ): Endpoint[tuplerABDCred.Out, Option[R]] =
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Endpoint[Out, Option[R]] =
     endpoint(
       request(method, url, requestEntity, requestHeaders ++ basicAuthenticationHeader),
       authenticated(response, unauthenticatedDocs),

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -56,22 +56,22 @@ trait Requests extends Urls with Methods with InvariantFunctorSyntax with Semigr
     * @tparam HeadersP Payload carried by headers
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
     */
-  def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled](
+  def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     method: Method,
     url: Url[UrlP],
     entity: RequestEntity[BodyP] = emptyRequest,
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out]
+  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out]
 
   /**
     * Helper method to perform GET request
     * @tparam UrlP Payload carried by url
     * @tparam HeadersP Payload carried by headers
     */
-  final def get[UrlP, HeadersP](
+  final def get[UrlP, HeadersP, Out](
     url: Url[UrlP],
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerAC: Tupler[UrlP, HeadersP]): Request[tuplerAC.Out] = request(Get, url, headers = headers)
+  )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] = request(Get, url, headers = headers)
 
   /**
     * Helper method to perform POST request
@@ -80,11 +80,11 @@ trait Requests extends Urls with Methods with InvariantFunctorSyntax with Semigr
     * @tparam HeadersP Payload carried by headers
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
     */
-  final def post[UrlP, BodyP, HeadersP, UrlAndBodyPTupled](
+  final def post[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     url: Url[UrlP],
     entity: RequestEntity[BodyP],
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerABC: Tupler[UrlAndBodyPTupled, HeadersP]): Request[tuplerABC.Out] = request(Post, url, entity, headers)
+  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] = request(Post, url, entity, headers)
 
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -20,7 +20,7 @@ trait EndpointsTestApi extends algebra.Endpoints {
   )
 
   val optionalEndpoint: Endpoint[Unit, Option[String]] = endpoint(
-    get[Unit, Unit](path / "users" / "1"),
+    get(path / "users" / "1"),
     option(textResponse())
   )
 

--- a/documentation/examples/basic/shared/src/main/scala/sample/ApiAlg.scala
+++ b/documentation/examples/basic/shared/src/main/scala/sample/ApiAlg.scala
@@ -1,23 +1,24 @@
 package sample
 
+import endpoints.algebra.BasicAuthentication.Credentials
 import endpoints.algebra._
 import io.circe.generic.JsonCodec
 
 trait ApiAlg extends Endpoints with circe.JsonEntitiesFromCodec with BasicAuthentication {
 
-  val index =
+  val index: Endpoint[(String, Int, String), User] =
     endpoint(get(path / "user" / segment[String]() /? (qs[Int]("age") & qs[String]("toto"))), jsonResponse[User]())
 
   val action =
     endpoint(post(path / "action", jsonRequest[ActionParameter]()), jsonResponse[ActionResult]())
 
-  val actionFut =
+  val actionFut: Endpoint[ActionParameter, ActionResult] =
     endpoint(post(path / "actionFut", jsonRequest[ActionParameter]()), jsonResponse[ActionResult]())
 
   val maybe =
     endpoint(get(path / "option"), option(emptyResponse()))
 
-  val auth =
+  val auth: Endpoint[Credentials, Option[Unit]] =
     authenticatedEndpoint(Get, path / "auth", response = emptyResponse())
 
 }

--- a/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/publicserver/PublicEndpoints.scala
+++ b/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/publicserver/PublicEndpoints.scala
@@ -35,13 +35,12 @@ trait PublicEndpoints extends Endpoints with circe.JsonEntitiesFromCodec {
 
   //#webapps-endpoint
   /** Registers a new meter */
-  val createMeter =
+  val createMeter: Endpoint[CreateMeter, Meter] =
     endpoint(post(metersPath, jsonRequest[CreateMeter]()), jsonResponse[Meter]())
-  // createMeter: Endpoint[CreateMeter, Meter]
   //#webapps-endpoint
 
   /** Add a record to an existing meter */
-  val addRecord/*: Endpoint[(UUID, AddRecord), Meter]*/ =
+  val addRecord: Endpoint[(UUID, AddRecord), Meter] =
     endpoint(post(metersPath / segment[UUID]() / "records", jsonRequest[AddRecord]()), jsonResponse[Meter]())
 
   implicit def uuidSegment: Segment[UUID]

--- a/documentation/examples/overview/endpoints/src/main/scala/overview/CounterEndpoints.scala
+++ b/documentation/examples/overview/endpoints/src/main/scala/overview/CounterEndpoints.scala
@@ -18,7 +18,8 @@ trait CounterEndpoints extends Endpoints with JsonEntitiesFromCodec {
     * Uses the HTTP verb “GET” and URL path “/current-value”.
     * The response entity is a JSON document representing the counter value.
     */
-  val currentValue = endpoint(get(path / "current-value"), jsonResponse[Counter]())
+  val currentValue: Endpoint[Unit, Counter] =
+    endpoint(get(path / "current-value"), jsonResponse[Counter]())
 
   /**
     * Increments the counter value.
@@ -26,7 +27,8 @@ trait CounterEndpoints extends Endpoints with JsonEntitiesFromCodec {
     * The request entity is a JSON document representing the increment to apply to the counter.
     * The response entity is empty.
     */
-  val increment = endpoint(post(path / "increment", jsonRequest[Increment]()), emptyResponse())
+  val increment: Endpoint[Increment, Unit] =
+    endpoint(post(path / "increment", jsonRequest[Increment]()), emptyResponse())
 
 }
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -53,12 +53,12 @@ trait Requests
     DocumentedRequestEntity(docs, Map("text/plain" -> MediaType(Some(Schema.simpleString))))
   )
 
-  def request[A, B, C, AB](
+  def request[A, B, C, AB, Out](
     method: Method,
     url: Url[A],
     entity: RequestEntity[B] = emptyRequest,
     headers: RequestHeaders[C] = emptyHeaders
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
+  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
     DocumentedRequest(method, url, headers, entity)
 
   implicit lazy val reqEntityInvFunctor: endpoints.InvariantFunctor[RequestEntity] = new InvariantFunctor[RequestEntity] {

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -68,11 +68,11 @@ class Endpoints(host: String, wsClient: WSClient)(implicit val executionContext:
       (to, req) => f(contramap(to), req)
   }
 
-  def request[A, B, C, AB](
+  def request[A, B, C, AB, Out](
     method: Method, url: Url[A],
     entity: RequestEntity[B], headers: RequestHeaders[C]
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
-    (abc: tuplerABC.Out) => {
+  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
+    (abc: Out) => {
       val (ab, c) = tuplerABC.unapply(abc)
       val (a, b) = tuplerAB.unapply(ab)
       val wsRequest = method(entity(b, headers(c, wsClient.url(host ++ url.encode(a)))))

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -184,7 +184,7 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
     * @param entity Request entity
     * @param headers Request headers
     */
-  def request[A, B, C, AB](method: Method, url: Url[A], entity: RequestEntity[B], headers: RequestHeaders[C])(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
+  def request[A, B, C, AB, Out](method: Method, url: Url[A], entity: RequestEntity[B], headers: RequestHeaders[C])(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
     extractMethodUrlAndHeaders(method, url, headers)
       .toRequest {
         case (a, c) => entity.map(b => tuplerABC.apply(tuplerAB.apply(a, b), c))

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -46,11 +46,11 @@ trait Requests extends algebra.Requests with Urls with Methods {
   }
 
 
-  def request[U, E, H, UE](method: Method,
+  def request[U, E, H, UE, Out](method: Method,
     url: Url[U],
     entity: RequestEntity[E] = emptyRequest,
     headers: RequestHeaders[H] = emptyHeaders
-  )(implicit tuplerUE: Tupler.Aux[U, E, UE], tuplerUEH: Tupler[UE, H]): Request[tuplerUEH.Out] =
+  )(implicit tuplerUE: Tupler.Aux[U, E, UE], tuplerUEH: Tupler.Aux[UE, H, Out]): Request[Out] =
     (ueh) => {
       val (ue, h) = tuplerUEH.unapply(ueh)
       val (u, e) = tuplerUE.unapply(ue)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -75,11 +75,11 @@ class Endpoints[R[_]](host: String, val backend: sttp.SttpBackend[R, Nothing]) e
       (to, req) => f(contramap(to), req)
   }
 
-  def request[A, B, C, AB](
+  def request[A, B, C, AB, Out](
     method: Method, url: Url[A],
     entity: RequestEntity[B], headers: RequestHeaders[C]
-  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
-    (abc: tuplerABC.Out) => {
+  )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
+    (abc: Out) => {
       val (ab, c) = tuplerABC.unapply(abc)
       val (a, b) = tuplerAB.unapply(ab)
 

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -74,16 +74,16 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
       (to, xhr) => f(contramap(to), xhr)
   }
 
-  def request[A, B, C, AB](method: Method, url: Url[A], entity: RequestEntity[B], headers: RequestHeaders[C])(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler[AB, C]): Request[tuplerABC.Out] =
-    new Request[tuplerABC.Out] {
-      def apply(abc: tuplerABC.Out) = {
+  def request[A, B, C, AB, Out](method: Method, url: Url[A], entity: RequestEntity[B], headers: RequestHeaders[C])(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
+    new Request[Out] {
+      def apply(abc: Out) = {
         val (ab, c) = tuplerABC.unapply(abc)
         val (a, b) = tuplerAB.unapply(ab)
         val xhr = makeXhr(method, url, a, headers, c)
         (xhr, Some(entity(b, xhr)))
       }
 
-      def href(abc: tuplerABC.Out) = {
+      def href(abc: Out) = {
         val (ab, _) = tuplerABC.unapply(abc)
         val (a, _) = tuplerAB.unapply(ab)
         url.encode(a)


### PR DESCRIPTION
Follow-up of our [discussion on gitter](https://gitter.im/julienrf/endpoints?at=5bbdcb92ef4afc4f284b7a0f).

It seems that by adding an additional type parameter (instead of using a path-dependent type), the compiler happily accepts our type annotations.