### PR TITLE
Support for OAS3 security schemes

### DIFF
--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -3,6 +3,7 @@ package openapi
 
 import endpoints.algebra.BasicAuthentication.Credentials
 import endpoints.algebra.Documentation
+import endpoints.openapi.model.{OperationSecurity, SecurityScheme}
 
 /**
   * Interpreter for [[algebra.BasicAuthentication]] that produces
@@ -14,9 +15,31 @@ trait BasicAuthentication
   extends algebra.BasicAuthentication
     with Endpoints {
 
-  private[endpoints] lazy val basicAuthenticationHeader: RequestHeaders[Credentials] = header("Authorization")
+  private[endpoints] def basicAuthenticationHeader: RequestHeaders[Credentials] =
+    DocumentedHeaders(Nil) // supported by OAS3 security schemes
 
   private[endpoints] def authenticated[A](response: Response[A], docs: Documentation): Response[Option[A]] =
     DocumentedResponse(401, docs.getOrElse(""), content = Map.empty) :: response
+
+  /**
+    * Describes an endpoint protected by Basic HTTP authentication
+    */
+  override def authenticatedEndpoint[U, E, R, H, UE, HCred, Out](
+    method: Method,
+    url: Url[U],
+    response: Response[R],
+    requestEntity: RequestEntity[E] = emptyRequest,
+    requestHeaders: RequestHeaders[H] = emptyHeaders,
+    unauthenticatedDocs: Documentation = None,
+    summary: Documentation = None,
+    description: Documentation = None,
+    tags: List[String] = Nil
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Endpoint[Out, Option[R]] =
+    super.authenticatedEndpoint(method, url, response, requestEntity, requestHeaders, unauthenticatedDocs, summary, description, tags)
+      .withSecurity(OperationSecurity("HttpBasic", SecurityScheme.httpBasic))
 
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -21,9 +21,8 @@ trait BasicAuthentication
   private[endpoints] def authenticated[A](response: Response[A], docs: Documentation): Response[Option[A]] =
     DocumentedResponse(401, docs.getOrElse(""), content = Map.empty) :: response
 
-  /**
-    * Describes an endpoint protected by Basic HTTP authentication
-    */
+  def basicAuthenticationSchemeName: String = "HttpBasic"
+
   override def authenticatedEndpoint[U, E, R, H, UE, HCred, Out](
     method: Method,
     url: Url[U],
@@ -40,6 +39,5 @@ trait BasicAuthentication
     tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
   ): Endpoint[Out, Option[R]] =
     super.authenticatedEndpoint(method, url, response, requestEntity, requestHeaders, unauthenticatedDocs, summary, description, tags)
-      .withSecurity(OperationSecurity("HttpBasic", SecurityScheme.httpBasic))
-
+      .withSecurity(OperationSecurity(basicAuthenticationSchemeName, SecurityScheme.httpBasic))
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
@@ -50,14 +50,18 @@ object PathItem {
 
 }
 
-case class Components(schemas: Map[String, Schema])
+case class Components(schemas: Map[String, Schema],
+                      securitySchemes: Map[String, SecurityScheme])
 
 object Components {
 
   implicit val jsonEncoder: ObjectEncoder[Components] = {
     ObjectEncoder.instance { components =>
       val schemas = components.schemas.mapValues(_.asJson).toSeq.sortBy(_._1)
-      JsonObject.singleton("schemas", JsonObject.fromIterable(schemas).asJson)
+      JsonObject(
+        "schemas" -> JsonObject.fromIterable(schemas).asJson,
+        "securitySchemes" -> JsonObject.fromMap(components.securitySchemes.mapValues(_.asJson)).asJson
+      )
     }
   }
 }
@@ -68,7 +72,8 @@ case class Operation(
   parameters: List[Parameter],
   requestBody: Option[RequestBody],
   responses: Map[Int, Response],
-  tags: List[String]
+  tags: List[String],
+  security: List[OperationSecurity]
 )
 
 object Operation {
@@ -80,6 +85,7 @@ object Operation {
         op.description.map(x => "description" -> x.asJson),
         op.requestBody.map(x => "requestBody" -> x.asJson),
         op.tags.headOption.map(_ => "tags" -> op.tags.asJson),
+        op.security.headOption.map(_ => "security" -> Json.fromValues(op.security.map(_.asJson))),
         if (op.parameters.isEmpty) None
         else Some("parameters" -> Json.fromValues(op.parameters.map(_.asJson)))
       ).flatten
@@ -102,6 +108,17 @@ object Operation {
       JsonObject.fromIterable(fields)
     }
 
+}
+
+case class OperationSecurity(name: String,
+                             scheme: SecurityScheme,
+                             scopes: List[String] = Nil)
+
+object OperationSecurity {
+
+  implicit val jsonEncoder: ObjectEncoder[OperationSecurity] = ObjectEncoder.instance { os =>
+    JsonObject.singleton(os.name, Json.fromValues(os.scopes.map(_.asJson)))
+  }
 }
 
 case class RequestBody(
@@ -274,4 +291,36 @@ object Schema {
         JsonObject.singleton("$ref", Json.fromString(Reference.toRefPath(name)))
     }
 
+}
+
+
+case class SecurityScheme(`type`: String,
+                          description: Option[String],
+                          name: Option[String],
+                          in: Option[String],
+                          scheme: Option[String],
+                          bearerFormat: Option[String])
+
+object SecurityScheme {
+
+  implicit val jsonEncoder: ObjectEncoder[SecurityScheme] = ObjectEncoder.instance { ss =>
+    val optFields = List(
+      ss.description.map(x => "description" -> Json.fromString(x)),
+      ss.name.map(x => "name" -> Json.fromString(x)),
+      ss.in.map(x => "in" -> Json.fromString(x)),
+      ss.scheme.map(x => "scheme" -> Json.fromString(x)),
+      ss.bearerFormat.map(x => "bearerFormat" -> Json.fromString(x))
+    )
+    val fields = "type" -> Json.fromString(ss.`type`) :: optFields.flatten
+    JsonObject(fields : _*)
+  }
+
+  def httpBasic: SecurityScheme = SecurityScheme(
+    `type` = "http",
+    description = Some("Http Basic Authentication"),
+    name = None,
+    in = None,
+    scheme = Some("basic"),
+    bearerFormat = None
+  )
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -15,14 +15,14 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
   case class Book(id: Int, title: String, author: String, isbnCodes: List[String], storage: Storage)
 
-  object Fixtures extends Fixtures with openapi.Endpoints with openapi.JsonSchemaEntities {
+  object Fixtures extends Fixtures with openapi.Endpoints with openapi.JsonSchemaEntities with openapi.BasicAuthentication {
 
     def openApi: OpenApi = openApi(
       Info(title = "TestFixturesOpenApi", version = "0.0.0")
     )(Fixtures.listBooks, Fixtures.postBook)
   }
 
-  trait Fixtures extends algebra.Endpoints with algebra.JsonSchemaEntities with generic.JsonSchemas {
+  trait Fixtures extends algebra.Endpoints with algebra.JsonSchemaEntities with generic.JsonSchemas with algebra.BasicAuthentication {
 
     implicit private val schemaStorage: JsonSchema[Storage] =
       withDiscriminator(genericJsonSchema[Storage].asInstanceOf[Tagged[Storage]], "storageType")
@@ -31,7 +31,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
     val listBooks = endpoint(get(path / "books"), jsonResponse[List[Book]](Some("Books list")), tags = List("Books"))
 
-    val postBook = endpoint(post(path / "books", jsonRequest[Book](docs = Some("Books list"))), emptyResponse(), tags = List("Books"))
+    val postBook = authenticatedEndpoint(Post, path / "books", emptyResponse(), jsonRequest[Book](docs = Some("Books list")), tags = List("Books"))
   }
 
   "OpenApi" should {
@@ -141,6 +141,13 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |          }
           |        ]
           |      }
+          |    },
+          |    "securitySchemes" : {
+          |      "HttpBasic" : {
+          |        "type" : "http",
+          |        "description" : "Http Basic Authentication",
+          |        "scheme" : "basic"
+          |      }
           |    }
           |  },
           |  "openapi" : "3.0.0",
@@ -172,6 +179,9 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |      },
           |      "post" : {
           |        "responses" : {
+          |          "401" : {
+          |            "description" : ""
+          |          },
           |          "200" : {
           |            "description" : ""
           |          }
@@ -188,6 +198,12 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
           |        },
           |        "tags" : [
           |          "Books"
+          |        ],
+          |        "security" : [
+          |          {
+          |            "HttpBasic" : [
+          |            ]
+          |          }
           |        ]
           |      }
           |    }


### PR DESCRIPTION
This is preview PR addressing proposal #138.

The idea is that openapi interpreters for specific authentication method algebras might specify security schemes for each operation. Then openapi generator captures all such schemes and put them in `components/securitySchemes` section, referring to them by name (this is similar to what was implemented for referenced schemas in #113).

Regarding [Security Scheme Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securitySchemeObject), I defined only fields that are required to support `http` and `apiKey` methods. I believe if we agree on final approach, remaining fields (for oauth2/openid) might be added in a follow-up PR.