### PR TITLE
Rename “invmap” operation to “xmap”, for consistency with the main algebra

### DIFF
--- a/documentation/manual/src/doc/algebras/json-schemas.md
+++ b/documentation/manual/src/doc/algebras/json-schemas.md
@@ -39,7 +39,7 @@ defines an optional field in a JSON object.
 
 In the above example, we define two JSON object schemas (one for the `width` field,
 of type `Record[Double]`, and one for the `height` field, of type `Record[Double]`),
-and then we combine them into a single JSON object schema by using the `zip` operation. Finally, we call the `invmap` operation
+and then we combine them into a single JSON object schema by using the `zip` operation. Finally, we call the `xmap` operation
 to turn the `Record[(Double, Double)]` value returned by the `zip` operation into
 a `Record[Rectangle]`.
 
@@ -62,7 +62,7 @@ be defined as follows:
 
 The `orElse` operation turns the `Record[Circle]` and `Record[Rectangle]` values into
 a `Record[Either[Circle, Rectangle]]`, which is then transformed into a `Record[Shape]` by
-using `invmap`.
+using `xmap`.
 
 By default, the discriminator field is named `type`, but you can use another field name if
 you want to.
@@ -124,7 +124,7 @@ uses the case class name.
 
 The module also takes advantage shapeless to define more convenient
 operations for combining JSON schema definitions: the `zip` operation
-is replaced by a `:*:` operator, and `invmap` is replaced by `as`:
+is replaced by a `:*:` operator, and `xmap` is replaced by `as`:
 
 ~~~ scala src=../../../../../json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala#explicit-schema
 ~~~

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -157,16 +157,16 @@ trait JsonSchemas
     Record(encoder, decoder)
   }
 
-  def invmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] =
+  def xmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] =
     Record(record.encoder.contramapObject(g), record.decoder.map(f))
 
-  def invmapTagged[A, B](tagged: Tagged[A], f: A => B, g: B => A): Tagged[B] =
+  def xmapTagged[A, B](tagged: Tagged[A], f: A => B, g: B => A): Tagged[B] =
     new Tagged[B] {
       def taggedEncoded(b: B): (String, JsonObject) = tagged.taggedEncoded(g(b))
       def taggedDecoder(tag: String): Option[Decoder[B]] = tagged.taggedDecoder(tag).map(_.map(f))
     }
 
-  def invmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B] =
+  def xmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B] =
     JsonSchema(jsonSchema.encoder.contramap(g), jsonSchema.decoder.map(f))
 
   implicit def uuidJsonSchema: JsonSchema[UUID] = JsonSchema(implicitly, implicitly)

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -65,11 +65,11 @@ class JsonSchemasTest extends FreeSpec {
       def zipRecords[A, B](recordA: String, recordB: String): String =
         s"$recordA,$recordB"
 
-      def invmapRecord[A, B](record: String, f: A => B, g: B => A): String = record
+      def xmapRecord[A, B](record: String, f: A => B, g: B => A): String = record
 
-      def invmapTagged[A, B](tagged: String, f: A => B, g: B => A): String = tagged
+      def xmapTagged[A, B](tagged: String, f: A => B, g: B => A): String = tagged
 
-      def invmapJsonSchema[A, B](jsonSchema: String, f: A => B, g: B => A): String = jsonSchema
+      def xmapJsonSchema[A, B](jsonSchema: String, f: A => B, g: B => A): String = jsonSchema
 
       lazy val uuidJsonSchema: String = "uuid"
 

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -144,10 +144,10 @@ trait JsonSchemas
     Record(reads, writes)
   }
 
-  def invmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] =
+  def xmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B] =
     Record(record.reads.map(f), record.writes.contramap(g))
 
-  def invmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B] =
+  def xmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B] =
     JsonSchema(jsonSchema.reads.map(f), jsonSchema.writes.contramap(g))
 
   trait Tagged[A] extends Record[A] {
@@ -202,7 +202,7 @@ trait JsonSchemas
         taggedB.findReads(tagName).map(_.map[Either[A, B]](Right(_)))
   }
 
-  def invmapTagged[A, B](tagged: Tagged[A], f: A => B, g: B => A): Tagged[B] = new Tagged[B] {
+  def xmapTagged[A, B](tagged: Tagged[A], f: A => B, g: B => A): Tagged[B] = new Tagged[B] {
     def tagAndJson(b: B): (String, JsObject) = tagged.tagAndJson(g(b))
     def findReads(tag: String): Option[Reads[B]] = tagged.findReads(tag).map(_.map(f))
   }

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -121,7 +121,7 @@ class JsonSchemasTest extends FreeSpec {
 
   "case class with one field" in {
     case class IntClass(i: Int)
-    val jsonSchemaTestClass = field[Int]("i").invmap[IntClass](i => IntClass(i))(_.i)
+    val jsonSchemaTestClass = field[Int]("i").xmap[IntClass](i => IntClass(i))(_.i)
 
     testRoundtrip(
       jsonSchemaTestClass,
@@ -133,7 +133,7 @@ class JsonSchemasTest extends FreeSpec {
   "case class with two fields" in {
     case class TestClass(i: Int, s: String)
     val jsonSchemaTestClass = (field[Int]("i") zip field[String]("s"))
-      .invmap[TestClass](tuple => TestClass(tuple._1, tuple._2))(test => (test.i, test.s))
+      .xmap[TestClass](tuple => TestClass(tuple._1, tuple._2))(test => (test.i, test.s))
 
     testRoundtrip(
       jsonSchemaTestClass,
@@ -253,8 +253,8 @@ class JsonSchemasTest extends FreeSpec {
     case class Circle(r: Double) extends Shape
     case class Rect(w: Int, h: Int) extends Shape
 
-    val schema = field[Double]("r").tagged("Circle").invmap(Circle)(_.r) orElse
-      (field[Int]("w") zip field[Int]("h")).tagged("Rect").invmap(Rect.tupled)(rect => (rect.w, rect.h))
+    val schema = field[Double]("r").tagged("Circle").xmap(Circle)(_.r) orElse
+      (field[Int]("w") zip field[Int]("h")).tagged("Rect").xmap(Rect.tupled)(rect => (rect.w, rect.h))
 
     testRoundtrip(
       schema,
@@ -268,13 +268,13 @@ class JsonSchemasTest extends FreeSpec {
     )
   }
 
-  "sealed trait with invmap and tagged swapped" in {
+  "sealed trait with xmap and tagged swapped" in {
     sealed trait Shape
     case class Circle(r: Double) extends Shape
     case class Rect(w: Int, h: Int) extends Shape
 
-    val schema = field[Double]("r").invmap(Circle)(_.r).tagged("Circle") orElse
-      (field[Int]("w") zip field[Int]("h")).invmap(Rect.tupled)(rect => (rect.w, rect.h)).tagged("Rect")
+    val schema = field[Double]("r").xmap(Circle)(_.r).tagged("Circle") orElse
+      (field[Int]("w") zip field[Int]("h")).xmap(Rect.tupled)(rect => (rect.w, rect.h)).tagged("Rect")
 
     testRoundtrip(
       schema,
@@ -293,8 +293,8 @@ class JsonSchemasTest extends FreeSpec {
     case class Circle(r: Double) extends Shape
     case class Rect(w: Int, h: Int) extends Shape
 
-    val schema = field[Double]("r").invmap(Circle)(_.r).tagged("Circle") orElse
-      (field[Int]("w") zip field[Int]("h")).invmap(Rect.tupled)(rect => (rect.w, rect.h)).tagged("Rect")
+    val schema = field[Double]("r").xmap(Circle)(_.r).tagged("Circle") orElse
+      (field[Int]("w") zip field[Int]("h")).xmap(Rect.tupled)(rect => (rect.w, rect.h)).tagged("Rect")
 
     assertError(
       schema,

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -26,7 +26,7 @@ import scala.language.higherKinds
   *     implicit val schema: JsonSchema[User] = (
   *       field[String]("name") zip
   *       field[Int]("age")
-  *     ).invmap((User.apply _).tupled)(Function.unlift(User.unapply))
+  *     ).xmap((User.apply _).tupled)(Function.unlift(User.unapply))
   *   }
   * }}}
   *
@@ -42,13 +42,13 @@ import scala.language.higherKinds
   *
   *   object Shape {
   *     implicit val schema: JsonSchema[Shape] = {
-  *       val circleSchema = field[Double]("radius").invmap(Circle)(Function.unlift(Circle.unapply))
+  *       val circleSchema = field[Double]("radius").xmap(Circle)(Function.unlift(Circle.unapply))
   *       val rectangleSchema = (
   *         field[Double]("width") zip
   *         field[Double]("height")
-  *       ).invmap((Rectangle.apply _).tupled)(Function.unlift(Rectangle.unapply))
+  *       ).xmap((Rectangle.apply _).tupled)(Function.unlift(Rectangle.unapply))
   *       (circleSchema.tagged("Circle") orElse rectangleSchema.tagged("Rectangle"))
-  *         .invmap[Shape] {
+  *         .xmap[Shape] {
   *           case Left(circle) => circle
   *           case Right(rect)  => rect
   *         } {
@@ -93,7 +93,7 @@ trait JsonSchemas {
     *   case class Rec(next: Option[Rec])
     *   val recSchema: JsonSchema[Rec] = (
     *     optField("next")(lazySchema(recSchema, "Rec"))
-    *   ).invmap(Rec)(_.next)
+    *   ).xmap(Rec)(_.next)
     * }}}
     *
     * Interpreters should return a JsonSchema value that does not evaluate
@@ -134,29 +134,29 @@ trait JsonSchemas {
   def zipRecords[A, B](recordA: Record[A], recordB: Record[B]): Record[(A, B)]
 
   /** Transforms the type of the JSON schema */
-  def invmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B]
+  def xmapRecord[A, B](record: Record[A], f: A => B, g: B => A): Record[B]
 
   /** Transforms the type of the JSON schema */
-  def invmapTagged[A, B](taggedA: Tagged[A], f: A => B, g: B => A): Tagged[B]
+  def xmapTagged[A, B](taggedA: Tagged[A], f: A => B, g: B => A): Tagged[B]
 
   /** Transforms the type of the JSON schema */
-  def invmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B]
+  def xmapJsonSchema[A, B](jsonSchema: JsonSchema[A], f: A => B, g: B => A): JsonSchema[B]
 
   /** Convenient infix operations */
   final implicit class RecordOps[A](recordA: Record[A]) {
     def zip[B](recordB: Record[B]): Record[(A, B)] = zipRecords(recordA, recordB)
-    def invmap[B](f: A => B)(g: B => A): Record[B] = invmapRecord(recordA, f, g)
+    def xmap[B](f: A => B)(g: B => A): Record[B] = xmapRecord(recordA, f, g)
     def tagged(tag: String): Tagged[A] = taggedRecord(recordA, tag)
   }
 
   /** Convenient infix operations */
   final implicit class JsonSchemaOps[A](jsonSchema: JsonSchema[A]) {
-    def invmap[B](f: A => B)(g: B => A): JsonSchema[B] = invmapJsonSchema(jsonSchema, f, g)
+    def xmap[B](f: A => B)(g: B => A): JsonSchema[B] = xmapJsonSchema(jsonSchema, f, g)
   }
 
   final implicit class TaggedOps[A](taggedA: Tagged[A]) {
     def orElse[B](taggedB: Tagged[B]): Tagged[Either[A, B]] = choiceTagged(taggedA, taggedB)
-    def invmap[B](f: A => B)(g: B => A): Tagged[B] = invmapTagged(taggedA, f, g)
+    def xmap[B](f: A => B)(g: B => A): Tagged[B] = xmapTagged(taggedA, f, g)
   }
 
   /** A JSON schema for type `UUID` */

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
@@ -10,7 +10,7 @@ trait JsonSchemasDocs extends JsonSchemas {
     implicit val rectangleSchema: JsonSchema[Rectangle] = (
       field[Double]("width", Some("Rectangle width")) zip
       field[Double]("height")
-    ).invmap((Rectangle.apply _).tupled)(rect => (rect.width, rect.height))
+    ).xmap((Rectangle.apply _).tupled)(rect => (rect.width, rect.height))
     //#record-schema
   }
 
@@ -24,19 +24,19 @@ trait JsonSchemasDocs extends JsonSchemas {
     implicit val schema: JsonSchema[Shape] = {
 
       val circleSchema =
-        field[Double]("radius").invmap(Circle)(_.radius)
+        field[Double]("radius").xmap(Circle)(_.radius)
 
       val rectangleSchema = (
         field[Double]("width") zip
         field[Double]("height")
-      ).invmap((Rectangle.apply _).tupled)(r => (r.width, r.height))
+      ).xmap((Rectangle.apply _).tupled)(r => (r.width, r.height))
 
       //#sum-type-schema
       // Given a `circleSchema: Record[Circle]` and a `rectangleSchema: Record[Rectangle]`
       (
         circleSchema.tagged("Circle") orElse
         rectangleSchema.tagged("Rectangle")
-      ).invmap[Shape] {
+      ).xmap[Shape] {
         case Left(circle) => circle
         case Right(rect)  => rect
       } {
@@ -65,7 +65,7 @@ trait JsonSchemasDocs extends JsonSchemas {
 
   val recSchema: JsonSchema[Rec] = (
     optField("next")(lazySchema(recSchema, "Rec"))
-  ).invmap(Rec)(_.next)
+  ).xmap(Rec)(_.next)
   //#recursive
 
 }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -15,15 +15,15 @@ trait JsonSchemasTest extends JsonSchemas {
     implicit val schema: JsonSchema[User] = (
       field[String]("name", Some("Name of the user")) zip
       field[Int]("age")
-    ).invmap((User.apply _).tupled)(Function.unlift(User.unapply))
+    ).xmap((User.apply _).tupled)(Function.unlift(User.unapply))
 
     val schema2: JsonSchema[User] = (
       emptyRecord zip
       field[String]("name", Some("Name of the user")) zip
       field[Int]("age")
     )
-      .invmap[(String, Int)](p => (p._1._2, p._2))(p => (((), p._1), p._2))
-      .invmap((User.apply _).tupled)(Function.unlift(User.unapply))
+      .xmap[(String, Int)](p => (p._1._2, p._2))(p => (((), p._1), p._2))
+      .xmap((User.apply _).tupled)(Function.unlift(User.unapply))
   }
 
   sealed trait Foo
@@ -34,13 +34,13 @@ trait JsonSchemasTest extends JsonSchemas {
 
   object Foo {
     implicit val schema: JsonSchema[Foo] = {
-      val barSchema: Record[Bar] = field[String]("s").invmap(Bar)(_.s)
-      val bazSchema: Record[Baz] = field[Int]("i").invmap(Baz)(_.i)
-      val baxSchema: Record[Bax] = emptyRecord.invmap(_ => Bax())(_ => ())
-      val quxSchema: Record[Qux.type] = emptyRecord.invmap(_ => Qux)(_ => ())
+      val barSchema: Record[Bar] = field[String]("s").xmap(Bar)(_.s)
+      val bazSchema: Record[Baz] = field[Int]("i").xmap(Baz)(_.i)
+      val baxSchema: Record[Bax] = emptyRecord.xmap(_ => Bax())(_ => ())
+      val quxSchema: Record[Qux.type] = emptyRecord.xmap(_ => Qux)(_ => ())
 
       (barSchema.tagged("Bar") orElse bazSchema.tagged("Baz") orElse baxSchema.tagged("Bax") orElse quxSchema.tagged("Qux"))
-        .invmap[Foo] {
+        .xmap[Foo] {
           case Left(Left(Left(bar))) => bar
           case Left(Left(Right(baz))) => baz
           case Left(Right(bax)) => bax
@@ -66,7 +66,7 @@ trait JsonSchemasTest extends JsonSchemas {
   case class Rec(next: Option[Rec])
   val recSchema: JsonSchema[Rec] = (
     optField("next")(lazySchema(recSchema, "Rec"))
-  ).invmap(Rec)(_.next)
+  ).xmap(Rec)(_.next)
 
   val intDictionary: JsonSchema[Map[String, Int]] = mapJsonSchema[Int]
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -89,11 +89,11 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
   def zipRecords[A, B](recordA: DocumentedRecord, recordB: DocumentedRecord): DocumentedRecord =
     DocumentedRecord(recordA.fields ++ recordB.fields)
 
-  def invmapRecord[A, B](record: DocumentedRecord, f: A => B, g: B => A): DocumentedRecord = record
+  def xmapRecord[A, B](record: DocumentedRecord, f: A => B, g: B => A): DocumentedRecord = record
 
-  def invmapTagged[A, B](tagged: DocumentedCoProd, f: A => B, g: B => A): DocumentedCoProd = tagged
+  def xmapTagged[A, B](tagged: DocumentedCoProd, f: A => B, g: B => A): DocumentedCoProd = tagged
 
-  def invmapJsonSchema[A, B](jsonSchema: DocumentedJsonSchema, f: A => B, g: B => A): DocumentedJsonSchema = jsonSchema
+  def xmapJsonSchema[A, B](jsonSchema: DocumentedJsonSchema, f: A => B, g: B => A): DocumentedJsonSchema = jsonSchema
 
   lazy val uuidJsonSchema: DocumentedJsonSchema = Primitive("string", format = Some("uuid"))
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -30,7 +30,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
       withDiscriminator(genericJsonSchema[Storage].asInstanceOf[Tagged[Storage]], "storageType")
 
     implicit val schemaAuthor: JsonSchema[Author] = (
-      field[String]("name", documentation = Some("Author name")).invmap[Author](Author)(_.name)
+      field[String]("name", documentation = Some("Author name")).xmap[Author](Author)(_.name)
     )
 
     implicit private val schemaBook: JsonSchema[Book] = genericJsonSchema[Book]


### PR DESCRIPTION
Fixes #238

Note that this introduces a backward binary incompatibility.