### PR TITLE
rename emptyRequest to emptyBody and document missing doc possibilities

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -67,7 +67,7 @@ class Endpoints(val settings: EndpointsSettings)
     }
   }
 
-  lazy val emptyRequest: RequestEntity[Unit] = (_, req) => req
+  lazy val emptyBody: RequestEntity[Unit] = (_, req) => req
 
   def textRequest(docs: Option[String]): (String, HttpRequest) => HttpRequest =
     (body, request) => request.copy(entity = HttpEntity(body))

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -42,7 +42,7 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
       REQUESTS
   ************************* */
 
-  def emptyRequest: RequestEntity[Unit] = convToDirective1(Directives.pass)
+  def emptyBody: RequestEntity[Unit] = convToDirective1(Directives.pass)
 
   def textRequest(docs: Documentation): RequestEntity[String] = {
     val um: FromRequestUnmarshaller[String] = implicitly
@@ -83,7 +83,7 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
   def request[A, B, C, AB, Out](
     method: Method,
     url: Url[A],
-    entity: RequestEntity[B] = emptyRequest,
+    entity: RequestEntity[B] = emptyBody,
     headers: RequestHeaders[C] = emptyHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] = {
     val methodDirective = convToDirective1(Directives.method(method))

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -35,7 +35,7 @@ trait BasicAuthentication extends Endpoints {
     method: Method,
     url: Url[U],
     response: Response[R],
-    requestEntity: RequestEntity[E] = emptyRequest,
+    requestEntity: RequestEntity[E] = emptyBody,
     requestHeaders: RequestHeaders[H] = emptyHeaders,
     unauthenticatedDocs: Documentation = None,
     summary: Documentation = None,

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -17,6 +17,8 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
     * be empty. Just that, from a server point of view no information will
     * be extracted from them, and from a client point of view no particular
     * headers will be built in the request.
+    *
+    * Use `description` of [[endpoints.algebra.Endpoints#endpoint]] to document empty headers.
     */
   def emptyHeaders: RequestHeaders[Unit]
 
@@ -37,13 +39,13 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
   implicit def reqEntityInvFunctor: InvariantFunctor[RequestEntity]
 
   /**
-    * Empty request.
+    * Request without a body.
+    * Use `description` of [[endpoints.algebra.Endpoints#endpoint]] to document an empty body.
     */
-  //TODO rename to emptyBody and maybe make uniform with all other by adding ()
-  def emptyRequest: RequestEntity[Unit]
+  def emptyBody: RequestEntity[Unit]
 
   /**
-    * Request with string body.
+    * Request with a [[String]] body.
     */
   def textRequest(docs: Documentation = None): RequestEntity[String]
 
@@ -62,7 +64,7 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
   def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     method: Method,
     url: Url[UrlP],
-    entity: RequestEntity[BodyP] = emptyRequest,
+    entity: RequestEntity[BodyP] = emptyBody,
     headers: RequestHeaders[HeadersP] = emptyHeaders
   )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out]
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
@@ -23,7 +23,7 @@ trait EndpointsDocs extends Endpoints {
   //#request-construction
   // A request that uses the verb “GET”, the URL path “/foo”,
   // no entity and no headers
-  request(Get, path / "foo", emptyRequest, emptyHeaders)
+  request(Get, path / "foo", emptyBody, emptyHeaders)
   //#request-construction
 
   //#convenient-get

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -15,7 +15,7 @@ trait EndpointsTestApi extends algebra.Endpoints {
   )
 
   val putUUIDEndpoint = endpoint(
-    put(path / "user" / segment[UUID](), emptyRequest),
+    put(path / "user" / segment[UUID](), emptyBody),
     emptyResponse()
   )
 
@@ -35,7 +35,7 @@ trait EndpointsTestApi extends algebra.Endpoints {
   )
 
   val putEndpoint = endpoint(
-    put(path / "user" / segment[String](), emptyRequest),
+    put(path / "user" / segment[String](), emptyBody),
     emptyResponse()
   )
 

--- a/documentation/examples/authentication/src/main/scala/authentication/Usage.scala
+++ b/documentation/examples/authentication/src/main/scala/authentication/Usage.scala
@@ -38,7 +38,7 @@ trait AuthenticationEndpoints
   val someResource: Endpoint[AuthenticationToken, String] = authenticatedEndpoint(
     Get,
     path / "some-resource",
-    emptyRequest,
+    emptyBody,
     textResponse()
   )
 //#protected-endpoint

--- a/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
+++ b/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
@@ -26,7 +26,7 @@ trait DocumentedApi
     authenticatedEndpoint(
       Get,
       path / "admin",
-      requestEntity = emptyRequest,
+      requestEntity = emptyBody,
       response = emptyResponse(Some("Administration page")),
       summary = Some("Authentication endpoint")
     )

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
@@ -23,7 +23,7 @@ trait Assets
 
   def assetsEndpoint(url: Url[AssetPath], docs: Documentation, notFoundDocs: Documentation): Endpoint[AssetRequest, AssetResponse] =
     endpoint(
-      DocumentedRequest(Get, url, emptyHeaders, emptyRequest),
+      DocumentedRequest(Get, url, emptyHeaders, emptyBody),
       DocumentedResponse(200, docs.getOrElse(""), Map.empty) ::
         DocumentedResponse(404, notFoundDocs.getOrElse(""), Map.empty) ::
         Nil

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -27,7 +27,7 @@ trait BasicAuthentication
     method: Method,
     url: Url[U],
     response: Response[R],
-    requestEntity: RequestEntity[E] = emptyRequest,
+    requestEntity: RequestEntity[E] = emptyBody,
     requestHeaders: RequestHeaders[H] = emptyHeaders,
     unauthenticatedDocs: Documentation = None,
     summary: Documentation = None,

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -49,7 +49,7 @@ trait Requests
     */
   case class DocumentedRequestEntity(documentation: Option[String], content: Map[String, MediaType])
 
-  def emptyRequest = None
+  def emptyBody = None
 
   override def textRequest(docs: Documentation): Option[DocumentedRequestEntity] = Some(
     DocumentedRequestEntity(docs, Map("text/plain" -> MediaType(Some(Schema.simpleString))))
@@ -58,7 +58,7 @@ trait Requests
   def request[A, B, C, AB, Out](
     method: Method,
     url: Url[A],
-    entity: RequestEntity[B] = emptyRequest,
+    entity: RequestEntity[B] = emptyBody,
     headers: RequestHeaders[C] = emptyHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
     DocumentedRequest(method, url, headers, entity)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
@@ -27,7 +27,7 @@ trait Urls extends algebra.Urls {
     * @param name Name of the parameter
     * @param required Whether this parameter is required or not (MUST be true for path parameters)
     */
-  case class DocumentedParameter(name: String, required: Boolean, description: Option[String], schema: Schema)
+  case class DocumentedParameter(name: String, required: Boolean, description: Documentation, schema: Schema)
 
   def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
     DocumentedQueryString(first.parameters ++ second.parameters)

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -112,7 +112,7 @@ trait Fixtures extends algebra.Endpoints {
 
   val foo = endpoint(get(path / "foo"), emptyResponse(Some("Foo response")), tags = List("foo"))
 
-  val bar = endpoint(post(path / "foo", emptyRequest), emptyResponse(Some("Bar response")), tags = List("bar", "bxx"))
+  val bar = endpoint(post(path / "foo", emptyBody), emptyResponse(Some("Bar response")), tags = List("bar", "bxx"))
 
   val baz = endpoint(get(path / "baz" / segment[Int]("quux")), emptyResponse(Some("Baz response")), tags = List("baz", "bxx"))
 
@@ -122,8 +122,7 @@ trait Fixtures extends algebra.Endpoints {
 
   val quux = endpoint(get(path / "quux" /? (qs[Double]("n") & qs[Option[String]]("lang") & qs[List[Long]]("ids"))), emptyResponse())
 
-  val multipleSegmentsPath =
-    endpoint(get(path / "assets" / remainingSegments("file")), textResponse())
+  val multipleSegmentsPath = endpoint(get(path / "assets" / remainingSegments("file")), textResponse())
 
 }
 

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -58,7 +58,7 @@ class Endpoints(host: String, wsClient: WSClient)(implicit val executionContext:
     */
   type RequestEntity[A] = (A, WSRequest) => WSRequest
 
-  lazy val emptyRequest: RequestEntity[Unit] = {
+  lazy val emptyBody: RequestEntity[Unit] = {
     case (_, req) => req
   }
 

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -157,7 +157,7 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
   /** Decodes a request entity */
   type RequestEntity[A] = BodyParser[A]
 
-  lazy val emptyRequest: BodyParser[Unit] = BodyParser(_ => Accumulator.done(Right(())))
+  lazy val emptyBody: BodyParser[Unit] = BodyParser(_ => Accumulator.done(Right(())))
 
   def textRequest(docs: Documentation): BodyParser[String] = playComponents.playBodyParsers.text
 

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -38,7 +38,7 @@ trait Requests extends algebra.Requests with Urls with Methods {
   }
 
 
-  def emptyRequest: RequestEntity[Unit] = (x: Unit, req: HttpRequest) => req
+  def emptyBody: RequestEntity[Unit] = (_: Unit, req: HttpRequest) => req
 
   def textRequest(docs: Option[String]): (String, HttpRequest) => scalaj.http.HttpRequest =
     (body, req) => req.postData(body)
@@ -51,10 +51,10 @@ trait Requests extends algebra.Requests with Urls with Methods {
 
   def request[U, E, H, UE, Out](method: Method,
     url: Url[U],
-    entity: RequestEntity[E] = emptyRequest,
+    entity: RequestEntity[E] = emptyBody,
     headers: RequestHeaders[H] = emptyHeaders
   )(implicit tuplerUE: Tupler.Aux[U, E, UE], tuplerUEH: Tupler.Aux[UE, H, Out]): Request[Out] =
-    (ueh) => {
+    ueh => {
       val (ue, h) = tuplerUEH.unapply(ueh)
       val (u, e) = tuplerUE.unapply(ue)
       val req = url.toReq(u)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -64,7 +64,7 @@ class Endpoints[R[_]](host: String, val backend: sttp.SttpBackend[R, Nothing]) e
     */
   type RequestEntity[A] = (A, SttpRequest) => SttpRequest
 
-  lazy val emptyRequest: RequestEntity[Unit] = {
+  lazy val emptyBody: RequestEntity[Unit] = {
     case (_, req) => req
   }
 

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -69,7 +69,7 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods {
     */
   type RequestEntity[A] = js.Function2[A, XMLHttpRequest, js.Any]
 
-  lazy val emptyRequest: RequestEntity[Unit] = (_, _) => null
+  lazy val emptyBody: RequestEntity[Unit] = (_, _) => null
 
   def textRequest(docs: endpoints.algebra.Documentation): RequestEntity[String] = (body, xhr) => {
     xhr.setRequestHeader("Content-type", "text/plain; charset=utf8")

--- a/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
+++ b/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
@@ -6,10 +6,10 @@ import org.scalatest.FreeSpec
 // of the underlying representation of header in the xhr algebra.
 trait FixturesAlgebra extends endpoints.algebra.Endpoints {
   val foo = endpoint(get(path / "foo" / segment[String]()), emptyResponse())
-  val bar = endpoint(post(path / "bar" /? qs[Int]("quux"), emptyRequest), emptyResponse())
+  val bar = endpoint(post(path / "bar" /? qs[Int]("quux"), emptyBody), emptyResponse())
   // Currently, the fact that this line compiles is a test, as there's no way
   // to inspect the result of constructing headers at the moment.
-  val baz = endpoint(post(path / "baz", emptyRequest, header("quuz") ++ header("corge") ++ optHeader("grault")), emptyResponse())
+  val baz = endpoint(post(path / "baz", emptyBody, header("quuz") ++ header("corge") ++ optHeader("grault")), emptyResponse())
 }
 
 object Fixtures extends FixturesAlgebra with thenable.Endpoints


### PR DESCRIPTION
We could add the possibility to document an empty body but then we
should also provide the possibility to document empty headers.
I kept it as is (no way to document an empty body or empty headers) but
mentioned that it can be documented in description of Endpoints.endpoint