### PR TITLE
#133 Support enums in JSON Schema and OpenAPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ $ sbt "+++ 2.12.4 test"
 ### Preview the documentation
 
 ~~~ sh
-$ sbt +manual/previewAuto
+$ sbt +manual/previewSite
 ~~~
 
 And then go to http://localhost:4000.

--- a/documentation/manual/src/ornate/algebras/json-schemas.md
+++ b/documentation/manual/src/ornate/algebras/json-schemas.md
@@ -41,6 +41,8 @@ and then we combine them into a single JSON object schema by using the `zip` ope
 to turn the `Record[(Double, Double)]` value returned by the `zip` operation into
 a `Record[Rectangle]`.
 
+### Sum types
+
 It is also possible to define schemas for sum types. Consider the following type definition,
 defining a `Shape`, which can be either a `Circle` or a `Rectangle`:
 
@@ -62,6 +64,31 @@ using `invmap`.
 
 By default, the discriminator field is named `type`, but you can use another field name if
 you want to.
+
+### Enumerations
+
+There are different ways to represent enumerations in Scala:
+
+- `scala.util.Enumeration`
+- Sealed trait with case objects
+- Third-party libraries, e.g. Enumeratum
+
+For example, an enumeration with three possible values can be defined as a sealed trait with three case objects:
+
+~~~ scala src=../../../../../json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala#enum-status
+~~~
+
+The method `enumeration` in the `JsonSchemas` algebra supports mapping the enum values to JSON strings.
+It has two parameters: the possible values, and a function to encode an enum value as a string.
+
+~~~ scala src=../../../../../json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala#enum-status-schema
+~~~
+
+The resulting `JsonSchema[Status]` allows defining JSON members with string values that are mapped to our case objects.
+
+It will work similarly for other representations of enumerated values.
+Most of them provide `values` which can conveniently be passed into `enumeration`.
+However, it is still possible to explicitly pass a certain subset of allowed values.
 
 ## Generic derivation of JSON schemas
 

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -75,6 +75,18 @@ trait JsonSchemas
       }
   }
 
+  type Enum[A] = JsonSchema[A]
+
+  def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: JsonSchema[String]): Enum[A] = {
+    lazy val stringToEnum: Map[String, A] = values.map(value => (encode(value), value)).toMap
+    def decode(string: String): Either[String, A] = stringToEnum.get(string).toRight("Cannot decode as enum value: " + string)
+
+    JsonSchema(
+      tpe.encoder.contramap(encode),
+      tpe.decoder.emap(decode)
+    )
+  }
+
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
 
   def emptyRecord: Record[Unit] =

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -33,6 +33,10 @@ class JsonSchemasTest extends FreeSpec {
       type JsonSchema[+A] = String
       type Record[+A] = String
       type Tagged[+A] = String
+      type Enum[+A] = String
+
+      def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: String): String =
+        s"$tpe"
 
       override def named[A, S[T] <: String](schema: S[A], name: String): S[A] =
         s"'$name'!($schema)".asInstanceOf[S[A]]

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -41,6 +41,23 @@ trait JsonSchemas
       OFormat(record.reads, record.writes)
   }
 
+  type Enum[A] = JsonSchema[A]
+
+  def enumeration[A](values: Seq[A])(encode: A => String)(implicit jsonSchema: JsonSchema[String]): Enum[A] = {
+    lazy val stringToEnum: Map[String, A] = values.map(value => (encode(value), value)).toMap
+    def decode(string: String): Either[String, A] = stringToEnum.get(string).toRight("Cannot decode as enum value: " + string)
+
+    JsonSchema(
+      new Reads[A] {
+        override def reads(json: JsValue): JsResult[A] = {
+          jsonSchema.reads.reads(json).flatMap(value => decode(value).fold(JsError(_), JsSuccess(_)))
+        }
+      },
+      jsonSchema.writes.contramap(encode)
+    )
+  }
+
+
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
 
   def emptyRecord: Record[Unit] =

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -305,6 +305,32 @@ class JsonSchemasTest extends FreeSpec {
     )
   }
 
+  import Enum._
+
+  "enum decoding fails because value cannot be decoded" in {
+    assertError(
+      colorSchema,
+      JsString("yellow"),
+      "Cannot decode as enum value: yellow"
+    )
+  }
+
+  "enum decoding fails because value is not possible" in {
+    assertError(
+      colorSchema,
+      JsString("Green"),
+      "Cannot decode as enum value: Green"
+    )
+  }
+
+  "enum decoding and encoding works" in {
+    testRoundtrip(
+      colorSchema,
+      JsString("Blue"),
+      Blue
+    )
+  }
+
   private def testRoundtrip[A](jsonSchema: JsonSchema[A], json: JsValue, expected: A) = {
     val result = jsonSchema.reads.reads(json)
     assert(result.isSuccess, result)

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -72,6 +72,15 @@ trait JsonSchemas {
     */
   type Tagged[A] <: JsonSchema[A]
 
+  /** A JSON schema for enumerations, i.e. types that have a restricted set of values. */
+  type Enum[A] <: JsonSchema[A]
+
+  /** Promotes a schema to an enumeration and converts between enum constants and JSON strings.
+    * Decoding fails if the input string does not match the encoded values of any of the possible values.
+    * Encoding does never fail, even if the value is not contained in the set of possible values.
+    * */
+  def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: JsonSchema[String]): Enum[A]
+
   /** Annotates JSON schema with a name */
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A]
 

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
@@ -47,4 +47,17 @@ trait JsonSchemasDocs extends JsonSchemas {
     }
   }
 
+  locally {
+    //#enum-status
+    sealed trait Status
+    case object Active extends Status
+    case object Inactive extends Status
+    case object Obsolete extends Status
+    //#enum-status
+    //#enum-status-schema
+    implicit lazy val statusSchema: JsonSchema[Status] =
+      enumeration[Status](Seq(Active, Inactive, Obsolete))(_.toString)
+    //#enum-status-schema
+  }
+
 }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -54,4 +54,13 @@ trait JsonSchemasTest extends JsonSchemas {
     }
   }
 
+  object Enum {
+    sealed trait Color
+    case object Red extends Color
+    case object Green extends Color
+    case object Blue extends Color
+
+    val colorSchema: Enum[Color] = enumeration[Color](Seq(Red, Blue))(_.toString)
+  }
+
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -118,6 +118,8 @@ trait Endpoints
         properties.map(_.schema).flatMap(captureReferencedSchemasRec)
       case Schema.Array(elementType) =>
         captureReferencedSchemasRec(elementType)
+      case Schema.Enum(elementType, _) =>
+        captureReferencedSchemasRec(elementType)
       case Schema.Primitive(_, _) =>
         Nil
       case Schema.OneOf(_, alternatives, _) =>

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -37,6 +37,8 @@ trait JsonSchemaEntities
         Schema.Primitive(name, format)
       case Array(elementType) =>
         Schema.Array(toSchema(elementType))
+      case DocumentedEnum(elementType, values) =>
+        Schema.Enum(toSchema(elementType), values)
     }
   }
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -19,6 +19,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
   type JsonSchema[+A] = DocumentedJsonSchema
   type Record[+A] = DocumentedRecord
   type Tagged[+A] = DocumentedCoProd
+  type Enum[+A] = DocumentedEnum
 
   sealed trait DocumentedJsonSchema
 
@@ -34,7 +35,12 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
     case class Primitive(name: String, format: Option[String] = None) extends DocumentedJsonSchema
 
     case class Array(elementType: DocumentedJsonSchema) extends DocumentedJsonSchema
+
+    case class DocumentedEnum(elementType: DocumentedJsonSchema, values: Seq[String]) extends DocumentedJsonSchema
   }
+
+  def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: JsonSchema[String]): DocumentedEnum =
+    DocumentedEnum(tpe, values.map(encode))
 
   override def named[A, S[_] <: DocumentedJsonSchema](schema: S[A], name: String): S[A] = {
     import DocumentedJsonSchema._

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
@@ -195,6 +195,8 @@ object Schema {
 
   case class Array(elementType: Schema) extends Schema
 
+  case class Enum(elementType: Schema, values: Seq[String]) extends Schema
+
   case class Property(name: String, schema: Schema, isRequired: Boolean, description: Option[String])
 
   case class Primitive(name: String, format: Option[String]) extends Schema
@@ -229,6 +231,8 @@ object Schema {
             "items" -> jsonEncoder.apply(elementType) ::
             Nil
         )
+      case Enum(elementType, values) =>
+        jsonEncoder.encodeObject(elementType).add("enum", Json.fromValues(values.map(Json.fromString)))
       case Object(properties, description) =>
         val fields =
           "type" -> Json.fromString("object") ::

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -33,4 +33,10 @@ class JsonSchemasTest extends FreeSpec {
     assert(DocumentedJsonSchemas.Foo.schema == expectedSchema)
   }
 
+  "enum" in {
+    val expectedSchema =
+      DocumentedEnum(DocumentedJsonSchemas.stringJsonSchema, Seq("Red", "Blue"))
+    assert(DocumentedJsonSchemas.Enum.colorSchema == expectedSchema)
+  }
+
 }


### PR DESCRIPTION
Only string-based enums are supported. I added an example that demonstrates usage with sealed trait and Scala `Enumeration`.