### PR TITLE
Implement JsonSchema[OpenApi] instance

### DIFF
--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
@@ -65,4 +65,12 @@ trait EndpointsDocs extends Endpoints {
   val someResource: Endpoint[Int, String] =
     endpoint(get(path / "some-resource" / segment[Int]()), textResponse())
   //#endpoint-definition
+
+  //#documented-endpoint-definition
+  val someDocumentedResource: Endpoint[Int, String] =
+    endpoint(
+      get(path / "some-resource" / segment[Int]("id")),
+      textResponse(docs = Some("The content of the resource"))
+    )
+  //#documented-endpoint-definition
 }

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -101,7 +101,7 @@ val `example-quickstart-server` =
   project.in(file("examples/quickstart/server"))
     .settings(noPublishSettings ++ `scala 2.11 to 2.12`)
     .settings(libraryDependencies += "org.scala-stm" %% "scala-stm" % "0.9")
-    .dependsOn(`example-quickstart-endpoints-jvm`, `play-server-circe`, `openapi-jvm`)
+    .dependsOn(`example-quickstart-endpoints-jvm`, `play-server-playjson`, `openapi-jvm`)
 
 // Basic example
 val `example-basic-shared` = {
@@ -135,7 +135,7 @@ val `example-basic-shared` = {
       unmanagedResourceDirectories in Compile += assetsDirectory(baseDirectory.value.getParentFile)
     )
     .enablePlugins(ScalaJSPlugin)
-    .dependsOnLocalCrossProjects("algebra", "algebra-circe", "openapi")
+    .dependsOnLocalCrossProjects("algebra", "algebra-circe")
 }
 
 val `example-basic-shared-jvm` = `example-basic-shared`.jvm
@@ -160,7 +160,7 @@ val `example-basic-play-server` =
       libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25",
       libraryDependencies += "com.typesafe.play" %% "play" % playVersion
     )
-    .dependsOn(`example-basic-shared-jvm`, `play-server-circe`)
+    .dependsOn(`example-basic-shared-jvm`, `play-server`, `algebra-playjson-jvm`, `json-schema-playjson-jvm`, `openapi-jvm`)
 
 val `example-basic-akkahttp-server` =
   project.in(file("examples/basic/akkahttp-server"))
@@ -322,7 +322,7 @@ val `example-documented` =
         )
       }.taskValue
     )
-    .dependsOn(`play-server-circe`, `json-schema-generic-jvm`, `openapi-jvm`)
+    .dependsOn(`play-server-playjson`, `json-schema-generic-jvm`, `openapi-jvm`)
 
 val `example-authentication` =
   project.in(file("examples/authentication"))

--- a/documentation/examples/basic/play-server/src/main/scala/sample/Api.scala
+++ b/documentation/examples/basic/play-server/src/main/scala/sample/Api.scala
@@ -5,7 +5,7 @@ import endpoints.play.server._
 import scala.concurrent.Future
 import scala.util.Random
 
-class Api(protected val playComponents: PlayComponents) extends ApiAlg with AssetsAlg with Endpoints with circe.JsonEntitiesFromCodec
+class Api(protected val playComponents: PlayComponents) extends ApiAlg with AssetsAlg with Endpoints with JsonEntitiesFromCodec
   with Assets with BasicAuthentication {
 
   val routes = routesFromEndpoints(

--- a/documentation/examples/basic/play-server/src/main/scala/sample/Server.scala
+++ b/documentation/examples/basic/play-server/src/main/scala/sample/Server.scala
@@ -3,6 +3,7 @@ package sample
 import _root_.play.api.http.ContentTypes.HTML
 import _root_.play.api.mvc.{Handler, RequestHeader, Results}
 import _root_.play.api.routing.sird._
+import _root_.play.api.libs.json.Json
 import _root_.play.core.server.ServerConfig
 import controllers.{AssetsBuilder, AssetsConfiguration, DefaultAssetsMetadata}
 import endpoints.play.server.{DefaultPlayComponents, HttpServer}
@@ -35,9 +36,8 @@ object Server extends App with Results {
     case GET(p"/assets/sample-client-fastopt.js") =>
       assets.versioned("/", "sample-client-fastopt.js")
     case GET(p"/api/description") => action {
-      import endpoints.play.server.circe.Util.circeJsonWriteable
-      import io.circe.syntax._
-      Ok(sample.openapi.DocumentedApi.documentation.asJson)
+      import sample.openapi.OpenApiEncoder.JsonSchema._
+      Ok(Json.toJson(sample.openapi.DocumentedApi.documentation))
     }
     case GET(p"/api/ui") => action {
       val html =

--- a/documentation/examples/basic/play-server/src/main/scala/sample/openapi/DocumentedApi.scala
+++ b/documentation/examples/basic/play-server/src/main/scala/sample/openapi/DocumentedApi.scala
@@ -20,3 +20,5 @@ object DocumentedApi
     )
 
 }
+
+object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.playjson.JsonSchemas

--- a/documentation/examples/basic/play-server/src/main/scala/sample/play/server/DocumentedApi.scala
+++ b/documentation/examples/basic/play-server/src/main/scala/sample/play/server/DocumentedApi.scala
@@ -8,7 +8,7 @@ class DocumentedApi(protected val playComponents: PlayComponents)
   extends sample.algebra.DocumentedApi
     with play.server.Endpoints
     with play.server.BasicAuthentication
-    with play.server.circe.JsonEntitiesFromCodec { parent =>
+    with play.server.JsonEntitiesFromCodec { parent =>
 
   lazy val routes = routesFromEndpoints(
     item.implementedBy(id => if (id == "123abc") Some(Item("foo")) else None),

--- a/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
+++ b/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
@@ -28,7 +28,7 @@ trait DocumentedApi
       path / "admin",
       requestEntity = emptyRequest,
       response = emptyResponse(Some("Administration page")),
-      summary = Some("Authentication error")
+      summary = Some("Authentication endpoint")
     )
 
 }

--- a/documentation/examples/cqrs/public-server/src/main/scala/cqrs/publicserver/BootstrapEndpoints.scala
+++ b/documentation/examples/cqrs/public-server/src/main/scala/cqrs/publicserver/BootstrapEndpoints.scala
@@ -1,7 +1,7 @@
 package cqrs.publicserver
 
-import endpoints.openapi.model.OpenApi
-import endpoints.play.server.circe.JsonEntities
+import endpoints.openapi.model.{OpenApi, OpenApiSchemas}
+import endpoints.play.server.circe.JsonSchemaEntities
 import endpoints.play.server.{Assets, Endpoints, PlayComponents}
 import play.api.routing.{Router => PlayRouter}
 import play.twirl.api.{Html, StringInterpolation}
@@ -9,7 +9,7 @@ import play.twirl.api.{Html, StringInterpolation}
 /**
   * These endpoints serve the web page and the assets.
   */
-class BootstrapEndpoints(protected val playComponents: PlayComponents) extends Endpoints with Assets with JsonEntities {
+class BootstrapEndpoints(protected val playComponents: PlayComponents) extends Endpoints with Assets with JsonSchemaEntities with OpenApiSchemas {
 
   val index: Endpoint[Unit, Html] =
     endpoint(get(path), htmlResponse)
@@ -17,8 +17,10 @@ class BootstrapEndpoints(protected val playComponents: PlayComponents) extends E
   val assets: Endpoint[AssetRequest, AssetResponse] =
     assetsEndpoint(path / "assets" / assetSegments())
 
-  val documentation: Endpoint[Unit, OpenApi] =
+  val documentation: Endpoint[Unit, OpenApi] = {
+    import JsonSchema._
     endpoint(get(path / "documentation"), jsonResponse[OpenApi]())
+  }
 
   val routes: PlayRouter.Routes =
     routesFromEndpoints(

--- a/documentation/examples/documented/src/main/scala/counter/Counter.scala
+++ b/documentation/examples/documented/src/main/scala/counter/Counter.scala
@@ -11,7 +11,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import endpoints.play.server.{DefaultPlayComponents, HttpServer, PlayComponents}
 import play.core.server.ServerConfig
 
-//#domain
 // Our domain model just contains a counter value
 case class Counter(value: Int)
 
@@ -23,7 +22,6 @@ object Operation {
   // Add `delta` to the counter value
   case class Add(delta: Int) extends Operation
 }
-//#domain
 
 // Description of the HTTP API
 //#documented-endpoints
@@ -66,11 +64,9 @@ trait CounterEndpoints
   implicit lazy val jsonSchemaOperation: JsonSchema[Operation] = genericJsonSchema
 
 }
-
 //#documented-endpoints
 
 // OpenAPI documentation for the HTTP API described in `CounterEndpoints`
-//#openapi
 import endpoints.openapi
 import endpoints.openapi.model.{Info, OpenApi}
 
@@ -85,17 +81,14 @@ object CounterDocumentation
     )(currentValue, update)
 }
 
-//#openapi
-
 // Implementation of the HTTP API and its business logic
 import endpoints.play
 
 class CounterServer(protected val playComponents: PlayComponents)
   extends CounterEndpoints
     with play.server.Endpoints
-    with play.server.circe.JsonSchemaEntities { parent =>
+    with play.server.playjson.JsonSchemaEntities { parent =>
 
-  //#business-logic
   // Internal state of our counter
   private val value = new AtomicInteger(0)
 
@@ -120,11 +113,9 @@ class CounterServer(protected val playComponents: PlayComponents)
     }
 
   )
-//#business-logic
 }
 
 object Main {
-  //#entry-point
   // JVM entry point that starts the HTTP server
   def main(args: Array[String]): Unit = {
     val playConfig = ServerConfig(port = sys.props.get("http.port").map(_.toInt).orElse(Some(9000)))
@@ -134,7 +125,10 @@ object Main {
   }
 
   class DocumentationServer(protected val playComponents: PlayComponents)
-    extends play.server.Endpoints with openapi.model.OpenApiSchemas with play.server.circe.JsonSchemaEntities with play.server.Assets {
+    extends play.server.Endpoints
+      with play.server.playjson.JsonSchemaEntities
+      with play.server.Assets
+      with openapi.model.OpenApiSchemas {
 
     // HTTP endpoint serving documentation. Uses the HTTP verb ''GET'' and the path
     // ''/documentation.json''. Returns an OpenAPI document.
@@ -155,5 +149,4 @@ object Main {
     lazy val digests = AssetsDigests.digests
   }
 
-  //#entry-point
 }

--- a/documentation/examples/documented/src/main/scala/counter/Counter.scala
+++ b/documentation/examples/documented/src/main/scala/counter/Counter.scala
@@ -134,7 +134,7 @@ object Main {
   }
 
   class DocumentationServer(protected val playComponents: PlayComponents)
-    extends play.server.Endpoints with play.server.circe.JsonEntities with play.server.Assets {
+    extends play.server.Endpoints with openapi.model.OpenApiSchemas with play.server.circe.JsonSchemaEntities with play.server.Assets {
 
     // HTTP endpoint serving documentation. Uses the HTTP verb ''GET'' and the path
     // ''/documentation.json''. Returns an OpenAPI document.

--- a/documentation/examples/quickstart/server/src/main/scala/quickstart/CounterServer.scala
+++ b/documentation/examples/quickstart/server/src/main/scala/quickstart/CounterServer.scala
@@ -14,7 +14,7 @@ import play.api.routing.Router
 class CounterServer(protected val playComponents: PlayComponents)
   extends CounterEndpoints
     with server.Endpoints
-    with server.circe.JsonSchemaEntities {
+    with server.playjson.JsonSchemaEntities {
 
   /** Simple implementation of an in-memory counter */
   val counter = Ref(0)

--- a/documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala
+++ b/documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala
@@ -1,7 +1,7 @@
 package quickstart
 
 //#relevant-code
-import endpoints.openapi.model.OpenApi
+import endpoints.openapi.model.{OpenApi, OpenApiSchemas}
 import endpoints.play.server
 //#main-only
 import endpoints.play.server.{DefaultPlayComponents, HttpServer, PlayComponents}
@@ -19,7 +19,7 @@ object Main extends App {
 // Additional route for serving the OpenAPI documentation
 class DocumentationServer(val playComponents: PlayComponents)
   extends server.Endpoints
-    with server.circe.JsonEntities {
+    with OpenApiSchemas with server.playjson.JsonSchemaEntities {
 
   val routes = routesFromEndpoints(
     endpoint(get(path / "documentation.json"), jsonResponse[OpenApi]())

--- a/documentation/manual/src/doc/interpreters/openapi.md
+++ b/documentation/manual/src/doc/interpreters/openapi.md
@@ -14,7 +14,7 @@ to generate an OpenAPI document.
 
 Given the following endpoint definition:
 
-~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala#endpoint-definition
+~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala#documented-endpoint-definition
 ~~~
 
 It can be documented as follows:
@@ -24,15 +24,59 @@ It can be documented as follows:
 
 The value returned by the `openApi` method has type `endpoints.openapi.models.OpenApi`,
 which is an abstract model for OpenAPI documents. You can generate a JSON
-representation of it, which you can then publish by your server, by
-serializing it into JSON. For instance, using circe:
+representation of it, which you can then publish to your server. For instance, using circe:
 
 ~~~ scala src=../../../../../openapi/openapi/src/test/scala/endpoints/openapi/EndpointsDocs.scala#documentation-asjson
 ~~~
 
+The `OpenApiSchemas` trait (mixed into the top-level object) provides a
+[`JsonSchema`](/algebras/json-schemas.md) instance for the `OpenApi` model, which
+is used by the circe `JsonSchemas` interpreter to turn the `api` value into a `Json`
+document.
+
+Finally, the `apiJson` value contains the following JSON document:
+
+~~~ json
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "title" : "API to get some resource",
+    "version" : "1.0"
+  },
+  "paths" : {
+    "/some-resource/{id}" : {
+      "get" : {
+        "parameters" : [
+          {
+            "name" : "id",
+            "in" : "path",
+            "schema" : {
+              "type" : "integer"
+            },
+            "required" : true
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "description" : "The content of the resource",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+~~~
+
 ## JSON entities
 
-To properly document the underlying JSON schema of your JSON entities,
+To properly document the underlying JSON schema of your [JSON entities](/algebras/json-entities.md),
 you have to define these schemas by using the
 [JsonSchemaEntities](/algebras/json-entities.md#jsonschemaentities)
 algebra (and its corresponding interpreter).

--- a/documentation/manual/src/doc/quick-start.md
+++ b/documentation/manual/src/doc/quick-start.md
@@ -55,7 +55,7 @@ val client =
 val server =
   project.settings(
     libraryDependencies ++= Seq(
-      "org.julienrf" %% "endpoints-play-server-circe" % "{{version}}",
+      "org.julienrf" %% "endpoints-play-server-playjson" % "{{version}}",
       "org.julienrf" %% "endpoints-openapi" % "{{version}}",
       "org.scala-stm" %% "scala-stm" % "0.8"
     )
@@ -74,7 +74,7 @@ circe’s encoders and decoders.
 
 Finally, the `server` project uses a server interpreter backed by [Play framework](interpreters/play.md),
 which also turns the JSON schemas defined in the `shared` project into
-circe’s encoders and decoders (like the `client` project does), as well as
+Play JSON encoders and decoders, as well as
 an interpreter producing OpenAPI documents.
 It also uses the scala-stm library for implementing the business logic.
 

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -187,4 +187,11 @@ trait JsonSchemas
       io.circe.Encoder.encodeIterable[A, C](jsonSchema.encoder, implicitly),
       io.circe.Decoder.decodeIterable[A, C](jsonSchema.decoder, cbf)
     )
+
+  implicit def mapJsonSchema[A](implicit jsonSchema: JsonSchema[A]): JsonSchema[Map[String, A]] =
+    JsonSchema(
+      io.circe.Encoder.encodeMap[String, A](implicitly, jsonSchema.encoder),
+      io.circe.Decoder.decodeMap[String, A](implicitly, jsonSchema.decoder)
+    )
+
 }

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -115,7 +115,7 @@ trait JsonSchemas
   // FIXME Check that this is the correct way to model optional fields with circe
   def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]] =
     Record(
-      io.circe.ObjectEncoder.instance[Option[A]](a => JsonObject.singleton(name, io.circe.Encoder.encodeOption(tpe.encoder).apply(a))),
+      io.circe.ObjectEncoder.instance[Option[A]](maybeA => JsonObject.fromIterable(maybeA.map(a => name -> tpe.encoder.apply(a)))),
       io.circe.Decoder.instance[Option[A]](cursor => io.circe.Decoder.decodeOption(tpe.decoder).tryDecode(cursor.downField(name)))
     )
 
@@ -146,7 +146,10 @@ trait JsonSchemas
   def zipRecords[A, B](recordA: Record[A], recordB: Record[B]): Record[(A, B)] = {
     val encoder =
       io.circe.ObjectEncoder.instance[(A, B)] { case (a, b) =>
-        recordA.encoder.apply(a).deepMerge(recordB.encoder.apply(b)).asObject.get
+        // For some reason, `deepMerge` puts the fields of its left-hand-side *after*
+        // the fields of its right-hand-side. Hence the inversion between `recordA`
+        // and `recordB`.
+        recordB.encoder.apply(b).deepMerge(recordA.encoder.apply(a)).asObject.get
       }
     val decoder = new io.circe.Decoder[(A, B)] {
       def apply(c: HCursor) = recordA.decoder.product(recordB.decoder).apply(c)

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -43,7 +43,7 @@ class JsonSchemasTest extends FreeSpec {
   }
 
   "recursive type" in {
-    val json = Json.obj("next" -> Json.obj("next" -> Json.obj("next" -> Json.Null)))
+    val json = Json.obj("next" -> Json.obj("next" -> Json.obj()))
     val rec = JsonSchemasCodec.Rec(Some(JsonSchemasCodec.Rec(Some(JsonSchemasCodec.Rec(None)))))
     assert(JsonSchemasCodec.recSchema.decoder.decodeJson(json).right.exists(_ == rec))
     assert(JsonSchemasCodec.recSchema.encoder(rec) == json)

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -91,6 +91,10 @@ class JsonSchemasTest extends FreeSpec {
                                              jsonSchema: String,
                                              cbf: CanBuildFrom[_, A, C[A]]
                                             ): String = s"[$jsonSchema]"
+
+      def mapJsonSchema[A](implicit
+                           jsonSchema: String
+                          ): String = s"{$jsonSchema}"
   }
 
   "case class" in {

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -128,6 +128,12 @@ trait JsonSchemas
       Writes.traversableWrites(jsonSchema.writes)
     )
 
+  implicit def mapJsonSchema[A](implicit jsonSchema: JsonSchema[A]): JsonSchema[Map[String, A]] =
+    JsonSchema(
+      Reads.mapReads(jsonSchema.reads),
+      Writes.mapWrites(jsonSchema.writes)
+    )
+
   def zipRecords[A, B](recordA: Record[A], recordB: Record[B]): Record[(A, B)] = {
     val reads = (recordA.reads and recordB.reads).tupled
     val writes = new OWrites[(A, B)] {

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -184,6 +184,14 @@ class JsonSchemasTest extends FreeSpec {
     assertError(jsonSchema, input, "error.expected.jsstring")
   }
 
+  "map with string key" in {
+    testRoundtrip(
+      field[Map[String, Boolean]]("relevant"),
+      Json.obj("relevant" -> Json.obj("no" -> JsBoolean(false), "yes" -> JsBoolean(true))),
+      Map("no" -> false, "yes" -> true)
+    )
+  }
+
   "tagged single record" in {
     testRoundtrip(
       field[Double]("x").tagged("Rectangle"),

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -189,4 +189,7 @@ trait JsonSchemas {
     cbf: CanBuildFrom[_, A, C[A]]
   ): JsonSchema[C[A]]
 
+  /** A JSON schema for maps with string keys */
+  implicit def mapJsonSchema[A](implicit jsonSchema: JsonSchema[A]): JsonSchema[Map[String, A]]
+
 }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -68,4 +68,6 @@ trait JsonSchemasTest extends JsonSchemas {
     optField("next")(lazySchema(recSchema, "Rec"))
   ).invmap(Rec)(_.next)
 
+  val intDictionary: JsonSchema[Map[String, Int]] = mapJsonSchema[Int]
+
 }

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -5,11 +5,15 @@ lazy val openapi =
   crossProject.crossType(CrossType.Pure).in(file("openapi"))
     .settings(publishSettings ++ `scala 2.11 to 2.12`: _*)
     .settings(
-      name := "endpoints-openapi",
-      libraryDependencies += "io.circe" %%% "circe-core" % circeVersion
+      name := "endpoints-openapi"
     )
     .dependsOnLocalCrossProjects("json-schema-generic")
-    .dependsOnLocalCrossProjectsWithScope("algebra" -> "test->test;compile->compile", "json-schema" -> "test->test;compile->compile")
+    .dependsOnLocalCrossProjectsWithScope(
+      "algebra" -> "test->test;compile->compile",
+      "json-schema" -> "test->test;compile->compile",
+      "json-schema-circe" -> "test->test",
+      "json-schema-playjson" -> "test->test"
+    )
 
 lazy val `openapi-js` = openapi.js
 lazy val `openapi-jvm` = openapi.jvm

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -88,7 +88,7 @@ trait Endpoints
         description,
         parameters,
         request.entity.map(r => RequestBody(r.documentation, r.content)),
-        response.map(r => r.status -> Response(r.documentation, r.content)).toMap,
+        response.map(r => r.status.toString -> Response(r.documentation, r.content)).toMap,
         tags,
         security = Nil // might be refined later by specific interpreters
       )
@@ -120,23 +120,24 @@ trait Endpoints
     } yield recSchema
 
     allReferencedSchemas
-      .collect { case Schema.Reference(name, Some(original)) => name -> original }
+      .collect { case Schema.Reference(name, Some(original), _) => name -> original }
       .toMap
   }
 
   private def captureReferencedSchemasRec(schema: Schema): Seq[Schema.Reference] =
     schema match {
-      case Schema.Object(properties, _) =>
-        properties.map(_.schema).flatMap(captureReferencedSchemasRec)
-      case Schema.Array(elementType) =>
+      case Schema.Object(properties, additionalProperties, _) =>
+        properties.map(_.schema).flatMap(captureReferencedSchemasRec) ++
+          additionalProperties.toList.flatMap(captureReferencedSchemasRec)
+      case Schema.Array(elementType, _) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Enum(elementType, _) =>
+      case Schema.Enum(elementType, _, _) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Primitive(_, _) =>
+      case Schema.Primitive(_, _, _) =>
         Nil
       case Schema.OneOf(_, alternatives, _) =>
         alternatives.map(_._2).flatMap(captureReferencedSchemasRec)
-      case Schema.AllOf(schemas) =>
+      case Schema.AllOf(schemas, _) =>
         schemas.flatMap {
           case _: Schema.Reference => Nil
           case s => captureReferencedSchemasRec(s)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -115,4 +115,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
     jsonSchema: JsonSchema[A],
     cbf: CanBuildFrom[_, A, C[A]]
   ): JsonSchema[C[A]] = Array(jsonSchema)
+
+  def mapJsonSchema[A](implicit jsonSchema: DocumentedJsonSchema): DocumentedJsonSchema = ??? // TODO
+
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -25,7 +25,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
   object DocumentedJsonSchema {
 
-    case class DocumentedRecord(fields: List[Field], name: Option[String] = None) extends DocumentedJsonSchema
+    case class DocumentedRecord(fields: List[Field], additionalProperties: Option[DocumentedJsonSchema] = None, name: Option[String] = None) extends DocumentedJsonSchema
     case class Field(name: String, tpe: DocumentedJsonSchema, isOptional: Boolean, documentation: Option[String])
 
     case class DocumentedCoProd(alternatives: List[(String, DocumentedRecord)],
@@ -36,7 +36,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
     case class Array(elementType: DocumentedJsonSchema) extends DocumentedJsonSchema
 
-    case class DocumentedEnum(elementType: DocumentedJsonSchema, values: Seq[String]) extends DocumentedJsonSchema
+    case class DocumentedEnum(elementType: DocumentedJsonSchema, values: List[String]) extends DocumentedJsonSchema
 
     // A documented JSON schema that is unevaluated unless its `value` is accessed
     sealed trait LazySchema extends DocumentedJsonSchema {
@@ -51,7 +51,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
   }
 
   def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: JsonSchema[String]): DocumentedEnum =
-    DocumentedEnum(tpe, values.map(encode))
+    DocumentedEnum(tpe, values.map(encode).toList)
 
   def named[A, S[_] <: DocumentedJsonSchema](schema: S[A], name: String): S[A] = {
     import DocumentedJsonSchema._
@@ -116,6 +116,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
     cbf: CanBuildFrom[_, A, C[A]]
   ): JsonSchema[C[A]] = Array(jsonSchema)
 
-  def mapJsonSchema[A](implicit jsonSchema: DocumentedJsonSchema): DocumentedJsonSchema = ??? // TODO
+  def mapJsonSchema[A](implicit jsonSchema: DocumentedJsonSchema): DocumentedJsonSchema =
+    DocumentedRecord(fields = Nil, additionalProperties = Some(jsonSchema))
 
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
@@ -21,9 +21,11 @@ trait Responses
     */
   case class DocumentedResponse(status: Int, documentation: String, content: Map[String, MediaType])
 
-  def emptyResponse(docs: Documentation): Response[Unit] = DocumentedResponse(200, docs.getOrElse(""), Map.empty) :: Nil
+  def emptyResponse(docs: Documentation): Response[Unit] =
+    DocumentedResponse(200, docs.getOrElse(""), Map.empty) :: Nil
 
-  def textResponse(docs: Documentation): Response[String] = DocumentedResponse(200, docs.getOrElse(""), Map("text/plain" -> MediaType(None))) :: Nil
+  def textResponse(docs: Documentation): Response[String] =
+    DocumentedResponse(200, docs.getOrElse(""), Map("text/plain" -> MediaType(Some(model.Schema.simpleString)))) :: Nil
 
   def wheneverFound[A](response: Response[A], notFoundDocs: Documentation): Response[Option[A]] =
     DocumentedResponse(404, notFoundDocs.getOrElse(""), content = Map.empty) :: response

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApiSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApiSchemas.scala
@@ -2,14 +2,31 @@ package endpoints.openapi.model
 
 import endpoints.algebra.JsonSchemas
 
+/**
+  * Provides an implicit instance of `JsonSchema[OpenApi]` which
+  * can be interpreted by a proper JSON encoder (e.g.,
+  * `endpoints-json-schema-playjson`) to produce a JSON document
+  * out of an `OpenApi` value.
+  */
 trait OpenApiSchemas extends JsonSchemas {
 
+  val openapiVersion = "3.0.0"
+
   implicit lazy val openApiSchema: JsonSchema[OpenApi] = (
-      field[String]("openapi") zip
-      field[Info]("info") zip
-      field[Map[String, PathItem]]("paths") zip
-      optField[Components]("components")
-    ).invmap[OpenApi](notImplemented)(o => ((("3.0.0", o.info), o.paths), if (o.components.schemas.isEmpty) None else Some(o.components))) // TODO pull openapi version into model?
+    field[String]("openapi") zip
+    field[Info]("info") zip
+    field[Map[String, PathItem]]("paths") zip
+    optField[Components]("components")
+  ).invmap[OpenApi]{
+    // TODO Reject if openapi version does not match our openapiVersion
+    case (((_, info), paths), components) => OpenApi(info, paths, components.getOrElse(Components(Map.empty, Map.empty)))
+  } {
+    o =>
+      val components =
+        if (o.components.schemas.isEmpty && o.components.securitySchemes.isEmpty) None
+        else Some(o.components)
+      (((openapiVersion, o.info), o.paths), components)
+  }
 
   implicit lazy val infoSchema: JsonSchema[Info] = (
       field[String]("title") zip
@@ -17,37 +34,178 @@ trait OpenApiSchemas extends JsonSchemas {
     ).invmap(Info.tupled)(info => (info.title, info.version))
 
   implicit lazy val pathItemSchema: JsonSchema[PathItem] =
-    mapJsonSchema(operationSchema).invmap(notImplemented)(_.operations)
+    mapJsonSchema[Operation].invmap(PathItem(_))(_.operations)
 
   implicit lazy val operationSchema: JsonSchema[Operation] = (
-    optField[String]("summary") zip
-    optField[String]("description")
-  ).invmap[Operation](notImplemented)(o => (o.summary, o.description))
+    optField [String]                    ("summary")     zip
+    optField [String]                    ("description") zip
+    optField [List[Parameter]]           ("parameters")  zip
+    optField [RequestBody]               ("requestBody") zip
+       field [Map[String, Response]]     ("responses")   zip
+    optField [List[String]]              ("tags")        zip
+    optField [List[SecurityRequirement]] ("security")
+  ).invmap[Operation] {
+    case ((((((summary, description), parameters), requestBody), responses), tags), security) =>
+      Operation(summary, description, parameters.getOrElse(Nil), requestBody, responses, tags.getOrElse(Nil), security.getOrElse(Nil))
+  } {
+    o => ((((((o.summary, o.description), if (o.parameters.isEmpty) None else Some(o.parameters)), o.requestBody), o.responses), if (o.tags.isEmpty) None else Some(o.tags)), if (o.security.isEmpty) None else Some(o.security))
+  }
 
-  implicit lazy val componentsSchema: JsonSchema[Components] =
-    field[Map[String, Schema]]("schemas")
-      .invmap[Components](notImplemented)(_.schemas)
+  implicit lazy val parameterSchema: JsonSchema[Parameter] = (
+       field [String]  ("name")        zip
+       field [In]      ("in")          zip
+       field [Schema]  ("schema")      zip
+    optField [String]  ("description") zip
+    optField [Boolean] ("required")
+  ).invmap[Parameter] {
+    case ((((name, in), schema), description), required) => Parameter(name, in, required.contains(true), description, schema)
+  } {
+    p => ((((p.name, p.in), p.schema), p.description), if (p.required) Some(true) else None)
+  }
 
+  implicit lazy val inSchema: JsonSchema[In] =
+    enumeration[In](In.values) {
+      case In.Cookie => "cookie"
+      case In.Header => "header"
+      case In.Path   => "path"
+      case In.Query  => "query"
+    }
+
+  implicit lazy val requestBodySchema: JsonSchema[RequestBody] = (
+       field [Map[String, MediaType]] ("content")     zip
+    optField [String]                 ("description")
+  ).invmap[RequestBody] {
+    case (content, description) => RequestBody(description, content)
+  } {
+    r => (r.content, r.description)
+  }
+
+  implicit lazy val mediaTypeSchema: JsonSchema[MediaType] = (
+    optField [Schema] ("schema")
+  ).invmap[MediaType](MediaType(_))(_.schema)
+
+  implicit lazy val responseSchema: JsonSchema[Response] = (
+       field [String]                 ("description") zip
+    optField [Map[String, MediaType]] ("content")
+  ).invmap[Response] {
+    case (description, content) => Response(description, content.getOrElse(Map.empty))
+  } {
+    r => (r.description, if (r.content.isEmpty) None else Some(r.content))
+  }
+
+  implicit lazy val securityRequirementSchema: JsonSchema[SecurityRequirement] =
+    mapJsonSchema[List[String]].invmap[SecurityRequirement] {
+      s =>
+        val (name, scopes) = s.head // TODO Better failure handling
+        SecurityRequirement(name, ???, scopes) // TODO We’d need the `Components` to look up for the `SecurityScheme`
+    } {
+      s => Map(s.name -> s.scopes)
+    }
+
+  implicit lazy val componentsSchema: JsonSchema[Components] = (
+    field [Map[String, Schema]]         ("schemas")         zip // FIXME Optional?
+    field [Map[String, SecurityScheme]] ("securitySchemes") // FIXME Optional?
+  ).invmap[Components] {
+    case (schemas, securitySchemes) => Components(schemas, securitySchemes)
+  } {
+    components => (components.schemas, components.securitySchemes)
+  }
+
+  private def schemaSchemaRef: JsonSchema[Schema] = lazySchema(schemaSchema, "Schema")
   implicit lazy val schemaSchema: JsonSchema[Schema] = (
-    optField[String]("type") zip
-    optField[String]("format") zip
-    optField[Schema]("items")
-  ).invmap[Schema](notImplemented) { schema =>
+    optField [String]              ("type")          zip
+    optField [String]              ("format")        zip
+    optField [Schema]              ("items")(schemaSchemaRef) zip
+    optField [Map[String, Schema]] ("properties")(mapJsonSchema(schemaSchemaRef)) zip
+    optField [Schema]              ("additionalProperties")(schemaSchemaRef) zip
+    optField [List[String]]        ("required")      zip
+    optField [List[Schema]]        ("oneOf")(arrayJsonSchema[List, Schema](schemaSchemaRef, implicitly)) zip
+    optField [DiscriminatorFields] ("discriminator") zip
+    optField [List[Schema]]        ("allOf")(arrayJsonSchema[List, Schema](schemaSchemaRef, implicitly)) zip
+    optField [List[String]]        ("enum")          zip
+    optField [String]              ("$ref")          zip
+    optField [String]              ("description")
+  ).invmap[Schema]{
+    case (((((((((((Some("integer"), format), _), _), _), _), _), _), _), _), _), description) => Schema.Primitive("integer", format, description)
+    case (((((((((((Some("string"), format), _), _), _), _), _), _), _), _), _), description)  => Schema.Primitive("string", format, description)
+    case (((((((((((Some("object"), _), _), Some(props)), additionalProperties), required), _), _), _), _), _), description) =>
+      // HACK We don’t decode properties descriptions
+      val properties =
+        props.map { case (n, s) => Schema.Property(n, s, required.forall(_.contains(n)), None) }.toList
+      Schema.Object(properties, additionalProperties, description)
+    case _ => ??? // TODO Complete. This is not really important because we don’t claim that we support *decoding* OpenAPI documents
+  } { schema =>
     val fields = schemaToFields(schema)
-    ((fields.`type`, fields.format), fields.items)
+    (((((((((((fields.`type`, fields.format), fields.items), fields.properties), fields.additionalProperties), fields.required.map(_.toList)), fields.oneOf), fields.discriminator), fields.allOf), fields.enum), fields.ref), fields.description)
   }
 
   private def schemaToFields(schema: Schema): SchemaFields = schema match {
-    case Schema.Primitive(name, None) => SchemaFields(`type` = Some(name))
-    case Schema.Primitive(name, Some(format)) => SchemaFields(`type` = Some(name), format = Some(format))
-    case Schema.Array(itemsSchema) => SchemaFields(`type` = Some("array"), items = Some(itemsSchema))
+    case Schema.Primitive(name, format, description) => SchemaFields(`type` = Some(name), format, description = description)
+    case Schema.Array(itemsSchema, description) => SchemaFields(`type` = Some("array"), items = Some(itemsSchema), description = description)
+    case Schema.Object(props, additionalProperties, descr) =>
+      val propsMap = props.map(p => p.name -> p.schema.withDefinedDescription(p.description)).toMap
+      val required = props.filter(_.isRequired).map(_.name).toSet
+      SchemaFields(
+        `type` = Some("object"),
+        properties = Some(propsMap),
+        additionalProperties = additionalProperties,
+        required = if (required.isEmpty) None else Some(required),
+        description = descr
+      )
+    case Schema.OneOf(discriminatorName, alternatives, description) =>
+      val mapping =
+        alternatives.collect { case (tag, ref: Schema.Reference) => tag -> Schema.Reference.toRefPath(ref.name) }.toMap
+      val discriminatorFields =
+        DiscriminatorFields(
+          propertyName = discriminatorName,
+          mapping = mapping
+        )
+      SchemaFields(oneOf = Some(alternatives.map(_._2)), discriminator = Some(discriminatorFields), description = description)
+    case Schema.AllOf(schemas, description) => SchemaFields(allOf = Some(schemas), description = description)
+    case Schema.Enum(elementType, values, description) =>
+      schemaToFields(elementType.withDefinedDescription(description)).copy(enum = Some(values))
+    case Schema.Reference(name, _, description) => SchemaFields(ref = Some(Schema.Reference.toRefPath(name)), description = description)
   }
-  case class SchemaFields(
-                           `type`: Option[String] = None,
-                           format: Option[String] = None,
-                           items: Option[Schema] = None
-                         )
 
-  private def notImplemented(a: Any): Nothing = ???
+  // Schemas can be encoded in various forms. Instead of using a sealed
+  // trait to enumerate all the alternatives, we use a single `SchemaFields`
+  // case class with all fields optionals.
+  case class SchemaFields(
+    `type`: Option[String] = None,
+    format: Option[String] = None,
+    items: Option[Schema] = None,
+    properties: Option[Map[String, Schema]] = None,
+    additionalProperties: Option[Schema] = None,
+    required: Option[Set[String]] = None,
+    oneOf: Option[List[Schema]] = None,
+    discriminator: Option[DiscriminatorFields] = None,
+    allOf: Option[List[Schema]] = None,
+    enum: Option[List[String]] = None,
+    ref: Option[String] = None,
+    description: Option[String] = None
+  )
+  case class DiscriminatorFields(propertyName: String, mapping: Map[String, String])
+
+  implicit lazy val discriminatorSchema: JsonSchema[DiscriminatorFields] = (
+    field [String]              ("propertyName") zip
+    field [Map[String, String]] ("mapping")
+  ).invmap[DiscriminatorFields] {
+    case (propertyName, mapping) => DiscriminatorFields(propertyName, mapping)
+  } {
+    d => (d.propertyName, d.mapping)
+  }
+
+  implicit lazy val securitySchemeSchema: JsonSchema[SecurityScheme] = (
+       field [String] ("type")         zip
+    optField [String] ("description")  zip
+    optField [String] ("name")         zip
+    optField [String] ("in")           zip
+    optField [String] ("scheme")       zip
+    optField [String] ("bearerFormat")
+  ).invmap[SecurityScheme] {
+    case (((((tpe, description), name), in), scheme), bearerFormat) => SecurityScheme(tpe, description, name, in, scheme, bearerFormat)
+  } {
+    ss => (((((ss.`type`, ss.description), ss.name), ss.in), ss.scheme), ss.bearerFormat)
+  }
 
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApiSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApiSchemas.scala
@@ -1,0 +1,53 @@
+package endpoints.openapi.model
+
+import endpoints.algebra.JsonSchemas
+
+trait OpenApiSchemas extends JsonSchemas {
+
+  implicit lazy val openApiSchema: JsonSchema[OpenApi] = (
+      field[String]("openapi") zip
+      field[Info]("info") zip
+      field[Map[String, PathItem]]("paths") zip
+      optField[Components]("components")
+    ).invmap[OpenApi](notImplemented)(o => ((("3.0.0", o.info), o.paths), if (o.components.schemas.isEmpty) None else Some(o.components))) // TODO pull openapi version into model?
+
+  implicit lazy val infoSchema: JsonSchema[Info] = (
+      field[String]("title") zip
+      field[String]("version")
+    ).invmap(Info.tupled)(info => (info.title, info.version))
+
+  implicit lazy val pathItemSchema: JsonSchema[PathItem] =
+    mapJsonSchema(operationSchema).invmap(notImplemented)(_.operations)
+
+  implicit lazy val operationSchema: JsonSchema[Operation] = (
+    optField[String]("summary") zip
+    optField[String]("description")
+  ).invmap[Operation](notImplemented)(o => (o.summary, o.description))
+
+  implicit lazy val componentsSchema: JsonSchema[Components] =
+    field[Map[String, Schema]]("schemas")
+      .invmap[Components](notImplemented)(_.schemas)
+
+  implicit lazy val schemaSchema: JsonSchema[Schema] = (
+    optField[String]("type") zip
+    optField[String]("format") zip
+    optField[Schema]("items")
+  ).invmap[Schema](notImplemented) { schema =>
+    val fields = schemaToFields(schema)
+    ((fields.`type`, fields.format), fields.items)
+  }
+
+  private def schemaToFields(schema: Schema): SchemaFields = schema match {
+    case Schema.Primitive(name, None) => SchemaFields(`type` = Some(name))
+    case Schema.Primitive(name, Some(format)) => SchemaFields(`type` = Some(name), format = Some(format))
+    case Schema.Array(itemsSchema) => SchemaFields(`type` = Some("array"), items = Some(itemsSchema))
+  }
+  case class SchemaFields(
+                           `type`: Option[String] = None,
+                           format: Option[String] = None,
+                           items: Option[Schema] = None
+                         )
+
+  private def notImplemented(a: Any): Nothing = ???
+
+}

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsDocs.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsDocs.scala
@@ -1,20 +1,27 @@
 package endpoints.openapi
 
 import endpoints.algebra
-import endpoints.openapi.model.{Info, OpenApi}
-import io.circe.Json
-import io.circe.syntax._
 
-trait EndpointsDocs extends algebra.EndpointsDocs with Endpoints {
+object EndpointsDocs extends algebra.EndpointsDocs with Endpoints {
 
   //#documentation
+  import endpoints.openapi.model.{Info, OpenApi}
+
   val api: OpenApi =
     openApi(Info(title = "API to get some resource", version = "1.0"))(
-      someResource
+      someDocumentedResource
     )
   //#documentation
 
   //#documentation-asjson
+  object OpenApiEncoder
+    extends endpoints.openapi.model.OpenApiSchemas
+      with endpoints.circe.JsonSchemas
+
+  import OpenApiEncoder.JsonSchema._
+  import io.circe.Json
+  import io.circe.syntax._
+
   val apiJson: Json = api.asJson
   //#documentation-asjson
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -30,9 +30,10 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
     "be exposed in JSON schema" in {
       val expectedSchema =
         Schema.Object(
-          Schema.Property("name", Schema.Primitive("string", None), isRequired = true, description = Some("Name of the user")) ::
-          Schema.Property("age", Schema.Primitive("integer", Some("int32")), isRequired = true, description = None) ::
+          Schema.Property("name", Schema.Primitive("string", None, None), isRequired = true, description = Some("Name of the user")) ::
+          Schema.Property("age", Schema.Primitive("integer", Some("int32"), None), isRequired = true, description = None) ::
           Nil,
+          None,
           None
         )
       Fixtures.toSchema(Fixtures.User.schema) shouldBe expectedSchema
@@ -41,7 +42,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
   "Enumerations" in {
     val expectedSchema =
-      Schema.Enum(Schema.Primitive("string", None), "Red" :: "Blue" :: Nil)
+      Schema.Enum(Schema.Primitive("string", None, None), "Red" :: "Blue" :: Nil, None)
     Fixtures.toSchema(Fixtures.Enum.colorSchema) shouldBe expectedSchema
   }
 
@@ -50,13 +51,16 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
       Schema.Reference(
         "Rec",
         Some(Schema.Object(
-          Schema.Property("next", Schema.Reference("Rec", None), isRequired = false, description = None) :: Nil,
+          Schema.Property("next", Schema.Reference("Rec", None, None), isRequired = false, description = None) :: Nil,
+          additionalProperties = None,
           description = None
-        ))
+        )),
+        None
       )
     val expectedSchema =
       Schema.Object(
         Schema.Property("next", recSchema, isRequired = false, description = None) :: Nil,
+        additionalProperties = None,
         description = None
       )
     Fixtures.toSchema(Fixtures.recSchema) shouldBe expectedSchema
@@ -68,7 +72,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
       reqBody shouldBe defined
       reqBody.value.description.value shouldEqual "Text Req"
-      reqBody.value.content("text/plain").schema.value shouldEqual Schema.Primitive("string", None)
+      reqBody.value.content("text/plain").schema.value shouldEqual Schema.Primitive("string", None, None)
     }
   }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -35,15 +35,20 @@ class JsonSchemasTest extends FreeSpec {
 
   "enum" in {
     val expectedSchema =
-      DocumentedEnum(DocumentedJsonSchemas.stringJsonSchema, Seq("Red", "Blue"))
+      DocumentedEnum(DocumentedJsonSchemas.stringJsonSchema, "Red" :: "Blue" :: Nil)
     assert(DocumentedJsonSchemas.Enum.colorSchema == expectedSchema)
   }
 
   "recursive" in {
     DocumentedJsonSchemas.recSchema match {
-      case DocumentedRecord(List(Field("next", tpe, true, None)), _) => assert(tpe.isInstanceOf[LazySchema])
+      case DocumentedRecord(List(Field("next", tpe, true, None)), None, None) => assert(tpe.isInstanceOf[LazySchema])
       case _ => fail(s"Unexpected type for 'recSchema': ${DocumentedJsonSchemas.recSchema}")
     }
+  }
+
+  "maps" in {
+    val expected = DocumentedRecord(Nil, Some(DocumentedJsonSchemas.intJsonSchema), None)
+    assert(DocumentedJsonSchemas.intDictionary == expected)
   }
 
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -13,11 +13,13 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
     case class Online(link: String) extends Storage
   }
 
-  case class Book(id: Int, title: String, author: String, isbnCodes: List[String], storage: Storage)
+  case class Author(name: String)
+
+  case class Book(id: Int, title: String, author: Author, isbnCodes: List[String], storage: Storage)
 
   object Fixtures extends Fixtures with openapi.Endpoints with openapi.JsonSchemaEntities with openapi.BasicAuthentication {
 
-    def openApi: OpenApi = openApi(
+    def openApiDocument: OpenApi = openApi(
       Info(title = "TestFixturesOpenApi", version = "0.0.0")
     )(Fixtures.listBooks, Fixtures.postBook)
   }
@@ -26,6 +28,10 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
     implicit private val schemaStorage: JsonSchema[Storage] =
       withDiscriminator(genericJsonSchema[Storage].asInstanceOf[Tagged[Storage]], "storageType")
+
+    implicit val schemaAuthor: JsonSchema[Author] = (
+      field[String]("name", documentation = Some("Author name")).invmap[Author](Author)(_.name)
+    )
 
     implicit private val schemaBook: JsonSchema[Book] = genericJsonSchema[Book]
 
@@ -36,179 +42,201 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
   "OpenApi" should {
 
-    "produce referenced schema" in {
+    val expectedSchema =
+      """{
+        |  "openapi" : "3.0.0",
+        |  "info" : {
+        |    "title" : "TestFixturesOpenApi",
+        |    "version" : "0.0.0"
+        |  },
+        |  "paths" : {
+        |    "/books" : {
+        |      "get" : {
+        |        "responses" : {
+        |          "200" : {
+        |            "description" : "Books list",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "type" : "array",
+        |                  "items" : {
+        |                    "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
+        |                  }
+        |                }
+        |              }
+        |            }
+        |          }
+        |        },
+        |        "tags" : [
+        |          "Books"
+        |        ]
+        |      },
+        |      "post" : {
+        |        "requestBody" : {
+        |          "content" : {
+        |            "application/json" : {
+        |              "schema" : {
+        |                "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
+        |              }
+        |            }
+        |          },
+        |          "description" : "Books list"
+        |        },
+        |        "responses" : {
+        |          "401" : {
+        |            "description" : ""
+        |          },
+        |          "200" : {
+        |            "description" : ""
+        |          }
+        |        },
+        |        "tags" : [
+        |          "Books"
+        |        ],
+        |        "security" : [
+        |          {
+        |            "HttpBasic" : [
+        |            ]
+        |          }
+        |        ]
+        |      }
+        |    }
+        |  },
+        |  "components" : {
+        |    "schemas" : {
+        |      "endpoints.openapi.ReferencedSchemaTest.Book" : {
+        |        "type" : "object",
+        |        "properties" : {
+        |          "isbnCodes" : {
+        |            "type" : "array",
+        |            "items" : {
+        |              "type" : "string"
+        |            }
+        |          },
+        |          "author" : {
+        |            "type" : "object",
+        |            "properties" : {
+        |              "name" : {
+        |                "type" : "string",
+        |                "description" : "Author name"
+        |              }
+        |            },
+        |            "required" : [
+        |              "name"
+        |            ]
+        |          },
+        |          "id" : {
+        |            "type" : "integer",
+        |            "format" : "int32"
+        |          },
+        |          "storage" : {
+        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
+        |          },
+        |          "title" : {
+        |            "type" : "string"
+        |          }
+        |        },
+        |        "required" : [
+        |          "isbnCodes",
+        |          "author",
+        |          "id",
+        |          "storage",
+        |          "title"
+        |        ]
+        |      },
+        |      "endpoints.openapi.ReferencedSchemaTest.Storage" : {
+        |        "oneOf" : [
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Library"
+        |          },
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Online"
+        |          }
+        |        ],
+        |        "discriminator" : {
+        |          "propertyName" : "storageType",
+        |          "mapping" : {
+        |            "Library" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Library",
+        |            "Online" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Online"
+        |          }
+        |        }
+        |      },
+        |      "endpoints.openapi.ReferencedSchemaTest.Storage.Library" : {
+        |        "allOf" : [
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
+        |          },
+        |          {
+        |            "type" : "object",
+        |            "properties" : {
+        |              "storageType" : {
+        |                "type" : "string"
+        |              },
+        |              "room" : {
+        |                "type" : "string"
+        |              },
+        |              "shelf" : {
+        |                "type" : "integer",
+        |                "format" : "int32"
+        |              }
+        |            },
+        |            "required" : [
+        |              "storageType",
+        |              "room",
+        |              "shelf"
+        |            ]
+        |          }
+        |        ]
+        |      },
+        |      "endpoints.openapi.ReferencedSchemaTest.Storage.Online" : {
+        |        "allOf" : [
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
+        |          },
+        |          {
+        |            "type" : "object",
+        |            "properties" : {
+        |              "storageType" : {
+        |                "type" : "string"
+        |              },
+        |              "link" : {
+        |                "type" : "string"
+        |              }
+        |            },
+        |            "required" : [
+        |              "storageType",
+        |              "link"
+        |            ]
+        |          }
+        |        ]
+        |      }
+        |    },
+        |    "securitySchemes" : {
+        |      "HttpBasic" : {
+        |        "type" : "http",
+        |        "description" : "Http Basic Authentication",
+        |        "scheme" : "basic"
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
 
+    "produce referenced schema with circe" in {
+
+      object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.circe.JsonSchemas
+      import OpenApiEncoder.JsonSchema._
       import io.circe.syntax._
 
-      Fixtures.openApi.asJson.spaces2 shouldBe // TODO test
-        """{
-          |  "components" : {
-          |    "schemas" : {
-          |      "endpoints.openapi.ReferencedSchemaTest.Book" : {
-          |        "required" : [
-          |          "id",
-          |          "title",
-          |          "author",
-          |          "isbnCodes",
-          |          "storage"
-          |        ],
-          |        "type" : "object",
-          |        "properties" : {
-          |          "id" : {
-          |            "type" : "integer",
-          |            "format" : "int32"
-          |          },
-          |          "title" : {
-          |            "type" : "string"
-          |          },
-          |          "author" : {
-          |            "type" : "string"
-          |          },
-          |          "isbnCodes" : {
-          |            "type" : "array",
-          |            "items" : {
-          |              "type" : "string"
-          |            }
-          |          },
-          |          "storage" : {
-          |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
-          |          }
-          |        }
-          |      },
-          |      "endpoints.openapi.ReferencedSchemaTest.Storage" : {
-          |        "oneOf" : [
-          |          {
-          |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Library"
-          |          },
-          |          {
-          |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Online"
-          |          }
-          |        ],
-          |        "discriminator" : {
-          |          "propertyName" : "storageType",
-          |          "mapping" : {
-          |            "Library" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Library",
-          |            "Online" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage.Online"
-          |          }
-          |        }
-          |      },
-          |      "endpoints.openapi.ReferencedSchemaTest.Storage.Library" : {
-          |        "allOf" : [
-          |          {
-          |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
-          |          },
-          |          {
-          |            "required" : [
-          |              "storageType",
-          |              "room",
-          |              "shelf"
-          |            ],
-          |            "type" : "object",
-          |            "properties" : {
-          |              "storageType" : {
-          |                "type" : "string"
-          |              },
-          |              "room" : {
-          |                "type" : "string"
-          |              },
-          |              "shelf" : {
-          |                "type" : "integer",
-          |                "format" : "int32"
-          |              }
-          |            }
-          |          }
-          |        ]
-          |      },
-          |      "endpoints.openapi.ReferencedSchemaTest.Storage.Online" : {
-          |        "allOf" : [
-          |          {
-          |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
-          |          },
-          |          {
-          |            "required" : [
-          |              "storageType",
-          |              "link"
-          |            ],
-          |            "type" : "object",
-          |            "properties" : {
-          |              "storageType" : {
-          |                "type" : "string"
-          |              },
-          |              "link" : {
-          |                "type" : "string"
-          |              }
-          |            }
-          |          }
-          |        ]
-          |      }
-          |    },
-          |    "securitySchemes" : {
-          |      "HttpBasic" : {
-          |        "type" : "http",
-          |        "description" : "Http Basic Authentication",
-          |        "scheme" : "basic"
-          |      }
-          |    }
-          |  },
-          |  "openapi" : "3.0.0",
-          |  "info" : {
-          |    "title" : "TestFixturesOpenApi",
-          |    "version" : "0.0.0"
-          |  },
-          |  "paths" : {
-          |    "/books" : {
-          |      "get" : {
-          |        "responses" : {
-          |          "200" : {
-          |            "description" : "Books list",
-          |            "content" : {
-          |              "application/json" : {
-          |                "schema" : {
-          |                  "type" : "array",
-          |                  "items" : {
-          |                    "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
-          |                  }
-          |                }
-          |              }
-          |            }
-          |          }
-          |        },
-          |        "tags" : [
-          |          "Books"
-          |        ]
-          |      },
-          |      "post" : {
-          |        "responses" : {
-          |          "401" : {
-          |            "description" : ""
-          |          },
-          |          "200" : {
-          |            "description" : ""
-          |          }
-          |        },
-          |        "requestBody" : {
-          |          "description" : "Books list",
-          |          "content" : {
-          |            "application/json" : {
-          |              "schema" : {
-          |                "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Book"
-          |              }
-          |            }
-          |          }
-          |        },
-          |        "tags" : [
-          |          "Books"
-          |        ],
-          |        "security" : [
-          |          {
-          |            "HttpBasic" : [
-          |            ]
-          |          }
-          |        ]
-          |      }
-          |    }
-          |  }
-          |}""".stripMargin
+      Fixtures.openApiDocument.asJson.spaces2 shouldBe expectedSchema // TODO test
+    }
+
+    "produce referenced schema with playjson" in {
+
+      object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.playjson.JsonSchemas
+      import OpenApiEncoder.JsonSchema._
+      import play.api.libs.json.Json
+
+      Json.toJson(Fixtures.openApiDocument) shouldBe Json.parse(expectedSchema)
     }
   }
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -40,7 +40,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
       import io.circe.syntax._
 
-      Fixtures.openApi.asJson.spaces2 shouldBe
+      Fixtures.openApi.asJson.spaces2 shouldBe // TODO test
         """{
           |  "components" : {
           |    "schemas" : {

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
@@ -12,7 +12,7 @@ import play.api.mvc.Results
   * JSON entities in HTTP requests, and circe’s [[io.circe.Encoder]] to build JSON entities
   * in HTTP responses.
   */
-trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.circe.JsonSchemas { // TODO is this still needed?
+trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.circe.JsonSchemas {
 
   import playComponents.executionContext
 

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
@@ -12,7 +12,7 @@ import play.api.mvc.Results
   * JSON entities in HTTP requests, and circe’s [[io.circe.Encoder]] to build JSON entities
   * in HTTP responses.
   */
-trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.circe.JsonSchemas {
+trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.circe.JsonSchemas { // TODO is this still needed?
 
   import playComponents.executionContext
 


### PR DESCRIPTION
- Remove previous circe encoder from OpenApi model
- Remove circe dependency from `openapi` and `example-documented`
  modules
- Align circe encoding of optional fields with play-json: a `None`
  value is encoded with a missing field rather than a `null` field
- All Schemas can now have an attached “description”

Fixes #126