### PR TITLE
Update Play to 2.7 and extend Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       scala: 2.11.12
       script: sbt "++ $TRAVIS_SCALA_VERSION test"
     - stage: test
-      scala: 2.12.8
+      scala: 2.12.10
       script: sbt ++$TRAVIS_SCALA_VERSION test manual/makeSite
     - stage: test
       scala: 2.13.0
@@ -44,7 +44,7 @@ jobs:
     - stage: coverage
       if: tag is blank
       script:
-        - sbt ++2.12.8 coverage test coverageReport coverageAggregate
+        - sbt ++2.12.10 coverage test coverageReport coverageAggregate
         - bash <(curl -s https://codecov.io/bash)
 
     - stage: publish
@@ -55,7 +55,7 @@ jobs:
         - chmod 600 ci/travis-key
         - eval "$(ssh-agent -s)"
         - ssh-add ci/travis-key
-        - sbt "++ 2.11.12 publishSigned" "++ 2.12.8 publishSigned" "++ 2.13.0 publishSigned" sonatypeReleaseAll "++ 2.12.8 manual/makeSite" manual/ghpagesPushSite
+        - sbt "++ 2.11.12 publishSigned" "++ 2.12.10 publishSigned" "++ 2.13.0 publishSigned" sonatypeReleaseAll "++ 2.12.10 manual/makeSite" manual/ghpagesPushSite
 
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ or for faster feedback loop:
 
 ~~~ sh
 $ sbt "++ 2.11.12 test"
-$ sbt "++ 2.12.8 test"
+$ sbt "++ 2.12.10 test"
 $ sbt "++ 2.13.0 test"
 ~~~
 

--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -7,21 +7,22 @@ val `json-schema-circe-jvm` = LocalProject("json-schema-circeJVM")
 val `json-schema-generic-jvm` = LocalProject("json-schema-genericJVM")
 val `json-schema-playjson-jvm` = LocalProject("json-schema-playjsonJVM")
 
-val akkaActorVersion = "2.5.22"
-val akkaHttpVersion = "10.1.8"
-val akkaHttpCirceVersion = "1.25.2"
-val akkaHttpPlayJsonVersion = "1.24.3"
+val akkaActorVersion = "2.5.25"
+val akkaHttpVersion = "10.1.9"
+val akkaHttpCirceVersion = "1.28.0"
+val akkaHttpPlayJsonVersion = "1.28.0"
 
 val `akka-http-client` =
   project.in(file("client"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`, // Note that we could support 2.11, only our tests depend on circe (which has dropped 2.11 support)
       name := "endpoints-akka-http-client",
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-stream" % akkaActorVersion,
         "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
+        "com.typesafe.akka" %% "akka-stream-testkit" % akkaActorVersion % Test,
         scalaTestDependency
       )
     )
@@ -33,7 +34,7 @@ val `akka-http-client-circe` =
   project.in(file("client-circe"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-akka-http-client-circe"
     ).dependsOn(
       `akka-http-client` % "test->test;compile->compile",
@@ -44,12 +45,13 @@ val `akka-http-server` =
   project.in(file("server"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-akka-http-server",
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-stream" % akkaActorVersion,
         "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+        "com.typesafe.akka" %% "akka-stream" % akkaActorVersion,
         "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
+        "com.typesafe.akka" %% "akka-stream-testkit" % akkaActorVersion % Test,
         "com.typesafe.akka" %% "akka-testkit" % akkaActorVersion % Test,
         "com.softwaremill.sttp" %% "core" % sttpVersion % Test, // Temporary
         scalaTestDependency
@@ -62,14 +64,14 @@ val `akka-http-server-circe` =
   project.in(file("server-circe"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-akka-http-server-circe",
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-stream" % akkaActorVersion,
         "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
         "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
         "com.typesafe.akka" %% "akka-testkit" % akkaActorVersion % Test,
-        "de.heikoseeberger" %% "akka-http-circe" % akkaHttpCirceVersion % Provided,
+        "de.heikoseeberger" %% "akka-http-circe" % akkaHttpCirceVersion,
         "com.softwaremill.sttp" %% "core" % sttpVersion % Test, // Temporary
         scalaTestDependency
       )
@@ -85,7 +87,7 @@ val `akka-http-server-playjson` =
   project.in(file("server-playjson"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-akka-http-server-playjson",
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-stream" % akkaActorVersion,

--- a/akka-http/client-circe/src/test/scala/endpoints/akkahttp/client/circe/AkkaHttpClientCirceEndpointsJsonSchemaTest.scala
+++ b/akka-http/client-circe/src/test/scala/endpoints/akkahttp/client/circe/AkkaHttpClientCirceEndpointsJsonSchemaTest.scala
@@ -2,6 +2,7 @@ package endpoints.akkahttp.client.circe
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
 import endpoints.akkahttp.client.{AkkaHttpRequestExecutor, BasicAuthentication, Endpoints, EndpointsSettings}
 import endpoints.algebra.client.{BasicAuthTestSuite, JsonTestSuite}
 import endpoints.algebra.{Address, BasicAuthTestApi, JsonTestApi, User}
@@ -21,7 +22,7 @@ class TestJsonSchemaClient(settings: EndpointsSettings)(implicit EC: ExecutionCo
   implicit def addresCodec: JsonSchema[Address] = genericJsonSchema[Address]
 }
 
-class EndpointsJsonSchemaTest
+class AkkaHttpClientCirceEndpointsJsonSchemaTest
     extends JsonTestSuite[TestJsonSchemaClient]
     with BasicAuthTestSuite[TestJsonSchemaClient] {
 
@@ -41,4 +42,10 @@ class EndpointsJsonSchemaTest
 
   clientTestSuite()
   basicAuthSuite()
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
 }

--- a/akka-http/client/src/test/scala/endpoints/akkahttp/client/AkkaHttpClientEndpointsTest.scala
+++ b/akka-http/client/src/test/scala/endpoints/akkahttp/client/AkkaHttpClientEndpointsTest.scala
@@ -2,9 +2,8 @@ package endpoints.akkahttp.client
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
-import endpoints.algebra._
-import endpoints.algebra.client._
-import endpoints.algebra.circe
+import akka.testkit.TestKit
+import endpoints.algebra
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -12,17 +11,17 @@ class TestClient(settings: EndpointsSettings)
   (implicit EC: ExecutionContext, M: Materializer)
   extends Endpoints(settings)
     with BasicAuthentication
-    with EndpointsTestApi
-    with BasicAuthTestApi
-    with JsonFromCodecTestApi
-    with circe.JsonFromCirceCodecTestApi
+    with algebra.EndpointsTestApi
+    with algebra.BasicAuthTestApi
+    with algebra.JsonFromCodecTestApi
+    with algebra.circe.JsonFromCirceCodecTestApi
     with JsonEntitiesFromCodec
-    with circe.JsonEntitiesFromCodec
+    with algebra.circe.JsonEntitiesFromCodec
 
-class EndpointsTest
-  extends EndpointsTestSuite[TestClient]
-    with BasicAuthTestSuite[TestClient]
-    with JsonFromCodecTestSuite[TestClient]
+class AkkaHttpClientEndpointsTest
+  extends algebra.client.EndpointsTestSuite[TestClient]
+    with algebra.client.BasicAuthTestSuite[TestClient]
+    with algebra.client.JsonFromCodecTestSuite[TestClient]
 {
 
   implicit val system = ActorSystem()
@@ -38,4 +37,10 @@ class EndpointsTest
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
 }

--- a/akka-http/server-circe/src/test/scala/endpoints/akkahttp/server/circe/ServerInterpreterTest.scala
+++ b/akka-http/server-circe/src/test/scala/endpoints/akkahttp/server/circe/ServerInterpreterTest.scala
@@ -2,8 +2,8 @@ package endpoints.akkahttp.server.circe
 
 import endpoints.akkahttp.server.EndpointsTestSuite
 import org.scalatest.{Matchers, WordSpecLike}
-import endpoints.akkahttp.server.EndpointsTestApi 
-import endpoints.akkahttp.server.ServerInterpreterBaseTest 
+import endpoints.akkahttp.server.EndpointsTestApi
+import endpoints.akkahttp.server.ServerInterpreterBaseTest
 
 class ServerInterpreterTest extends ServerInterpreterBaseTest(new EndpointsCodecsTestApi)
   with EndpointsTestSuite[EndpointsTestApi]

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterBaseTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterBaseTest.scala
@@ -10,7 +10,6 @@ import endpoints.algebra.server.{DecodedUrl, ServerTestBase}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import endpoints.akkahttp.server.EndpointsTestApi 
 
 class ServerInterpreterBaseTest(val serverApi: EndpointsTestApi)
   extends ServerTestBase[EndpointsTestApi]

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
@@ -123,15 +123,15 @@ trait Urls extends PartialInvariantFunctorSyntax {
 
   /** Ability to define `UUID` query string parameters */
   implicit def uuidQueryString: QueryStringParam[UUID] =
-    stringQueryString.xmapPartial(s => Try(UUID.fromString(s)).toOption)(_.toString)
+    stringQueryString.xmapPartial(s => Try(UUID.fromString(s)).toOption)(_.toString())
 
   /** Ability to define `Int` query string parameters */
   implicit def intQueryString: QueryStringParam[Int] =
-    stringQueryString.xmapPartial(s => Try(s.toInt).toOption)(_.toString)
+    stringQueryString.xmapPartial(s => Try(s.toInt).toOption)(_.toString())
 
   /** Query string parameter containing a `Long` value */
   implicit def longQueryString: QueryStringParam[Long] =
-    stringQueryString.xmapPartial(s => Try(s.toLong).toOption)(_.toString)
+    stringQueryString.xmapPartial(s => Try(s.toLong).toOption)(_.toString())
 
   /** Query string parameter containing a `Boolean` value */
   implicit def booleanQueryString: QueryStringParam[Boolean] =
@@ -139,10 +139,10 @@ trait Urls extends PartialInvariantFunctorSyntax {
       case "true"  | "1" => Some(true)
       case "false" | "0" => Some(false)
       case _ => None
-    }(_.toString)
+    }(_.toString())
 
   implicit def doubleQueryString: QueryStringParam[Double] =
-    stringQueryString.xmapPartial(s => Try(s.toDouble).toOption)(_.toString)
+    stringQueryString.xmapPartial(s => Try(s.toDouble).toOption)(_.toString())
 
   /**
     * An URL path segment carrying an `A` information.
@@ -159,18 +159,18 @@ trait Urls extends PartialInvariantFunctorSyntax {
 
   /** Ability to define `UUID` path segments */
   implicit def uuidSegment: Segment[UUID] =
-    stringSegment.xmapPartial(s => Try(UUID.fromString(s)).toOption)(_.toString)
+    stringSegment.xmapPartial(s => Try(UUID.fromString(s)).toOption)(_.toString())
 
   /** Ability to define `Int` path segments */
   implicit def intSegment: Segment[Int] =
-    stringSegment.xmapPartial(s => Try(s.toInt).toOption)(_.toString)
+    stringSegment.xmapPartial(s => Try(s.toInt).toOption)(_.toString())
 
   /** Segment containing a `Long` value */
   implicit def longSegment: Segment[Long] =
-    stringSegment.xmapPartial(s => Try(s.toLong).toOption)(_.toString)
+    stringSegment.xmapPartial(s => Try(s.toLong).toOption)(_.toString())
 
   implicit def doubleSegment: Segment[Double] =
-    stringSegment.xmapPartial(s => Try(s.toDouble).toOption)(_.toString)
+    stringSegment.xmapPartial(s => Try(s.toDouble).toOption)(_.toString())
 
   /** An URL path carrying an `A` information */
   type Path[A] <: Url[A]

--- a/algebras/build.sbt
+++ b/algebras/build.sbt
@@ -16,32 +16,29 @@ val algebra =
     .dependsOnLocalCrossProjectsWithScope("json-schema" -> "test->test;compile->compile")
 
 val `algebra-js` = algebra.js
-
 val `algebra-jvm` = algebra.jvm
 
 val `algebra-circe` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("algebra-circe"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-algebra-circe",
       libraryDependencies ++= Seq(
         "io.circe" %%% "circe-parser" % circeVersion,
-        "io.circe" %%% "circe-generic" % circeVersion % Test,
-        compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" % Test cross CrossVersion.full)
+        "io.circe" %%% "circe-generic" % circeVersion % Test
       )
     )
     .dependsOn(`algebra` % "test->test;compile->compile")
 
 val `algebra-circe-js` = `algebra-circe`.js
-
 val `algebra-circe-jvm` = `algebra-circe`.jvm
 
 val `algebra-playjson` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("algebra-playjson"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-algebra-playjson",
       libraryDependencies += "com.typesafe.play" %%% "play-json" % playjsonVersion
     )

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,6 @@ val `akka-http` = project.in(file("akka-http")).settings(noPublishSettings)
 val scalaj = project.in(file("scalaj")).settings(noPublishSettings)
 val sttp = project.in(file("sttp")).settings(noPublishSettings)
 
-// Test kit
-val testsuite = project.in(file("testsuite")).settings(noPublishSettings)
-
 // Documentation and examples
 val documentation = project.in(file("documentation")).settings(noPublishSettings)
 

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -38,7 +38,7 @@ val apiDoc =
     .enablePlugins(ScalaUnidocPlugin)
     .settings(
       noPublishSettings,
-      scalaVersion := "2.12.8",
+      `scala 2.12`,
       coverageEnabled := false,
       scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
         "-implicits",
@@ -62,7 +62,7 @@ val manual =
   project.in(file("manual"))
     .enablePlugins(OrnatePlugin, GhpagesPlugin)
     .settings(
-      scalaVersion := "2.12.8",
+      `scala 2.12`,
       coverageEnabled := false,
       git.remoteRepo := "git@github.com:julienrf/endpoints.git",
       ornateSettings := Map("version" -> version.value),
@@ -82,7 +82,7 @@ val manual =
 val `example-quickstart-endpoints` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
     .in(file("examples/quickstart/endpoints"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.11 to latest`)
     .jsSettings(
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false
@@ -100,7 +100,7 @@ val `example-quickstart-client` =
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       noPublishSettings,
-      `scala 2.11 to 2.12`
+      `scala 2.12 to latest`
     )
     .dependsOn(`example-quickstart-endpoints-js`, `xhr-client-circe`)
 
@@ -108,8 +108,8 @@ val `example-quickstart-server` =
   project.in(file("examples/quickstart/server"))
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
-      libraryDependencies += "org.scala-stm" %% "scala-stm" % "0.9"
+      `scala 2.12 to latest`,
+      libraryDependencies += "org.scala-stm" %% "scala-stm" % "0.9.1"
     )
     .dependsOn(`example-quickstart-endpoints-jvm`, `play-server-playjson`, `openapi-jvm`)
 
@@ -119,8 +119,8 @@ val `example-basic-shared` = {
   CrossProject("example-basic-shared", file("examples/basic/shared"))(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
-      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
+      `scala 2.12 to latest`,
+      macroParadiseDependency,
       (sourceGenerators in Compile) += Def.task {
         assets.AssetsTasks.generateDigests(
           baseDirectory = baseDirectory.value.getParentFile,
@@ -150,7 +150,6 @@ val `example-basic-shared` = {
 }
 
 val `example-basic-shared-jvm` = `example-basic-shared`.jvm
-
 val `example-basic-shared-js` = `example-basic-shared`.js
 
 val `example-basic-client` =
@@ -158,9 +157,11 @@ val `example-basic-client` =
     .enablePlugins(ScalaJSPlugin)
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
+      coverageEnabled := false,
+      scalaJSUseMainModuleInitializer := true,
+      libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3"
     )
     .dependsOn(`example-basic-shared-js`, `xhr-client-circe`)
 
@@ -168,7 +169,7 @@ val `example-basic-play-server` =
   project.in(file("examples/basic/play-server"))
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       unmanagedResources in Compile += (fastOptJS in(`example-basic-client`, Compile)).map(_.data).value,
       libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25",
       libraryDependencies += "com.typesafe.play" %% "play" % playVersion
@@ -179,7 +180,7 @@ val `example-basic-akkahttp-server` =
   project.in(file("examples/basic/akkahttp-server"))
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       publishArtifact := false
     )
     .dependsOn(`example-basic-shared-jvm`, `akka-http-server`, `akka-http-server-circe`)
@@ -190,19 +191,21 @@ val `example-basic-akkahttp-server` =
 val `example-cqrs-public-endpoints` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
     .in(file("examples/cqrs/public-endpoints"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .jsSettings(
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false
     )
     .jvmSettings(coverageEnabled := true)
     .settings(
-      libraryDependencies += "io.circe" %%% "circe-generic" % circeVersion
+      libraryDependencies ++= Seq(
+        "io.circe" %%% "circe-generic" % circeVersion,
+        "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3"
+      )
     )
-    .dependsOnLocalCrossProjects("example-cqrs-circe-instant", "json-schema-generic", "algebra-circe")
+    .dependsOnLocalCrossProjects("json-schema-generic", "algebra-circe")
 
 val `example-cqrs-public-endpoints-jvm` = `example-cqrs-public-endpoints`.jvm
-
 val `example-cqrs-public-endpoints-js` = `example-cqrs-public-endpoints`.js
 
 // web-client, *uses* the public endpoints’ definitions
@@ -211,14 +214,13 @@ val `example-cqrs-web-client` =
     .enablePlugins(ScalaJSPlugin)
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12`,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies ++= Seq(
         "in.nvilla" %%% "monadic-html" % "0.2.3",
-        "in.nvilla" %%% "monadic-rx-cats" % "0.2.3",
-        "org.julienrf" %%% "faithful-cats" % "1.1.0",
-        "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
+        "org.julienrf" %%% "faithful-cats" % "2.0.0",
+        "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3"
       ),
       scalaJSUseMainModuleInitializer := true
     )
@@ -230,7 +232,7 @@ val `example-cqrs-public-server` =
   project.in(file("examples/cqrs/public-server"))
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12`,
       unmanagedResources in Compile += (fastOptJS in (`example-cqrs-web-client`, Compile)).map(_.data).value,
       (sourceGenerators in Compile) += Def.task {
         assets.AssetsTasks.generateDigests(
@@ -250,22 +252,22 @@ lazy val `example-cqrs-commands-endpoints` =
   project.in(file("examples/cqrs/commands-endpoints"))
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       libraryDependencies ++= Seq(
-        "org.scala-stm" %% "scala-stm" % "0.9",
+        "org.scala-stm" %% "scala-stm" % "0.9.1",
         "io.circe" %% "circe-generic" % circeVersion
       )
     )
-    .dependsOn(`algebra-circe-jvm`, `circe-instant-jvm`)
+    .dependsOn(`algebra-circe-jvm`)
 
 // commands implementation
 val `example-cqrs-commands` =
   project.in(file("examples/cqrs/commands"))
     .settings(
       noPublishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       libraryDependencies ++= Seq(
-        "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
+        "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
         scalaTestDependency
       )
     )
@@ -275,47 +277,32 @@ val `example-cqrs-commands` =
 // queries endpoints definitions
 lazy val `example-cqrs-queries-endpoints` =
   project.in(file("examples/cqrs/queries-endpoints"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .dependsOn(`algebra-circe-jvm`, `example-cqrs-public-endpoints-jvm` /* because we reuse the DTOs */)
 
 // queries implementation
 val `example-cqrs-queries` =
   project.in(file("examples/cqrs/queries"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .dependsOn(`play-server-circe`, `play-client`)
     .dependsOn(`example-cqrs-queries-endpoints`, `example-cqrs-commands-endpoints`)
 
 // this one exists only for the sake of simplifying the infrastructure: it runs all the HTTP services
 val `example-cqrs` =
   project.in(file("examples/cqrs/infra"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.12`)
     .settings(
       cancelable in Global := true,
       libraryDependencies ++= Seq(
-        "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
+        "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
         scalaTestDependency
       )
     )
-    .dependsOn(`example-cqrs-queries`, `example-cqrs-commands`, `example-cqrs-public-server`, `example-cqrs-web-client`/*, `circe-instant-js`*/ /*, `circe-instant-jvm`*/)
-
-lazy val `circe-instant` =
-  CrossProject("example-cqrs-circe-instant", file("examples/cqrs/circe-instant"))(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
-    .jsSettings(
-      //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
-      coverageEnabled := false
-    )
-    .jvmSettings(coverageEnabled := true)
-    .settings(
-      libraryDependencies += "io.circe" %%% "circe-core" % circeVersion
-    )
-
-lazy val `circe-instant-js` = `circe-instant`.js
-lazy val `circe-instant-jvm` = `circe-instant`.jvm
+    .dependsOn(`example-cqrs-queries`, `example-cqrs-commands`, `example-cqrs-public-server`)
 
 val `example-documented` =
   project.in(file("examples/documented"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .settings(
       herokuAppName in Compile := "documented-counter",
       herokuFatJar in Compile := Some((assemblyOutputPath in assembly).value),
@@ -343,12 +330,11 @@ val `example-documented` =
 
 val `example-authentication` =
   project.in(file("examples/authentication"))
-    .settings(noPublishSettings, `scala 2.11 to 2.12`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .settings(
       libraryDependencies ++= Seq(
-        "com.pauldijou" %% "jwt-play" % "1.0.0",
-        "com.lihaoyi"   %% "utest"    % "0.6.6"   % Test
-      ),
-      testFrameworks += new TestFramework("utest.runner.Framework")
+        "com.pauldijou" %% "jwt-play" % "4.0.0",
+        scalaTestDependency
+      )
     )
     .dependsOn(`play-server`, `play-client`, `algebra-playjson-jvm`)

--- a/documentation/examples/authentication/src/main/scala/authentication/Usage.scala
+++ b/documentation/examples/authentication/src/main/scala/authentication/Usage.scala
@@ -9,6 +9,8 @@ import endpoints.play.server
 
 //#login-implementation
 import endpoints.play.client
+import endpoints.play.server.PlayComponents
+import play.api.Configuration
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.ExecutionContext
@@ -51,7 +53,7 @@ trait AuthenticationEndpoints
   * Client for the `AuthenticationEndpoints`, using the `ClientAuthentication`
   * interpreter (implementing the authentication logic), defined below.
   */
-class Client(host: String, wsClient: WSClient)(implicit ec: ExecutionContext)
+class Client(host: String, wsClient: WSClient, val playConfiguration: Configuration)(implicit ec: ExecutionContext)
   extends client.Endpoints(host, wsClient)
     with AuthenticationEndpoints
     with ClientAuthentication
@@ -60,7 +62,7 @@ class Client(host: String, wsClient: WSClient)(implicit ec: ExecutionContext)
   * Example of server implementing the `AuthenticationEndpoints`
   */
 //#login-implementation
-class Server(val playComponents: server.PlayComponents)
+class Server(val playComponents: PlayComponents, val playConfiguration: Configuration)
   extends AuthenticationEndpoints
     with server.Endpoints
     with ServerAuthentication {

--- a/documentation/examples/authentication/src/test/scala/authentication/AuthenticationTest.scala
+++ b/documentation/examples/authentication/src/test/scala/authentication/AuthenticationTest.scala
@@ -1,49 +1,50 @@
 package authentication
 
-import endpoints.play.server.{DefaultPlayComponents, HttpServer}
+import endpoints.play.server.PlayComponents
+import org.scalatest.{AsyncFreeSpec, BeforeAndAfterAll}
 import pdi.jwt.JwtSession
-import play.api.Mode
+import play.api.{Configuration, Mode}
 import play.api.http.{HeaderNames, Status}
 import play.api.libs.ws.ahc.{AhcWSClient, AhcWSClientConfig}
-import play.core.server.ServerConfig
-import utest.{TestSuite, TestableSymbol, Tests, assert}
+import play.core.server.{NettyServer, ServerConfig}
 
-object AuthenticationTest extends TestSuite {
+class AuthenticationTest extends AsyncFreeSpec with BeforeAndAfterAll {
 
   val host = "0.0.0.0"
   val port = 8765
   val playConfig = ServerConfig(port = Some(port), mode = Mode.Test, address = host)
-  val playComponents = new DefaultPlayComponents(playConfig)
-  import playComponents.executionContext
-  val server = {
-    val serverInstance = new Server(playComponents)
-    HttpServer(playConfig, playComponents, serverInstance.routes)
-  }
-  val wsClient = AhcWSClient(AhcWSClientConfig())(playComponents.materializer)
-  val client = new Client(s"http://$host:$port", wsClient)
+  val server = NettyServer.fromRouterWithComponents(playConfig) { components =>
+    new Server(PlayComponents.fromBuiltInComponents(components), components.configuration).routes
+  }.asInstanceOf[NettyServer]
+  import server.materializer
+  import server.actorSystem.dispatcher
+  import ClockSettings._
+  implicit val playConfiguration: Configuration = Configuration.reference
+  val wsClient = AhcWSClient(AhcWSClientConfig())
+  val client = new Client(s"http://$host:$port", wsClient, playConfiguration)
 
   def uri(path: String): String = s"http://$host:$port$path"
 
-  override def utestAfterAll(): Unit = {
-    server.stop()
+  override def afterAll(): Unit = {
     wsClient.close()
-    super.utestAfterAll()
+    server.stop()
+    super.afterAll()
   }
 
-  val tests = Tests {
-    'unauthenticatedRequestGetsRejected - {
+  "authentication" - {
+    "unauthenticated request gets rejected" in {
       for {
         response <- wsClient.url(uri("/some-resource")).get()
       } yield assert(response.status == Status.UNAUTHORIZED)
     }
-    'invalidAuthenticatedRequestGetsRejected - {
+    "invalid authenticated request gets rejected" in {
       for {
         response <- wsClient.url(uri("/some-resource"))
           .withHttpHeaders(HeaderNames.AUTHORIZATION -> "lol")
           .get()
       } yield assert(response.status == Status.UNAUTHORIZED)
     }
-    'invalidJsonTokenGetsRejected - {
+    "invalid json token gets rejected" in {
       val token = """eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"""
       for {
         response <- wsClient.url(uri("/some-resource"))
@@ -51,12 +52,12 @@ object AuthenticationTest extends TestSuite {
           .get()
       } yield assert(response.status == Status.UNAUTHORIZED)
     }
-    'wrongLoginIsRejected - {
+    "wrong login is rejected" in {
       for {
         loginResponse <- wsClient.url(uri("/login")).withQueryStringParameters("apiKey" -> "unknown").get()
       } yield assert(loginResponse.status == Status.BAD_REQUEST)
     }
-    'loginGivesAValidJsonToken - {
+    "login gives a valid json token" in {
       for {
         loginResponse <- wsClient.url(uri("/login")).withQueryStringParameters("apiKey" -> "foobar").get()
         token = loginResponse.headers(HeaderNames.AUTHORIZATION).head.drop("Bearer ".length)
@@ -72,19 +73,19 @@ object AuthenticationTest extends TestSuite {
       } yield assert(response.status == Status.OK)
     }
     //#login-test-client
-    'wrongLoginUsingClient - {
+    "wrong login using client" in {
       for {
         loginResult <- client.login("unknown")
       } yield assert(loginResult.isEmpty)
     }
-    'validLoginUsingClient - {
+    "valid login using client" in {
       for {
         loginResult <- client.login("foobar")
       } yield assert(loginResult.nonEmpty)
     }
     //#login-test-client
     //#protected-endpoint-test
-    'loginAndAccessProtectedResource - {
+    "login and access protected resource" in {
       for {
         maybeToken <- client.login("foobar")
         token = maybeToken.get

--- a/documentation/examples/basic/play-server/src/main/resources/application.conf
+++ b/documentation/examples/basic/play-server/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-play.crypto.secret=1
+play.http.secret.key=123123123123123123

--- a/documentation/examples/cqrs/commands-endpoints/src/main/scala/cqrs/commands/CommandsEndpoints.scala
+++ b/documentation/examples/cqrs/commands-endpoints/src/main/scala/cqrs/commands/CommandsEndpoints.scala
@@ -4,7 +4,6 @@ import java.time.Instant
 import java.util.UUID
 
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.java8.time._
 import io.circe.{Decoder, Encoder}
 
 //#endpoints

--- a/documentation/examples/cqrs/commands/src/test/scala/cqrs/commands/CommandsTest.scala
+++ b/documentation/examples/cqrs/commands/src/test/scala/cqrs/commands/CommandsTest.scala
@@ -3,10 +3,10 @@ package cqrs.commands
 import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
-import akka.stream.Materializer
 import org.scalatest.{AsyncFreeSpec, BeforeAndAfterAll}
-import endpoints.play.client.{JsonEntitiesFromCodec, Endpoints}
-import endpoints.play.server.DefaultPlayComponents
+import endpoints.play.client.{Endpoints, JsonEntitiesFromCodec}
+import endpoints.play.server.PlayComponents
+import play.api.Mode
 import play.api.libs.ws.ahc.{AhcWSClient, AhcWSClientConfig}
 import play.core.server.{NettyServer, ServerConfig}
 
@@ -15,9 +15,11 @@ import scala.math.BigDecimal
 
 class CommandsTest extends AsyncFreeSpec with BeforeAndAfterAll {
 
-  private val server = NettyServer.fromRouter()(new Commands(new DefaultPlayComponents(ServerConfig())).routes)
-
-  implicit val materializer: Materializer = server.materializer
+  private val server = NettyServer.fromRouterWithComponents(ServerConfig(mode = Mode.Test)) { components =>
+    new Commands(PlayComponents.fromBuiltInComponents(components)).routes
+  }
+  val app = server.applicationProvider.get.get
+  import app.materializer
   private val wsClient = AhcWSClient(AhcWSClientConfig())
 
   object client

--- a/documentation/examples/cqrs/infra/src/main/resources/application.conf
+++ b/documentation/examples/cqrs/infra/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-play.crypto.secret=abc
+play.crypto.secret=abcabcabcabcabcabc

--- a/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/publicserver/PublicEndpoints.scala
+++ b/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/publicserver/PublicEndpoints.scala
@@ -7,7 +7,6 @@ import cqrs.publicserver.commands.{AddRecord, CreateMeter}
 import cqrs.queries.Meter
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.java8.time._
 
 /**
   * Definition of the public HTTP API of our application.

--- a/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/queries/model.scala
+++ b/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/queries/model.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.java8.time._
 
 import scala.collection.immutable.SortedMap
 
@@ -21,7 +20,7 @@ object Meter {
     Decoder[Seq[(A, B)]].map(entries => (SortedMap.newBuilder[A, B] ++= entries).result())
 
   implicit def encodeSortedMap[A : Encoder, B : Encoder]: Encoder[SortedMap[A, B]] =
-    Encoder.encodeList[(A, B)].contramap[SortedMap[A, B]](_.to[List])
+    Encoder.encodeList[(A, B)].contramap[SortedMap[A, B]](_.toList)
 
   implicit val decoder: Decoder[Meter] = deriveDecoder
   implicit val encoder: Encoder[Meter] = deriveEncoder

--- a/documentation/examples/cqrs/public-server/src/main/scala/cqrs/publicserver/PublicServer.scala
+++ b/documentation/examples/cqrs/public-server/src/main/scala/cqrs/publicserver/PublicServer.scala
@@ -7,7 +7,7 @@ import play.api.libs.ws.WSClient
 import play.api.routing.{Router => PlayRouter}
 import cats.instances.option._
 import cats.instances.future._
-import endpoints.play.server.{JsonEntitiesFromCodec, Endpoints, PlayComponents}
+import endpoints.play.server.{Endpoints, JsonEntitiesFromCodec, PlayComponents}
 
 import scala.concurrent.Future
 

--- a/documentation/examples/cqrs/queries/src/main/scala/cqrs/queries/QueriesService.scala
+++ b/documentation/examples/cqrs/queries/src/main/scala/cqrs/queries/QueriesService.scala
@@ -23,7 +23,7 @@ class QueriesService(commandsBaseUrl: String, wsClient: WSClient, scheduler: Sch
     updateIfRequired(maybeAfter)(_.meters.get(id))
 
   def findAll(): Future[List[Meter]] =
-    Future.successful(stateRef.single.get.meters.values.to[List])
+    Future.successful(stateRef.single.get.meters.values.toList)
 
   // --- internals
 

--- a/documentation/examples/documented/src/main/resources/application.conf
+++ b/documentation/examples/documented/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-play.crypto.secret=abc
+play.crypto.secret=abcabcabcabcabc

--- a/documentation/examples/quickstart/server/src/main/resources/application.conf
+++ b/documentation/examples/quickstart/server/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-play.crypto.secret=123
+play.crypto.secret=123123123123123

--- a/documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala
+++ b/documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala
@@ -3,16 +3,19 @@ package quickstart
 //#relevant-code
 import endpoints.openapi.model.{OpenApi, OpenApiSchemas}
 import endpoints.play.server
+import endpoints.play.server.PlayComponents
+import play.core.server.NettyServer
 //#main-only
-import endpoints.play.server.{DefaultPlayComponents, HttpServer, PlayComponents}
 import play.core.server.ServerConfig
 
 object Main extends App {
   val config = ServerConfig()
-  val playComponents = new DefaultPlayComponents(config)
-  val counterServer = new CounterServer(playComponents)
-  val documentationServer = new DocumentationServer(playComponents)
-  HttpServer(config, playComponents, counterServer.routes orElse documentationServer.routes)
+  NettyServer.fromRouterWithComponents(config) { components =>
+    val playComponents = PlayComponents.fromBuiltInComponents(components)
+    val counterServer = new CounterServer(playComponents)
+    val documentationServer = new DocumentationServer(playComponents)
+    counterServer.routes orElse documentationServer.routes
+  }
 }
 //#main-only
 

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -33,7 +33,7 @@ lazy val `json-schema-circe` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("json-schema-circe"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-json-schema-circe",
       libraryDependencies += "io.circe" %%% "circe-core" % circeVersion
     )
@@ -47,7 +47,7 @@ lazy val `json-schema-playjson` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("json-schema-playjson"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-json-schema-playjson",
       libraryDependencies += "com.typesafe.play" %%% "play-json" % playjsonVersion
     )

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -361,7 +361,7 @@ class JsonSchemasTest extends FreeSpec {
     val jsResult = jsonSchema.reads.reads(json)
     assert(jsResult.isError)
 
-    val errorMessages: Seq[String] = jsResult.asEither.left.get.flatMap(_._2).flatMap(_.messages) // ignoring JsPath
+    val errorMessages: scala.collection.Seq[String] = jsResult.asEither.left.get.flatMap(_._2).flatMap(_.messages) // ignoring JsPath
     assert(errorMessages.head == expectedError)
   }
 

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -6,7 +6,7 @@ lazy val openapi =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("openapi"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`, // We don’t support 2.11 because our tests have a dependency on circe
       name := "endpoints-openapi"
     )
     .dependsOnLocalCrossProjects("json-schema-generic")

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -26,7 +26,7 @@ trait Endpoints
         .groupBy(_.path)
         .mapValues(es => es.tail.foldLeft(PathItem(es.head.item.operations)) { (item, e2) =>
           PathItem(item.operations ++ e2.item.operations)
-        })
+        }).toMap
     val components = Components(
       schemas = captureSchemas(endpoints),
       securitySchemes = captureSecuritySchemes(endpoints)

--- a/play/build.sbt
+++ b/play/build.sbt
@@ -10,7 +10,7 @@ val `play-server` =
   project.in(file("server"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`, // Note that we could support 2.11. Only our tests use circe (which has dropped 2.11)
       name := "endpoints-play-server",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play-netty-server" % playVersion,
@@ -24,7 +24,7 @@ val `play-server-circe` =
   project.in(file("server-circe"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-play-server-circe",
       libraryDependencies += "io.circe" %% "circe-parser" % circeVersion
     )
@@ -32,8 +32,9 @@ val `play-server-circe` =
 
 val `play-server-playjson` =
   project.in(file("server-playjson"))
-    .settings(publishSettings ++ `scala 2.11 to 2.12`: _*)
     .settings(
+      publishSettings,
+      `scala 2.12 to latest`,
       name := "endpoints-play-server-playjson",
       libraryDependencies += "com.typesafe.play" %% "play-json" % playjsonVersion
     )
@@ -41,10 +42,13 @@ val `play-server-playjson` =
 
 val `play-client` =
   project.in(file("client"))
-      .settings(
-        publishSettings,
-        `scala 2.11 to 2.12`,
-        name := "endpoints-play-client",
-        libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % playVersion
+    .settings(
+      publishSettings,
+      `scala 2.12 to latest`,
+      name := "endpoints-play-client",
+      libraryDependencies ++= Seq(
+        "com.typesafe.play" %% "play-ahc-ws" % playVersion,
+        "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0", // See https://github.com/playframework/play-ws/issues/371
       )
-      .dependsOn(`algebra-jvm` % "test->test;compile->compile", `algebra-circe-jvm` % "compile->test;test->test")
+    )
+    .dependsOn(`algebra-jvm` % "test->test;compile->compile", `algebra-circe-jvm` % "compile->test;test->test")

--- a/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
+++ b/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
@@ -41,8 +41,8 @@ class EndpointsTest
 
   override def afterAll(): Unit = {
     wsClient.close()
+    Thread.sleep(6000) // Unfortunate hack to let WSTestClient terminate its ActorSystem. See https://github.com/playframework/playframework/blob/8b0d5afb8c353dd8cd8d9e8057136e1858ad0173/transport/client/play-ahc-ws/src/main/scala/play/api/test/WSTestClient.scala#L142
     super.afterAll()
   }
 
 }
-

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -278,7 +278,7 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
     def playHandler(header: RequestHeader): Option[PlayHandler] =
       endpoint.request.decode(header)
         .map { bodyParser =>
-          playComponents.actionBuilder.async(bodyParser) { request =>
+          playComponents.defaultActionBuilder.async(bodyParser) { request =>
             service(request.body).map { b =>
               endpoint.response(b)
             }

--- a/play/server/src/main/scala/endpoints/play/server/MuxEndpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/MuxEndpoints.scala
@@ -41,7 +41,7 @@ trait MuxEndpoints extends algebra.MuxEndpoints with Endpoints {
     ): ToPlayHandler =
       header =>
         request.decode(header).map { bodyParser =>
-          playComponents.actionBuilder.async(bodyParser) { request =>
+          playComponents.defaultActionBuilder.async(bodyParser) { request =>
             handler(decoder.decode(request.body).right.get /* TODO Handle failure */.asInstanceOf[Req { type Response = Resp}])
               .map(resp => response(encoder.encode(resp)))
           }

--- a/play/server/src/main/scala/endpoints/play/server/PlayComponents.scala
+++ b/play/server/src/main/scala/endpoints/play/server/PlayComponents.scala
@@ -1,19 +1,8 @@
 package endpoints.play.server
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
-import play.api.ApplicationLoader.Context
-import play.api.{ApplicationLoader, Configuration, DefaultApplication, Environment}
-import play.api.http._
-import play.api.inject.{ApplicationLifecycle, NewInstanceInjector, SimpleInjector}
-import play.api.libs.Files._
-import play.api.libs.concurrent.ActorSystemProvider
-import play.api.mvc._
-import play.api.mvc.request.DefaultRequestFactory
-import play.api.routing.Router
-import play.api.routing.Router.Routes
-import play.core.SourceMapper
-import play.core.server.ServerConfig
+import play.api.BuiltInComponents
+import play.api.http.FileMimeTypes
+import play.api.mvc.{DefaultActionBuilder, PlayBodyParsers}
 
 import scala.concurrent.ExecutionContext
 
@@ -21,56 +10,33 @@ import scala.concurrent.ExecutionContext
   * Play components needed by the interpreter
   */
 trait PlayComponents {
-  def environment: Environment
-  def configuration: Configuration
-  def applicationLifecycle: ApplicationLifecycle
-  def actorSystem: ActorSystem
-  implicit def executionContext: ExecutionContext
-  implicit def materializer: Materializer
-  def httpConfiguration: HttpConfiguration
-  def httpErrorHandler: HttpErrorHandler
   def playBodyParsers: PlayBodyParsers
-  def actionBuilder: ActionBuilder[Request, AnyContent]
+  def defaultActionBuilder: DefaultActionBuilder
   def fileMimeTypes: FileMimeTypes
+  implicit def executionContext: ExecutionContext
 }
 
-/**
-  * Instantiation of the Play components for a given server configuration.
-  * @param config Server configuration
-  */
-class DefaultPlayComponents(config: ServerConfig) extends PlayComponents {
-  val environment: Environment = Environment.simple(mode = config.mode)
-  val configuration: Configuration = config.configuration
-  val context: Context = ApplicationLoader.createContext(environment)
-  val applicationLifecycle: ApplicationLifecycle = context.lifecycle
-  val sourceMapper: Option[SourceMapper] = context.sourceMapper
-  val actorSystem: ActorSystem = new ActorSystemProvider(environment, configuration, applicationLifecycle).get
-  implicit val materializer: Materializer = ActorMaterializer()(actorSystem)
-  implicit val executionContext: ExecutionContext = actorSystem.dispatcher
+object PlayComponents {
 
-  val httpConfiguration: HttpConfiguration = HttpConfiguration.fromConfiguration(configuration, environment)
-  val httpErrorHandler: HttpErrorHandler = new DefaultHttpErrorHandler(environment, configuration, sourceMapper, None)
-  val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
-  val tempFileReaper: TemporaryFileReaper = new DefaultTemporaryFileReaper(actorSystem, TemporaryFileReaperConfiguration.fromConfiguration(configuration))
-  val tempFileCreator: TemporaryFileCreator = new DefaultTemporaryFileCreator(applicationLifecycle, tempFileReaper)
-  val playBodyParsers: PlayBodyParsers = PlayBodyParsers(tempFileCreator, httpErrorHandler, httpConfiguration.parser)
-  val actionBuilder: DefaultActionBuilder = DefaultActionBuilder(playBodyParsers.default)
-}
+  /** Creates the `PlayComponents` from a `BuiltInComponents` instance
+    *
+    * This can be useful in conjunction with the usage of `fromXxxWithComponents`
+    * methods of Play framework:
+    *
+    * {{{
+    *   val serverConfig = ServerConfig(...)
+    *   NettyServer.fromRouterWithComponents(serverConfig) { builtInComponents =>
+    *     val playComponents = PlayComponents.fromBuiltInComponents(builtInComponents)
+    *     ...
+    *   }
+    * }}}
+    */
+  def fromBuiltInComponents(builtInComponents: BuiltInComponents): PlayComponents =
+    new PlayComponents {
+      def playBodyParsers: PlayBodyParsers = builtInComponents.playBodyParsers
+      def defaultActionBuilder: DefaultActionBuilder = builtInComponents.defaultActionBuilder
+      def fileMimeTypes: FileMimeTypes = builtInComponents.fileMimeTypes
+      implicit def executionContext: ExecutionContext = builtInComponents.executionContext
+    }
 
-object HttpServer {
-  def apply(config: ServerConfig, playComponents: PlayComponents, routes: Routes): play.core.server.NettyServer = {
-    val httpRequestHandler = new DefaultHttpRequestHandler(Router.from(routes), playComponents.httpErrorHandler, playComponents.httpConfiguration)
-    val application = new DefaultApplication(
-      playComponents.environment,
-      playComponents.applicationLifecycle,
-      new SimpleInjector(NewInstanceInjector),
-      playComponents.configuration,
-      new DefaultRequestFactory(playComponents.httpConfiguration),
-      httpRequestHandler,
-      playComponents.httpErrorHandler,
-      playComponents.actorSystem,
-      playComponents.materializer
-    )
-    play.core.server.NettyServer.fromApplication(application, config)
-  }
 }

--- a/play/server/src/main/scala/endpoints/play/server/Urls.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Urls.scala
@@ -40,7 +40,7 @@ trait Urls extends algebra.Urls {
     new Applicative[RequestExtractor] {
       def apply[A, B](mf: RequestExtractor[A => B], ma: RequestExtractor[A]): RequestExtractor[B] =
         request => mf(request).flatMap(f => ma(request).map(f))
-      def pure[A](a: A): RequestExtractor[A] =
+      def pure[A](a: => A): RequestExtractor[A] =
         _ => Some(a)
       def map[A, B](m: RequestExtractor[A], f: A => B): RequestExtractor[B] =
         request => m(request).map(f)
@@ -315,7 +315,7 @@ trait Urls extends algebra.Urls {
   private def pathExtractor[A](path: Path[A], request: RequestHeader): Option[Either[Result, A]] = {
       val segments =
         request.path
-          .split("/").to[List]
+          .split("/").toList
           .map(s => URLDecoder.decode(s, utf8Name))
       path.decode(if (segments.isEmpty) List("") else segments).flatMap {
         case Left(error)     => Some(Left(error))

--- a/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
@@ -2,13 +2,19 @@ package endpoints.play.server
 
 import endpoints.algebra.server.{DecodedUrl, EndpointsTestSuite}
 import play.api.Mode
+import play.api.routing.Router
 import play.api.test.FakeRequest
-import play.core.server.ServerConfig
+import play.core.server.{DefaultNettyServerComponents, ServerConfig}
 
-class ServerInterpreterTest extends EndpointsTestSuite[Endpoints] {
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 
-  val config = ServerConfig(mode = Mode.Test)
-  val serverApi: Endpoints = new EndpointsTestApi(new DefaultPlayComponents(config), Map.empty)
+class ServerInterpreterTest extends EndpointsTestSuite[Endpoints] with DefaultNettyServerComponents {
+
+  override lazy val serverConfig = ServerConfig(mode = Mode.Test)
+  lazy val router = Router.empty // We don’t use the server, we just want the BuiltInComponents to be wired for us
+  lazy val playComponents = PlayComponents.fromBuiltInComponents(this)
+  lazy val serverApi: Endpoints = new EndpointsTestApi(playComponents, Map.empty)
 
   def decodeUrl[A](url: serverApi.Url[A])(rawValue: String): DecodedUrl[A] = {
     val request = FakeRequest("GET", rawValue)
@@ -20,5 +26,10 @@ class ServerInterpreterTest extends EndpointsTestSuite[Endpoints] {
   }
 
   urlsTestSuite()
+
+  override protected def afterAll(): Unit = {
+    Await.ready(actorSystem.terminate(), 10.seconds)
+    super.afterAll()
+  }
 
 }

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -29,13 +29,21 @@ object EndpointsSettings {
     scalaVersion := "2.11.12",
     crossScalaVersions := Seq("2.11.12")
   )
+  val `scala 2.12` = Seq(
+    scalaVersion := "2.12.10",
+    crossScalaVersions := Seq("2.12.10")
+  )
   val `scala 2.11 to 2.12` = Seq(
     scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.11.12", "2.12.8")
+    crossScalaVersions := Seq("2.12.10", "2.11.12")
   )
   val `scala 2.11 to latest` = Seq(
-    scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
+    scalaVersion := "2.13.0",
+    crossScalaVersions := Seq("2.13.0", "2.12.10", "2.11.12")
+  )
+  val `scala 2.12 to latest` = Seq(
+    scalaVersion := "2.13.0",
+    crossScalaVersions := Seq("2.13.0", "2.12.10")
   )
 
   val publishSettings = commonSettings ++ Seq(
@@ -71,13 +79,26 @@ object EndpointsSettings {
 
   // --- Common dependencies
 
-  val circeVersion = "0.11.1"
-  val playjsonVersion = "2.6.13"
-  val playVersion = "2.6.21"
-  val sttpVersion = "1.5.15"
+  val circeVersion = "0.12.1"
+  val playjsonVersion = "2.7.4"
+  val playVersion = "2.7.3"
+  val sttpVersion = "1.6.6"
 
   val scalaTestVersion = "3.0.8"
   val scalaTestDependency = "org.scalatest" %% "scalatest" % scalaTestVersion % Test
   val addScalaTestCrossDependency = libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
-
+  val macroParadiseDependency = Seq(
+    scalacOptions in Compile ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
+        case _ => Nil
+      }
+    },
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 13 => Nil
+        case _ => compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+      }
+    }
+  )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.29")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
@@ -14,8 +14,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.3")
 addSbtPlugin("com.novocode" % "sbt-ornate" % "0.6")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
-
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 

--- a/scalaj/build.sbt
+++ b/scalaj/build.sbt
@@ -7,7 +7,7 @@ val `scalaj-client` =
   project.in(file("client"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-scalaj-client",
       libraryDependencies ++= Seq(
         "org.scalaj" %% "scalaj-http" % "2.4.2"

--- a/sttp/build.sbt
+++ b/sttp/build.sbt
@@ -7,12 +7,12 @@ val `sttp-client` =
   project.in(file("client"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-sttp-client",
       libraryDependencies ++= Seq(
         "com.softwaremill.sttp" %% "core" % sttpVersion,
         "com.softwaremill.sttp" %% "akka-http-backend" % sttpVersion % Test,
-        "com.typesafe.akka" %% "akka-stream" % "2.5.19" % Test
+        "com.typesafe.akka" %% "akka-stream" % "2.5.23" % Test
       )
     )
     .dependsOn(`algebra-jvm` % "compile->compile;test->test", `algebra-playjson-jvm` % "test->test")

--- a/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
+++ b/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
@@ -57,5 +57,11 @@ class EndpointsTestAkka
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+
+  override def afterAll(): Unit = {
+    backend.close()
+    Thread.sleep(1000) // See https://github.com/softwaremill/sttp/issues/269
+    super.afterAll()
+  }
 }
 

--- a/xhr/build.sbt
+++ b/xhr/build.sbt
@@ -5,7 +5,7 @@ val `xhr-client` =
     .enablePlugins(ScalaJSPlugin)
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-xhr-client",
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
@@ -21,11 +21,11 @@ val `xhr-client-faithful` =
     .enablePlugins(ScalaJSPlugin)
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-xhr-client-faithful",
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
-      libraryDependencies += "org.julienrf" %%% "faithful" % "1.1.0"
+      libraryDependencies += "org.julienrf" %%% "faithful" % "2.0.0"
     )
     .dependsOn(`xhr-client`)
 
@@ -34,7 +34,7 @@ val `xhr-client-circe` =
     .enablePlugins(ScalaJSPlugin)
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.12 to latest`,
       name := "endpoints-xhr-client-circe",
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
@@ -1,7 +1,6 @@
 package endpoints.xhr.circe
 
 import endpoints.algebra
-import endpoints.algebra.Documentation
 import endpoints.xhr.Endpoints
 import io.circe.{parser, Decoder => CirceDecoder, Encoder => CirceEncoder}
 import org.scalajs.dom.XMLHttpRequest


### PR DESCRIPTION
Update dependencies to Akka 10.1 and Play 2.7. This makes it possible to build the corresponding interpreters for Scala 2.13.