### PR TITLE
Extending xhr thenable tests to represent multiple header parameters

### DIFF
--- a/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
+++ b/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
@@ -2,10 +2,17 @@ package endpoints.xhr
 
 import org.scalatest.FreeSpec
 
-object Fixtures extends thenable.Endpoints {
+// Separation of the Algebra here is important, due to implementation details
+// of the underlying representation of header in the xhr algebra.
+trait FixturesAlgebra extends endpoints.algebra.Endpoints {
   val foo = endpoint(get(path / "foo" / segment[String]()), emptyResponse())
   val bar = endpoint(post(path / "bar" /? qs[Int]("quux"), emptyRequest), emptyResponse())
+  // Currently, the fact that this line compiles is a test, as there's no way
+  // to inspect the result of constructing headers at the moment.
+  val baz = endpoint(post(path / "baz", emptyRequest, header("quuz") ++ header("corge") ++ optHeader("grault")), emptyResponse())
 }
+
+object Fixtures extends FixturesAlgebra with thenable.Endpoints
 
 // TODO try to use traits defined in algebra tests.
 // It cannot be simply reused because dependency on wiremock which is not available for js


### PR DESCRIPTION
Resolves #221 

I'm OK to drop the second commit, if desired.

I didn't see any obvious way to test the presence of headers for two reasons:
1) `XMLHttpRequest` is not defined in the DOM available
2) `XMLHttpRequest` API doesn't provide a way to get access to headers once they're set