### PR TITLE
Add support for JSON schemas of recursive data types

### DIFF
--- a/documentation/manual/src/doc/algebras/json-schemas.md
+++ b/documentation/manual/src/doc/algebras/json-schemas.md
@@ -17,6 +17,8 @@ This algebra provides vocabulary to define JSON schemas of data types.
 
 The algebra introduces the concept of `JsonSchema[A]`: a JSON schema for a type `A`.
 
+### Basic types and record types
+
 The trait provides some predefined JSON schemas (for `String`, `Int`, `Boolean`, etc.)
 and ways to combine them together to build more complex schemas.
 
@@ -89,6 +91,14 @@ The resulting `JsonSchema[Status]` allows defining JSON members with string valu
 It will work similarly for other representations of enumerated values.
 Most of them provide `values` which can conveniently be passed into `enumeration`.
 However, it is still possible to explicitly pass a certain subset of allowed values.
+
+### Recursive types
+
+You can reference a currently being defined schema without causing a `StackOverflow` error
+by wrapping it in the `lazySchema` constructor:
+
+~~~ scala src=../../../../../json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala#recursive
+~~~
 
 ## Generic derivation of JSON schemas
 

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -89,6 +89,15 @@ trait JsonSchemas
 
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
 
+  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] = {
+    // The schema won’t be evaluated until its `encoder` or `decoder` is effectively used
+    lazy val evaluatedSchema = schema
+    new JsonSchema[A] {
+      def encoder: Encoder[A] = Encoder.instance(a => evaluatedSchema.encoder(a))
+      def decoder: Decoder[A] = Decoder.instance(c => evaluatedSchema.decoder(c))
+    }
+  }
+
   def emptyRecord: Record[Unit] =
     Record(
       io.circe.Encoder.encodeUnit,

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -42,4 +42,11 @@ class JsonSchemasTest extends FreeSpec {
     assert(Foo.schema.decoder.decodeJson(wrongJson).swap.right.exists(_ == DecodingFailure("No decoder for discriminator 'Unknown'!", Nil)))
   }
 
+  "recursive type" in {
+    val json = Json.obj("next" -> Json.obj("next" -> Json.obj("next" -> Json.Null)))
+    val rec = JsonSchemasCodec.Rec(Some(JsonSchemasCodec.Rec(Some(JsonSchemasCodec.Rec(None)))))
+    assert(JsonSchemasCodec.recSchema.decoder.decodeJson(json).right.exists(_ == rec))
+    assert(JsonSchemasCodec.recSchema.encoder(rec) == json)
+  }
+
 }

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -38,8 +38,11 @@ class JsonSchemasTest extends FreeSpec {
       def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: String): String =
         s"$tpe"
 
-      override def named[A, S[T] <: String](schema: S[A], name: String): S[A] =
+      def named[A, S[T] <: String](schema: S[A], name: String): S[A] =
         s"'$name'!($schema)".asInstanceOf[S[A]]
+
+      def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] =
+        s"=>'$name'!($schema)"
 
       def emptyRecord: String =
         "$"

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -60,6 +60,15 @@ trait JsonSchemas
 
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
 
+  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] = {
+    // The schema won’t be evaluated until its `reads` or `writes` is effectively used
+    lazy val evaluatedSchema = schema
+    new JsonSchema[A] {
+      def reads: Reads[A] = Reads(js => evaluatedSchema.reads.reads(js))
+      def writes: Writes[A] = Writes(a => evaluatedSchema.writes.writes(a))
+    }
+  }
+
   def emptyRecord: Record[Unit] =
     Record(
       new Reads[Unit] {

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -331,6 +331,14 @@ class JsonSchemasTest extends FreeSpec {
     )
   }
 
+  "recursive type" in {
+    testRoundtrip(
+      recSchema,
+      Json.obj("next" -> Json.obj("next" -> Json.obj())),
+      Rec(Some(Rec(Some(Rec(None)))))
+    )
+  }
+
   private def testRoundtrip[A](jsonSchema: JsonSchema[A], json: JsValue, expected: A) = {
     val result = jsonSchema.reads.reads(json)
     assert(result.isSuccess, result)

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -84,6 +84,24 @@ trait JsonSchemas {
   /** Annotates JSON schema with a name */
   def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A]
 
+  /**
+    * Captures a lazy reference to a JSON schema currently being defined:
+    *
+    * {{{
+    *   case class Rec(next: Option[Rec])
+    *   val recSchema: JsonSchema[Rec] = (
+    *     optField("next")(lazySchema(recSchema, "Rec"))
+    *   ).invmap(Rec)(_.next)
+    * }}}
+    *
+    * Interpreters should return a JsonSchema value that does not evaluate
+    * the given `schema` unless it is effectively used.
+    *
+    * @param schema The JSON schema whose evaluation should be delayed
+    * @param name A unique name identifying the schema
+    */
+  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A]
+
   /** The JSON schema of a record with no fields */
   def emptyRecord: Record[Unit]
 

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
@@ -60,4 +60,12 @@ trait JsonSchemasDocs extends JsonSchemas {
     //#enum-status-schema
   }
 
+  //#recursive
+  case class Rec(next: Option[Rec])
+
+  val recSchema: JsonSchema[Rec] = (
+    optField("next")(lazySchema(recSchema, "Rec"))
+  ).invmap(Rec)(_.next)
+  //#recursive
+
 }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -63,4 +63,9 @@ trait JsonSchemasTest extends JsonSchemas {
     val colorSchema: Enum[Color] = enumeration[Color](Seq(Red, Blue))(_.toString)
   }
 
+  case class Rec(next: Option[Rec])
+  val recSchema: JsonSchema[Rec] = (
+    optField("next")(lazySchema(recSchema, "Rec"))
+  ).invmap(Rec)(_.next)
+
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -22,29 +22,35 @@ trait JsonSchemaEntities
   def jsonResponse[A](docs: Documentation)(implicit codec: JsonSchema[A]): List[DocumentedResponse] =
     DocumentedResponse(200, docs.getOrElse(""), Map("application/json" -> MediaType(Some(toSchema(codec))))) :: Nil
 
-  def toSchema(documentedCodec: DocumentedJsonSchema, coprodBase: Option[DocumentedCoProd] = None): Schema = {
+  def toSchema(jsonSchema: DocumentedJsonSchema): Schema =
+    toSchema(jsonSchema, None, Set.empty)
 
+  private def toSchema(documentedCodec: DocumentedJsonSchema, coprodBase: Option[DocumentedCoProd], referencedSchemas: Set[String]): Schema = {
     documentedCodec match {
       case record @ DocumentedRecord(_, Some(name)) =>
-        Schema.Reference(name, Some(expandRecordSchema(record, coprodBase)))
+        if (referencedSchemas(name)) Schema.Reference(name, None)
+        else Schema.Reference(name, Some(expandRecordSchema(record, coprodBase, referencedSchemas + name)))
       case record @ DocumentedRecord(_, None) =>
-        expandRecordSchema(record)
+        expandRecordSchema(record, None, referencedSchemas)
       case coprod @ DocumentedCoProd(_, Some(name), _) =>
-        Schema.Reference(name, Some(expandCoproductSchema(coprod)))
+        if (referencedSchemas(name)) Schema.Reference(name, None)
+        else Schema.Reference(name, Some(expandCoproductSchema(coprod, referencedSchemas + name)))
       case coprod @ DocumentedCoProd(_, None, _) =>
-        expandCoproductSchema(coprod)
+        expandCoproductSchema(coprod, referencedSchemas)
       case Primitive(name, format) =>
         Schema.Primitive(name, format)
       case Array(elementType) =>
-        Schema.Array(toSchema(elementType))
+        Schema.Array(toSchema(elementType, coprodBase, referencedSchemas))
       case DocumentedEnum(elementType, values) =>
-        Schema.Enum(toSchema(elementType), values)
+        Schema.Enum(toSchema(elementType, coprodBase, referencedSchemas), values)
+      case lzy: LazySchema =>
+        toSchema(lzy.value, coprodBase, referencedSchemas)
     }
   }
 
-  private def expandRecordSchema(record: DocumentedJsonSchema.DocumentedRecord, coprodBase: Option[DocumentedCoProd] = None): Schema = {
+  private def expandRecordSchema(record: DocumentedJsonSchema.DocumentedRecord, coprodBase: Option[DocumentedCoProd], referencedSchemas: Set[String]): Schema = {
     val fieldsSchema = record.fields
-      .map(f => Schema.Property(f.name, toSchema(f.tpe), !f.isOptional, f.documentation))
+      .map(f => Schema.Property(f.name, toSchema(f.tpe, None, referencedSchemas), !f.isOptional, f.documentation))
 
     coprodBase.fold[Schema] {
       Schema.Object(fieldsSchema, None)
@@ -65,8 +71,9 @@ trait JsonSchemaEntities
     }
   }
 
-  private def expandCoproductSchema(coprod: DocumentedJsonSchema.DocumentedCoProd): Schema = {
-    val alternativesSchemas = coprod.alternatives.map { case (tag, record) => tag -> toSchema(record, Some(coprod)) }
+  private def expandCoproductSchema(coprod: DocumentedJsonSchema.DocumentedCoProd, referencedSchemas: Set[String]): Schema = {
+    val alternativesSchemas =
+      coprod.alternatives.map { case (tag, record) => tag -> toSchema(record, Some(coprod), referencedSchemas) }
     Schema.OneOf(coprod.discriminatorName, alternativesSchemas, None)
   }
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -39,6 +39,29 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
     }
   }
 
+  "Enumerations" in {
+    val expectedSchema =
+      Schema.Enum(Schema.Primitive("string", None), "Red" :: "Blue" :: Nil)
+    Fixtures.toSchema(Fixtures.Enum.colorSchema) shouldBe expectedSchema
+  }
+
+  "Recursive types" in {
+    val recSchema =
+      Schema.Reference(
+        "Rec",
+        Some(Schema.Object(
+          Schema.Property("next", Schema.Reference("Rec", None), isRequired = false, description = None) :: Nil,
+          description = None
+        ))
+      )
+    val expectedSchema =
+      Schema.Object(
+        Schema.Property("next", recSchema, isRequired = false, description = None) :: Nil,
+        description = None
+      )
+    Fixtures.toSchema(Fixtures.recSchema) shouldBe expectedSchema
+  }
+
   "Text response" should {
     "be properly encoded" in {
       val reqBody = Fixtures.documentation.paths("/textRequestEndpoint").operations("post").requestBody

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -39,4 +39,11 @@ class JsonSchemasTest extends FreeSpec {
     assert(DocumentedJsonSchemas.Enum.colorSchema == expectedSchema)
   }
 
+  "recursive" in {
+    DocumentedJsonSchemas.recSchema match {
+      case DocumentedRecord(List(Field("next", tpe, true, None)), _) => assert(tpe.isInstanceOf[LazySchema])
+      case _ => fail(s"Unexpected type for 'recSchema': ${DocumentedJsonSchemas.recSchema}")
+    }
+  }
+
 }


### PR DESCRIPTION
It is now possible to refer to a currently being defined JSON schema
by wrapping it in a `lazySchema` constructor:

~~~ scala
case class Rec(next: Option[Rec])

val recSchema: JsonSchema[Rec] = (
  optField("next")(lazySchema(recSchema, "Rec"))
).invmap(Rec)(_.next)
~~~

The `json-schema-generic` module does not use this construct, therefore
it does not support recursive data types.