### PR TITLE
add .editorconfig fixing line endings to LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -227,7 +227,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
       import OpenApiEncoder.JsonSchema._
       import io.circe.syntax._
 
-      Fixtures.openApiDocument.asJson.spaces2 shouldBe expectedSchema // TODO test
+      Fixtures.openApiDocument.asJson.spaces2 shouldBe expectedSchema
     }
 
     "produce referenced schema with playjson" in {


### PR DESCRIPTION
ReferencedSchemaTest fails on Windows if line endings are not LF
but CRLF (circe uses LF)