### PR TITLE
Feature/response entity

### DIFF
--- a/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
+++ b/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
@@ -16,15 +16,15 @@ import io.circe.parser.decode
   */
 trait JsonSchemaEntities extends algebra.JsonSchemaEntities with circe.JsonSchemas { this: Endpoints =>
 
-  def jsonRequest[A: JsonSchema](docs: algebra.Documentation): RequestEntity[A] = { (a, req) =>
+  def jsonRequest[A: JsonSchema]: RequestEntity[A] = { (a, req) =>
     implicit def encoder: Encoder[A] = implicitly[JsonSchema[A]].encoder
     req.copy(entity = HttpEntity(ContentTypes.`application/json`, a.asJson.spaces2))
   }
 
-  def jsonResponse[A: JsonSchema](docs: algebra.Documentation): Response[A] = { a =>
+  def jsonResponse[A: JsonSchema]: ResponseEntity[A] = { entity =>
     implicit def decoder: Decoder[A] = implicitly[JsonSchema[A]].decoder
     for {
-      strictEntity <- a.entity.toStrict(settings.toStrictTimeout)
+      strictEntity <- entity.toStrict(settings.toStrictTimeout)
     } yield decode[A](settings.stringContentExtractor(strictEntity))
   }
 }

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
@@ -25,8 +25,8 @@ trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints 
     * Checks that the result is not `Forbidden`
     */
   private[endpoints] def authenticated[A](response: Response[A], docs: Documentation): Response[Option[A]] =
-    resp =>
-      if (resp.status == AkkaStatusCodes.Forbidden) Future.successful(Right(None))
-      else response(resp).map(_.right.map(Some.apply))
+    (status, headers) =>
+      if (status == AkkaStatusCodes.Forbidden) discardingEntity(Future.successful(Right(None)))
+      else entity => response(status, headers)(entity).map(_.right.map(Some.apply))
 
 }

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/JsonEntitiesFromCodec.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/JsonEntitiesFromCodec.scala
@@ -1,7 +1,7 @@
 package endpoints.akkahttp.client
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
-import endpoints.algebra.{Codec, Documentation}
+import endpoints.algebra.Codec
 
 /**
   * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that encodes JSON request
@@ -11,13 +11,13 @@ import endpoints.algebra.{Codec, Documentation}
   */
 trait JsonEntitiesFromCodec extends endpoints.algebra.JsonEntitiesFromCodec { this: Endpoints =>
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
     req.copy(entity = HttpEntity(ContentTypes.`application/json`, codec.encode(a)))
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]): Response[A] = { response =>
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = { entity =>
     for {
-      strictEntity <- response.entity.toStrict(settings.toStrictTimeout)
+      strictEntity <- entity.toStrict(settings.toStrictTimeout)
     } yield codec.decode(settings.stringContentExtractor(strictEntity))
   }
 

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/MuxEndpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/MuxEndpoints.scala
@@ -22,7 +22,7 @@ trait MuxEndpoints extends algebra.MuxEndpoints { self: Endpoints =>
       decoder: Decoder[Transport, Resp]
     ): Future[req.Response] =
       request(encoder.encode(req)).flatMap { resp =>
-        response(resp).flatMap { t =>
+        response(resp.status, resp.headers)(resp.entity).flatMap { t =>
           futureFromEither(t).flatMap(tt =>
             futureFromEither(decoder.decode(tt)).map(_.asInstanceOf[req.Response])
           )

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/StatusCodes.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/StatusCodes.scala
@@ -13,11 +13,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = AkkaStatusCode
 
   def OK = AkkaStatusCodes.OK
+  def Created = AkkaStatusCodes.Created
+  def Accepted = AkkaStatusCodes.Accepted
+  def NoContent = AkkaStatusCodes.NoContent
 
   def BadRequest= AkkaStatusCodes.BadRequest
-
   def Unauthorized = AkkaStatusCodes.Unauthorized
-
+  def Forbidden = AkkaStatusCodes.Forbidden
   def NotFound = AkkaStatusCodes.NotFound
+
+  def InternalServerError = AkkaStatusCodes.InternalServerError
 
 }

--- a/akka-http/server-circe/src/main/scala/endpoints/akkahttp/server/circe/JsonSchemaEntities.scala
+++ b/akka-http/server-circe/src/main/scala/endpoints/akkahttp/server/circe/JsonSchemaEntities.scala
@@ -16,13 +16,14 @@ import io.circe.{Decoder, Encoder}
   */
 trait JsonSchemaEntities extends server.Endpoints with algebra.JsonSchemaEntities with circe.JsonSchemas {
 
-  def jsonRequest[A : JsonSchema](docs: Documentation): RequestEntity[A] = {
+  def jsonRequest[A : JsonSchema]: RequestEntity[A] = {
     implicit def decoder: Decoder[A] = implicitly[JsonSchema[A]].decoder
     Directives.entity[A](implicitly)
   }
 
-  def jsonResponse[A : JsonSchema](docs: Documentation): Response[A] = { a =>
+  def jsonResponse[A : JsonSchema]: ResponseEntity[A] = {
     implicit def encoder: Encoder[A] = implicitly[JsonSchema[A]].encoder
-    Directives.complete(a)
+    implicitly
   }
+
 }

--- a/akka-http/server-circe/src/test/scala/endpoints/akkahttp/server/circe/EndpointsJsonSchemaTest.scala
+++ b/akka-http/server-circe/src/test/scala/endpoints/akkahttp/server/circe/EndpointsJsonSchemaTest.scala
@@ -21,7 +21,7 @@ class EndpointsJsonSchemaTest extends WordSpec with Matchers with ScalatestRoute
     implicit val userJsonSchema: JsonSchema[User] = genericJsonSchema[User]
 
     val singleStaticGetSegment = endpoint[Unit, User](
-      get(path / "user"), jsonResponse[User]()
+      get(path / "user"), ok(jsonResponse[User])
     ).implementedBy(_ => User("Bob", 30))
   }
 

--- a/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
+++ b/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
@@ -1,18 +1,10 @@
 package endpoints.akkahttp.server.playjson
 
-import akka.http.scaladsl.marshalling.{Marshaller, ToResponseMarshaller}
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
 import endpoints.akkahttp.server
-import endpoints.algebra.Documentation
 import endpoints.algebra
-import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
-import endpoints._
-
-import akka.http.scaladsl.marshalling.{Marshaller, ToResponseMarshaller}
-import akka.http.scaladsl.unmarshalling.Unmarshaller
-import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
-import endpoints.algebra.Documentation
 
 /**
   * Interpreter for [[algebra.JsonEntities]] that uses Play JSON [[play.api.libs.json.Reads]] to decode
@@ -23,16 +15,13 @@ import endpoints.algebra.Documentation
   */
 trait JsonSchemaEntities extends server.Endpoints with algebra.JsonSchemaEntities with endpoints.playjson.JsonSchemas {
 
-  def jsonRequest[A: JsonSchema](docs: Documentation): RequestEntity[A] = {
+  def jsonRequest[A: JsonSchema]: RequestEntity[A] = {
     Directives.entity[A](
       Unmarshaller.messageUnmarshallerFromEntityUnmarshaller(
         PlayJsonSupport.unmarshaller(implicitly[JsonSchema[A]].reads)))
   }
 
-  def jsonResponse[A: JsonSchema](docs: Documentation): Response[A] = { a =>
-    implicit val m: ToResponseMarshaller[A] =
-      Marshaller.liftMarshaller(PlayJsonSupport.marshaller(implicitly[JsonSchema[A]].writes))
+  def jsonResponse[A: JsonSchema]: ResponseEntity[A] =
+    PlayJsonSupport.marshaller(implicitly[JsonSchema[A]].writes)
 
-    Directives.complete(a)
-  }
 }

--- a/akka-http/server-playjson/src/test/scala/endpoints/akkahttp/server/playjson/EndpointsJsonSchemaTest.scala
+++ b/akka-http/server-playjson/src/test/scala/endpoints/akkahttp/server/playjson/EndpointsJsonSchemaTest.scala
@@ -21,7 +21,7 @@ class EndpointsJsonSchemaTest extends WordSpec with Matchers with ScalatestRoute
     implicit val userJsonSchema: JsonSchema[User] = genericJsonSchema[User]
 
     val singleStaticGetSegment = endpoint[Unit, User](
-      get(path / "user"), jsonResponse[User]()
+      get(path / "user"), ok(jsonResponse[User])
     ).implementedBy(_ => User("Bob", 30))
   }
 

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntities.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntities.scala
@@ -1,9 +1,8 @@
 package endpoints.akkahttp.server
 
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
+import akka.http.scaladsl.marshalling.ToEntityMarshaller
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
-
 import endpoints._
 
 /**
@@ -18,11 +17,12 @@ trait JsonEntities extends algebra.JsonEntities with Endpoints {
 
   type JsonRequest[A] = FromRequestUnmarshaller[A]
 
-  def jsonRequest[A : JsonRequest](docs: algebra.Documentation = None): RequestEntity[A] = Directives.entity[A](implicitly)
+  def jsonRequest[A : JsonRequest]: RequestEntity[A] = Directives.entity[A](implicitly)
 
 
-  type JsonResponse[A] = ToResponseMarshaller[A]
+  type JsonResponse[A] = ToEntityMarshaller[A]
 
-  def jsonResponse[A : JsonResponse](docs: algebra.Documentation = None): Response[A] = entity => Directives.complete(entity)
+  def jsonResponse[A : JsonResponse]: ResponseEntity[A] =
+    implicitly
 
 }

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntitiesFromCodec.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntitiesFromCodec.scala
@@ -1,9 +1,10 @@
 package endpoints.akkahttp.server
-import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+
+import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
-import endpoints.algebra.{Codec, Documentation}
+import endpoints.algebra.Codec
 
 /**
   * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that decodes JSON requests and
@@ -13,7 +14,7 @@ import endpoints.algebra.{Codec, Documentation}
   */
 trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] = {
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = {
     implicit val fromEntityUnmarshaller: FromEntityUnmarshaller[A] =
       Unmarshaller.stringUnmarshaller
         .forContentTypes(MediaTypes.`application/json`)
@@ -21,12 +22,9 @@ trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitie
     Directives.entity[A](implicitly)
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]): Response[A] = { a =>
-    implicit val toEntityMarshaller: ToEntityMarshaller[A] =
-      Marshaller.withFixedContentType(MediaTypes.`application/json`) { value =>
-        HttpEntity(MediaTypes.`application/json`, codec.encode(value))
-      }
-    Directives.complete(a)
-  }
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] =
+    Marshaller.withFixedContentType(MediaTypes.`application/json`) { value =>
+      HttpEntity(MediaTypes.`application/json`, codec.encode(value))
+    }
 
 }

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/StatusCodes.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/StatusCodes.scala
@@ -13,11 +13,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = AkkaStatusCode
 
   def OK = AkkaStatusCodes.OK
+  def Created = AkkaStatusCodes.Created
+  def Accepted = AkkaStatusCodes.Accepted
+  def NoContent = AkkaStatusCodes.NoContent
 
   def BadRequest= AkkaStatusCodes.BadRequest
-
   def Unauthorized = AkkaStatusCodes.Unauthorized
-
+  def Forbidden = AkkaStatusCodes.Forbidden
   def NotFound = AkkaStatusCodes.NotFound
+
+  def InternalServerError = AkkaStatusCodes.InternalServerError
 
 }

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
@@ -2,7 +2,6 @@ package endpoints.akkahttp.server
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import endpoints.akkahttp.server.{BasicAuthentication, Endpoints, JsonEntities}
 import endpoints.algebra
 import org.scalatest.{Matchers, WordSpec}
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -38,6 +38,7 @@ trait BasicAuthentication extends Endpoints {
     requestEntity: RequestEntity[E] = emptyRequest,
     requestHeaders: RequestHeaders[H] = emptyHeaders,
     unauthenticatedDocs: Documentation = None,
+    requestDocs: Documentation = None,
     summary: Documentation = None,
     description: Documentation = None,
     tags: List[String] = Nil
@@ -47,7 +48,7 @@ trait BasicAuthentication extends Endpoints {
     tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
   ): Endpoint[Out, Option[R]] =
     endpoint(
-      request(method, url, requestEntity, requestHeaders ++ basicAuthenticationHeader),
+      request(method, url, requestEntity, requestDocs, requestHeaders ++ basicAuthenticationHeader),
       authenticated(response, unauthenticatedDocs),
       summary,
       description,

--- a/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
@@ -28,10 +28,10 @@ trait JsonEntities extends Endpoints {
 //#request-response-types
 
   /** Defines a `RequestEntity[A]` given an implicit `JsonRequest[A]` */
-  def jsonRequest[A : JsonRequest](docs: Documentation = None): RequestEntity[A]
+  def jsonRequest[A : JsonRequest]: RequestEntity[A]
 
   /** Defines a `Response[A]` given an implicit `JsonResponse[A]` */
-  def jsonResponse[A : JsonResponse](docs: Documentation = None): Response[A]
+  def jsonResponse[A : JsonResponse]: ResponseEntity[A]
 }
 
 /**

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -47,7 +47,7 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
   /**
     * Request with a [[String]] body.
     */
-  def textRequest(docs: Documentation = None): RequestEntity[String]
+  def textRequest: RequestEntity[String]
 
   /**
     * Request for given parameters
@@ -55,6 +55,7 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
     * @param method Request method
     * @param url Request URL
     * @param entity Request entity
+    * @param docs Request documentation
     * @param headers Request headers
     * @tparam UrlP Payload carried by url
     * @tparam BodyP Payload carried by body
@@ -65,6 +66,7 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
     method: Method,
     url: Url[UrlP],
     entity: RequestEntity[BodyP] = emptyRequest,
+    docs: Documentation = None,
     headers: RequestHeaders[HeadersP] = emptyHeaders
   )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out]
 
@@ -75,11 +77,14 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
     */
   final def get[UrlP, HeadersP, Out](
     url: Url[UrlP],
+    docs: Documentation = None,
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] = request(Get, url, headers = headers)
+  )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] =
+    request(Get, url, docs = docs, headers = headers)
 
   /**
     * Helper method to perform POST request
+    * @param docs Request documentation
     * @tparam UrlP Payload carried by url
     * @tparam BodyP Payload carried by body
     * @tparam HeadersP Payload carried by headers
@@ -88,8 +93,10 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
   final def post[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     url: Url[UrlP],
     entity: RequestEntity[BodyP],
+    docs: Documentation = None,
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] = request(Post, url, entity, headers)
+  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] =
+    request(Post, url, entity, docs, headers)
 
   /**
     * Helper method to perform PUT request
@@ -101,8 +108,10 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
   final def put[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     url: Url[UrlP],
     entity: RequestEntity[BodyP],
+    docs: Documentation = None,
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] = request(Put, url, entity, headers)
+  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] =
+    request(Put, url, entity, docs, headers)
 
   /**
     * Helper method to perform DELETE request
@@ -111,7 +120,9 @@ trait Requests extends Urls with Methods with PartialInvariantFunctorSyntax with
     */
   final def delete[UrlP, HeadersP, Out](
     url: Url[UrlP],
+    docs: Documentation = None,
     headers: RequestHeaders[HeadersP] = emptyHeaders
-  )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] = request(Delete, url, headers = headers)
+  )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] =
+    request(Delete, url, docs = docs, headers = headers)
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
@@ -7,18 +7,37 @@ import scala.language.higherKinds
   */
 trait Responses extends StatusCodes {
 
-  /** Information carried by a response */
+  /** An HTTP response (status, headers, and entity) carrying an information of type A */
   type Response[A]
 
-  /**
-    * Empty response.
-    */
-  def emptyResponse(docs: Documentation = None): Response[Unit]
+  /** An HTTP response entity carrying an information of type A */
+  type ResponseEntity[A]
 
   /**
-    * Text response.
+    * Empty response entity
     */
-  def textResponse(docs: Documentation = None): Response[String]
+  def emptyResponse: ResponseEntity[Unit]
+
+  /**
+    * Text response entity
+    */
+  def textResponse: ResponseEntity[String]
+
+  /**
+    * @param statusCode Response status code
+    * @param entity     Response entity
+    * @param docs       Response documentation
+    *
+    * Server interpreters should construct a response with the given status and entity.
+    * Client interpreters should accept a response only if it has a corresponding status code.
+    */
+  def response[A](statusCode: StatusCode, entity: ResponseEntity[A], docs: Documentation = None): Response[A]
+
+  /**
+    * OK Response with the given entity
+    */
+  final def ok[A](entity: ResponseEntity[A], docs: Documentation = None): Response[A] =
+    response(OK, entity, docs)
 
   /**
     * Turns a `Response[A]` into a `Response[Option[A]]`.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/StatusCodes.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/StatusCodes.scala
@@ -11,11 +11,22 @@ trait StatusCodes {
   /** 2xx Success */
   def OK: StatusCode
 
+  def Created: StatusCode
+
+  def Accepted: StatusCode
+
+  def NoContent: StatusCode
+
   /** 4xx Client Error */
   def BadRequest: StatusCode
 
   def Unauthorized: StatusCode
 
+  def Forbidden: StatusCode
+
   def NotFound: StatusCode
+
+  /** 5xx Server Error */
+  def InternalServerError: StatusCode
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/BasicAuthTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/BasicAuthTestApi.scala
@@ -8,7 +8,7 @@ trait BasicAuthTestApi extends algebra.Endpoints with algebra.BasicAuthenticatio
   val protectedEndpoint = authenticatedEndpoint(
     Get,
     path / "users",
-    textResponse()
+    ok(textResponse)
   )
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
@@ -10,22 +10,22 @@ trait EndpointsDocs extends Endpoints {
     // path “/some-resource”, and whose responses have an entity of
     // type “text/plain”
     val someResource: Endpoint[Unit, String] =
-      endpoint(get(path / "some-resource"), textResponse())
+      endpoint(get(path / "some-resource"), ok(textResponse))
     //#construction
   }
 
   //#with-docs
   endpoint(
     get(path / "some-resource"),
-    textResponse(),
+    ok(textResponse),
     description = Some("The contents of some resource")
   )
   //#with-docs
 
   //#request-construction
   // A request that uses the verb “GET”, the URL path “/foo”,
-  // no entity and no headers
-  request(Get, path / "foo", emptyRequest, emptyHeaders)
+  // no entity, no documentation, and no headers
+  request(Get, path / "foo", emptyRequest, None, emptyHeaders)
   //#request-construction
 
   //#convenient-get
@@ -58,26 +58,31 @@ trait EndpointsDocs extends Endpoints {
 
   //#response
   // An HTTP response with status code 200 (Ok) and no entity
-  val nothing: Response[Unit] = emptyResponse()
+  val nothing: Response[Unit] = ok(emptyResponse)
   //#response
+
+  //#general-response
+  // An HTTP response with status code 200 (Ok) and a text entity
+  val aTextResponse: Response[String] = response(OK, textResponse)
+  //#general-response
 
   //#response-combinator
   // An HTTP response with status code 404 (Not Found) and no entity,
   // or with status code 200 (Ok) and a text entity.
-  val maybeText: Response[Option[String]] = wheneverFound(textResponse())
+  val maybeText: Response[Option[String]] = wheneverFound(aTextResponse)
   //#response-combinator
 
   // Shared definition used by the documentation of interpreters
   //#endpoint-definition
   val someResource: Endpoint[Int, String] =
-    endpoint(get(path / "some-resource" / segment[Int]()), textResponse())
+    endpoint(get(path / "some-resource" / segment[Int]()), ok(textResponse))
   //#endpoint-definition
 
   //#documented-endpoint-definition
   val someDocumentedResource: Endpoint[Int, String] =
     endpoint(
       get(path / "some-resource" / segment[Int]("id")),
-      textResponse(docs = Some("The content of the resource"))
+      ok(textResponse, docs = Some("The content of the resource"))
     )
   //#documented-endpoint-definition
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -11,82 +11,82 @@ trait EndpointsTestApi extends algebra.Endpoints {
 
   val UUIDEndpoint = endpoint(
     get(path / "user" / segment[UUID]() / "description" /? (qs[String]("name") & qs[Int]("age"))),
-    textResponse()
+    ok(textResponse)
   )
 
   val putUUIDEndpoint = endpoint(
     put(path / "user" / segment[UUID](), emptyRequest),
-    emptyResponse()
+    ok(emptyResponse)
   )
 
   val deleteUUIDEndpoint = endpoint(
     delete(path / "user" / segment[UUID]()),
-    emptyResponse()
+    ok(emptyResponse)
   )
 
   val emptyResponseUUIDEndpoint = endpoint(
     get(path / "user" / segment[UUID]() / "description" /? (qs[String]("name") & qs[Int]("age"))),
-    emptyResponse()
+    ok(emptyResponse)
   )
 
   val smokeEndpoint = endpoint(
     get(path / "user" / segment[String]() / "description" /? (qs[String]("name") & qs[Int]("age"))),
-    textResponse()
+    ok(textResponse)
   )
 
   val putEndpoint = endpoint(
     put(path / "user" / segment[String](), emptyRequest),
-    emptyResponse()
+    ok(emptyResponse)
   )
 
   val deleteEndpoint = endpoint(
     delete(path / "user" / segment[String]()),
-    emptyResponse()
+    ok(emptyResponse)
   )
 
   val emptyResponseSmokeEndpoint = endpoint(
     get(path / "user" / segment[String]() / "description" /? (qs[String]("name") & qs[Int]("age"))),
-    emptyResponse()
+    ok(emptyResponse)
   )
 
   val optionalEndpoint: Endpoint[Unit, Option[String]] = endpoint(
     get(path / "users" / "1"),
-    wheneverFound(textResponse())
+    wheneverFound(ok(textResponse))
   )
 
   val headers1 = header("A") ++ header("B")
   val joinedHeadersEndpoint = endpoint(
-    get(path / "joinedHeadersEndpoint", headers1),
-    textResponse()
+    get(path / "joinedHeadersEndpoint", headers = headers1),
+    ok(textResponse)
   )
 
   val headers2 = header("C").xmap(_.toInt)(_.toString)
   val xmapHeadersEndpoint = endpoint(
-    get(path / "xmapHeadersEndpoint", headers2),
-    textResponse()
+    get(path / "xmapHeadersEndpoint", headers = headers2),
+    ok(textResponse)
   )
 
   val url1 = (path / "xmapUrlEndpoint" / segment[Long]() : Url[Long]).xmap(_.toString)( _.toLong)
   val xmapUrlEndpoint = endpoint(
     get(url1),
-    textResponse()
+    ok(textResponse)
   )
 
   val dateTimeFormatter = DateTimeFormatter.ISO_DATE
-  val reqBody1 = textRequest().xmap(s => LocalDate.parse(s, dateTimeFormatter))( d => dateTimeFormatter.format(d))
+  val reqBody1 = textRequest.xmap(s => LocalDate.parse(s, dateTimeFormatter))( d => dateTimeFormatter.format(d))
   val xmapReqBodyEndpoint = endpoint(
     post(path / "xmapReqBodyEndpoint", reqBody1),
-    textResponse()
+    ok(textResponse)
   )
 
   val optUUIDQsEndpoint = endpoint(
     get(path / "user" / segment[String]() / "whatever" /? (qs[UUID]("id") & qs[Option[Int]]("age"))),
-    textResponse()
+    ok(textResponse)
   )
 
   val optQsEndpoint = endpoint(
     get(path / "user" / segment[String]() / "whatever" /? (qs[String]("name") & qs[Option[Int]]("age"))),
-    textResponse()
+    ok(textResponse)
   )
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala
@@ -10,8 +10,8 @@ trait JsonEntitiesDocs extends JsonEntities {
 
   //#json-entities
   endpoint(
-    post(path / "user", jsonRequest[CreateUser]()),
-    jsonResponse[User]()
+    post(path / "user", jsonRequest[CreateUser]),
+    ok(jsonResponse[User])
   )
   //#json-entities
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonFromCodecTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonFromCodecTestApi.scala
@@ -10,8 +10,8 @@ trait JsonFromCodecTestApi
   implicit def addressCodec: JsonCodec[Address]
 
   val jsonCodecEndpoint = endpoint(
-    post(path / "user-json-codec", jsonRequest[User]()),
-    jsonResponse[Address]()
+    post(path / "user-json-codec", jsonRequest[User]),
+    ok(jsonResponse[Address])
   )
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonTestApi.scala
@@ -9,8 +9,8 @@ trait JsonTestApi extends algebra.Endpoints with algebra.JsonEntities {
 
 
   val smokeEndpoint = endpoint(
-    post(path / "user", jsonRequest[User]()),
-    jsonResponse[Address]()
+    post(path / "user", jsonRequest[User]),
+    ok(jsonResponse[Address])
   )
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/MuxEndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/MuxEndpointsDocs.scala
@@ -10,8 +10,8 @@ trait MuxEndpointsDocs extends MuxEndpoints with JsonEntities {
   //#mux-endpoint
   val users: MuxEndpoint[Command, Event, Json] =
     muxEndpoint[Command, Event, Json](
-      post(path / "users", jsonRequest[Json]()),
-      jsonResponse[Json]()
+      post(path / "users", jsonRequest[Json]),
+      ok(jsonResponse[Json])
     )
 
   // Types of commands

--- a/documentation/examples/authentication/src/main/scala/authentication/Usage.scala
+++ b/documentation/examples/authentication/src/main/scala/authentication/Usage.scala
@@ -39,7 +39,7 @@ trait AuthenticationEndpoints
     Get,
     path / "some-resource",
     emptyRequest,
-    textResponse()
+    ok(textResponse)
   )
 //#protected-endpoint
 //#login-endpoint

--- a/documentation/examples/basic/shared/src/main/scala/sample/ApiAlg.scala
+++ b/documentation/examples/basic/shared/src/main/scala/sample/ApiAlg.scala
@@ -7,19 +7,22 @@ import io.circe.generic.JsonCodec
 trait ApiAlg extends Endpoints with circe.JsonEntitiesFromCodec with BasicAuthentication {
 
   val index: Endpoint[(String, Int, String), User] =
-    endpoint(get(path / "user" / segment[String]() /? (qs[Int]("age") & qs[String]("toto"))), jsonResponse[User]())
+    endpoint(
+      get(path / "user" / segment[String]() /? (qs[Int]("age") & qs[String]("toto"))),
+      ok(jsonResponse[User])
+    )
 
   val action =
-    endpoint(post(path / "action", jsonRequest[ActionParameter]()), jsonResponse[ActionResult]())
+    endpoint(post(path / "action", jsonRequest[ActionParameter]), ok(jsonResponse[ActionResult]))
 
   val actionFut: Endpoint[ActionParameter, ActionResult] =
-    endpoint(post(path / "actionFut", jsonRequest[ActionParameter]()), jsonResponse[ActionResult]())
+    endpoint(post(path / "actionFut", jsonRequest[ActionParameter]), ok(jsonResponse[ActionResult]))
 
   val maybe =
-    endpoint(get(path / "option"), wheneverFound(emptyResponse()))
+    endpoint(get(path / "option"), wheneverFound(ok(emptyResponse)))
 
   val auth: Endpoint[Credentials, Option[Unit]] =
-    authenticatedEndpoint(Get, path / "auth", response = emptyResponse())
+    authenticatedEndpoint(Get, path / "auth", response = ok(emptyResponse))
 
 }
 

--- a/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
+++ b/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
@@ -11,7 +11,7 @@ trait DocumentedApi
   val items =
     endpoint(
       get(path / "items" / segment[String]("category") /? qs[Option[Int]]("page")),
-      jsonResponse[List[Item]](Some("List all the items of the given category"))
+      ok(jsonResponse[List[Item]], Some("List all the items of the given category"))
     )
 
   val itemId = segment[String]("id")
@@ -19,7 +19,10 @@ trait DocumentedApi
   val item =
     endpoint(
       get(path / "item" / itemId),
-      wheneverFound(jsonResponse[Item](Some("The item identified by 'id'")), Some("Item not found"))
+      wheneverFound(
+        ok(jsonResponse[Item], Some("The item identified by 'id'")),
+        Some("Item not found")
+      )
     )
 
   val admin =
@@ -27,7 +30,7 @@ trait DocumentedApi
       Get,
       path / "admin",
       requestEntity = emptyRequest,
-      response = emptyResponse(Some("Administration page")),
+      response = ok(emptyResponse, Some("Administration page")),
       summary = Some("Authentication endpoint")
     )
 

--- a/documentation/examples/cqrs/commands-endpoints/src/main/scala/cqrs/commands/CommandsEndpoints.scala
+++ b/documentation/examples/cqrs/commands-endpoints/src/main/scala/cqrs/commands/CommandsEndpoints.scala
@@ -21,14 +21,20 @@ trait CommandsEndpoints extends Endpoints with JsonEntitiesFromCodec {
     * not found or invalid command).
     */
   val command: Endpoint[Command, Option[StoredEvent]] =
-    endpoint(post(path / "command", jsonRequest[Command]()), jsonResponse[Option[StoredEvent]]())
+    endpoint(
+      post(path / "command", jsonRequest[Command]),
+      ok(jsonResponse[Option[StoredEvent]])
+    )
 //#microservice-endpoint-description
 
   /**
     * Read the event long (optionally from a given timestamp).
     */
   val events: Endpoint[Option[Long], Seq[StoredEvent]] =
-    endpoint(get(path / "events" /? qs[Option[Long]]("since")), jsonResponse[Seq[StoredEvent]]())
+    endpoint(
+      get(path / "events" /? qs[Option[Long]]("since")),
+      ok(jsonResponse[Seq[StoredEvent]])
+    )
 
 }
 //#endpoints

--- a/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/publicserver/PublicEndpoints.scala
+++ b/documentation/examples/cqrs/public-endpoints/src/main/scala/cqrs/publicserver/PublicEndpoints.scala
@@ -25,23 +25,32 @@ trait PublicEndpoints extends Endpoints with circe.JsonEntitiesFromCodec {
 
   /** Lists all the registered meters */
   val listMeters: Endpoint[Unit, List[Meter]] =
-    endpoint(get(metersPath), jsonResponse[List[Meter]]())
+    endpoint(get(metersPath), ok(jsonResponse[List[Meter]]))
 
   /** Find a meter by id */
 //#get-meter
   val getMeter: Endpoint[UUID, Option[Meter]] =
-    endpoint(get(metersPath / segment[UUID]()), jsonResponse[Meter]().orNotFound())
+    endpoint(
+      get(metersPath / segment[UUID]()),
+      ok(jsonResponse[Meter]).orNotFound()
+    )
 //#get-meter
 
   //#webapps-endpoint
   /** Registers a new meter */
   val createMeter: Endpoint[CreateMeter, Meter] =
-    endpoint(post(metersPath, jsonRequest[CreateMeter]()), jsonResponse[Meter]())
+    endpoint(
+      post(metersPath, jsonRequest[CreateMeter]),
+      ok(jsonResponse[Meter])
+    )
   //#webapps-endpoint
 
   /** Add a record to an existing meter */
   val addRecord: Endpoint[(UUID, AddRecord), Meter] =
-    endpoint(post(metersPath / segment[UUID]() / "records", jsonRequest[AddRecord]()), jsonResponse[Meter]())
+    endpoint(
+      post(metersPath / segment[UUID]() / "records", jsonRequest[AddRecord]),
+      ok(jsonResponse[Meter])
+    )
 
 }
 //#public-endpoints

--- a/documentation/examples/cqrs/public-server/src/main/scala/cqrs/publicserver/BootstrapEndpoints.scala
+++ b/documentation/examples/cqrs/public-server/src/main/scala/cqrs/publicserver/BootstrapEndpoints.scala
@@ -12,13 +12,13 @@ import play.twirl.api.{Html, StringInterpolation}
 class BootstrapEndpoints(protected val playComponents: PlayComponents) extends Endpoints with Assets with JsonSchemaEntities with OpenApiSchemas {
 
   val index: Endpoint[Unit, Html] =
-    endpoint(get(path), htmlResponse)
+    endpoint(get(path), ok(htmlResponse))
 
   val assets: Endpoint[AssetRequest, AssetResponse] =
     assetsEndpoint(path / "assets" / assetSegments())
 
   val documentation: Endpoint[Unit, OpenApi] = {
-    endpoint(get(path / "documentation"), jsonResponse[OpenApi]())
+    endpoint(get(path / "documentation"), ok(jsonResponse[OpenApi]))
   }
 
   val routes: PlayRouter.Routes =

--- a/documentation/examples/cqrs/queries-endpoints/src/main/scala/cqrs/queries/QueriesEndpoints.scala
+++ b/documentation/examples/cqrs/queries-endpoints/src/main/scala/cqrs/queries/QueriesEndpoints.scala
@@ -18,8 +18,8 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 trait QueriesEndpoints extends MuxEndpoints with circe.JsonEntitiesFromCodec {
 
   val query: MuxEndpoint[QueryReq, QueryResp, Json] = {
-    val request = post(path / "query", jsonRequest[Json]())
-    muxEndpoint[QueryReq, QueryResp, Json](request, jsonResponse())
+    val request = post(path / "query", jsonRequest[Json])
+    muxEndpoint[QueryReq, QueryResp, Json](request, ok(jsonResponse))
   }
 
 }

--- a/documentation/examples/documented/src/main/scala/counter/Counter.scala
+++ b/documentation/examples/documented/src/main/scala/counter/Counter.scala
@@ -35,22 +35,22 @@ trait CounterEndpoints
   // HTTP endpoint for querying the current value of the counter. Uses the HTTP
   // verb ''GET'' and the path ''/counter''. Returns the current value of the counter
   // in a JSON object. (see below for the `counterJson` definition)
-  val currentValue = endpoint(get(path / "counter"), counterJson)
+  val currentValue = endpoint(get(path / "counter"), counterJsonResponse)
 
   // HTTP endpoint for updating the value of the counter. Uses the HTTP verb ''POST''
   // and the path ''/counter''. The request entity contains an `Operation` object encoded
   // in JSON. The endpoint returns the current value of the counter in a JSON object.
   val update = endpoint(
-    post(path / "counter", jsonRequest[Operation](docs = Some("The operation to apply to the counter"))),
-    counterJson
+    post(path / "counter", jsonRequest[Operation], docs = Some("The operation to apply to the counter")),
+    counterJsonResponse
   )
 
   // Since both the `currentValue` and `update` endpoints return the same
   // information, we define it once and just reuse it. Here, we say
   // that they return an HTTP response whose entity contains a JSON document
   // with the counter value
-  lazy val counterJson =
-    jsonResponse[Counter](docs = Some("The counter current value"))
+  lazy val counterJsonResponse =
+    ok(jsonResponse[Counter], docs = Some("The counter current value"))
 
   // We generically derive a data type schema. This schema
   // describes that the case class `Counter` has one field
@@ -132,7 +132,7 @@ object Main {
 
     // HTTP endpoint serving documentation. Uses the HTTP verb ''GET'' and the path
     // ''/documentation.json''. Returns an OpenAPI document.
-    val documentation = endpoint(get(path / "documentation.json"), jsonResponse[OpenApi]())
+    val documentation = endpoint[Unit, OpenApi](get(path / "documentation.json"), ok(jsonResponse[OpenApi]))
 
     // We “render” the OpenAPI document using the swagger-ui, provided as static assets
     val assets = assetsEndpoint(path / "assets" / assetSegments())

--- a/documentation/examples/quickstart/endpoints/src/main/scala/quickstart/CounterEndpoints.scala
+++ b/documentation/examples/quickstart/endpoints/src/main/scala/quickstart/CounterEndpoints.scala
@@ -19,7 +19,7 @@ trait CounterEndpoints
     * The response entity is a JSON document representing the counter value.
     */
   val currentValue: Endpoint[Unit, Counter] =
-    endpoint(get(path / "current-value"), jsonResponse[Counter]())
+    endpoint(get(path / "current-value"), ok(jsonResponse[Counter]))
 
   /**
     * Increments the counter value.
@@ -29,7 +29,7 @@ trait CounterEndpoints
     */
 //#endpoint-definition
   val increment: Endpoint[Increment, Unit] =
-    endpoint(post(path / "increment", jsonRequest[Increment]()), emptyResponse())
+    endpoint(post(path / "increment", jsonRequest[Increment]), ok(emptyResponse))
 //#endpoint-definition
 
   // Generically derive the JSON schema of our `Counter`

--- a/documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala
+++ b/documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala
@@ -22,7 +22,7 @@ class DocumentationServer(val playComponents: PlayComponents)
     with OpenApiSchemas with server.playjson.JsonSchemaEntities {
 
   val routes = routesFromEndpoints(
-    endpoint(get(path / "documentation.json"), jsonResponse[OpenApi]())
+    endpoint[Unit, OpenApi](get(path / "documentation.json"), ok(jsonResponse[OpenApi]))
       .implementedBy(_ => CounterDocumentation.api)
   )
 

--- a/documentation/manual/src/doc/algebras/endpoints.md
+++ b/documentation/manual/src/doc/algebras/endpoints.md
@@ -103,12 +103,18 @@ that there is no representation of the source type in the target type.
 The `Response[A]` type models an HTTP response carrying some information of type `A`.
 For instance, a `Response[User]` value is an HTTP response containing a user.
 
-A response can be defined by using a constructor:
+A response is defined in terms of a status and an entity. Here is an example
+of a simple OK response with no entity:
 
 ~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala#response
 ~~~
 
-Or by using a combinator:
+There is a more general response constructor taking the status as parameter:
+
+~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala#general-response
+~~~
+
+You can also define a response by transforming another one:
 
 ~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala#response-combinator
 ~~~

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
@@ -1,7 +1,6 @@
 package endpoints
 package openapi
 
-import endpoints.algebra
 import endpoints.algebra.Documentation
 import endpoints.openapi.model._
 
@@ -24,7 +23,7 @@ trait Assets
 
   def assetsEndpoint(url: Url[AssetPath], docs: Documentation, notFoundDocs: Documentation): Endpoint[AssetRequest, AssetResponse] =
     endpoint(
-      DocumentedRequest(Get, url, emptyHeaders, emptyRequest),
+      DocumentedRequest(Get, url, emptyHeaders, None, emptyRequest),
       DocumentedResponse(OK, docs.getOrElse(""), Map.empty) ::
         DocumentedResponse(NotFound, notFoundDocs.getOrElse(""), Map.empty) ::
         Nil

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -31,6 +31,7 @@ trait BasicAuthentication
     requestEntity: RequestEntity[E] = emptyRequest,
     requestHeaders: RequestHeaders[H] = emptyHeaders,
     unauthenticatedDocs: Documentation = None,
+    requestDocs: Documentation = None,
     summary: Documentation = None,
     description: Documentation = None,
     tags: List[String] = Nil
@@ -39,6 +40,6 @@ trait BasicAuthentication
     tuplerHCred: Tupler.Aux[H, Credentials, HCred],
     tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
   ): Endpoint[Out, Option[R]] =
-    super.authenticatedEndpoint(method, url, response, requestEntity, requestHeaders, unauthenticatedDocs, summary, description, tags)
+    super.authenticatedEndpoint(method, url, response, requestEntity, requestHeaders, unauthenticatedDocs, requestDocs, summary, description, tags)
       .withSecurity(SecurityRequirement(basicAuthenticationSchemeName, SecurityScheme.httpBasic))
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -87,7 +87,7 @@ trait Endpoints
         summary,
         description,
         parameters,
-        request.entity.map(r => RequestBody(r.documentation, r.content)),
+        if (request.entity.isEmpty) None else Some(RequestBody(request.documentation, request.entity)),
         response.map(r => r.status.toString -> Response(r.documentation, r.content)).toMap,
         tags,
         security = Nil // might be refined later by specific interpreters

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonEntities.scala
@@ -2,11 +2,13 @@ package endpoints
 package openapi
 
 import endpoints.openapi.model.MediaType
-import endpoints.algebra
-import endpoints.algebra.Documentation
 
 /**
   * Partial interpreter for [[algebra.JsonEntities]].
+  *
+  * This interpreter documents that entities have a JSON content type, but
+  * it can not document the schemas of these entities. See [[algebra.JsonSchemaEntities]]
+  * for this purpose.
   *
   * @group interpreters
   */
@@ -14,10 +16,10 @@ trait JsonEntities
   extends algebra.JsonEntities
     with Endpoints {
 
-  def jsonRequest[A : JsonRequest](docs: Documentation): RequestEntity[A] =
-    Some(DocumentedRequestEntity(docs, Map("application/json" -> MediaType(None))))
+  def jsonRequest[A : JsonRequest]: RequestEntity[A] =
+    Map("application/json" -> MediaType(None))
 
-  def jsonResponse[A : JsonResponse](docs: Documentation): Response[A] =
-    DocumentedResponse(OK, docs.getOrElse(""), Map("application/json" -> MediaType(None))) :: Nil
+  def jsonResponse[A : JsonResponse]: ResponseEntity[A] =
+    Map("application/json" -> MediaType(None))
 
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -1,7 +1,6 @@
 package endpoints
 package openapi
 
-import endpoints.algebra.Documentation
 import endpoints.openapi.model.{MediaType, Schema}
 
 /**
@@ -16,11 +15,9 @@ trait JsonSchemaEntities
 
   import DocumentedJsonSchema._
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: JsonSchema[A]): Option[DocumentedRequestEntity] =
-    Some(DocumentedRequestEntity(docs, Map("application/json" -> MediaType(Some(toSchema(codec))))))
+  def jsonRequest[A](implicit codec: JsonSchema[A]) = Map("application/json" -> MediaType(Some(toSchema(codec))))
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: JsonSchema[A]): List[DocumentedResponse] =
-    DocumentedResponse(OK, docs.getOrElse(""), Map("application/json" -> MediaType(Some(toSchema(codec))))) :: Nil
+  def jsonResponse[A](implicit codec: JsonSchema[A]) = Map("application/json" -> MediaType(Some(toSchema(codec))))
 
   def toSchema(jsonSchema: DocumentedJsonSchema): Schema =
     toSchema(jsonSchema, None, Set.empty)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -38,30 +38,24 @@ trait Requests
     method: Method,
     url: DocumentedUrl,
     headers: DocumentedHeaders,
-    entity: Option[DocumentedRequestEntity]
+    documentation: Documentation,
+    entity: Map[String, MediaType]
   )
 
-  type RequestEntity[A] = Option[DocumentedRequestEntity]
+  type RequestEntity[A] = Map[String, MediaType]
 
-  /**
-    * @param documentation Human readable documentation of the request entity
-    * @param content       Map that associates each possible content-type (e.g. “text/html”) with a [[MediaType]] description
-    */
-  case class DocumentedRequestEntity(documentation: Option[String], content: Map[String, MediaType])
+  lazy val emptyRequest = Map.empty[String, MediaType]
 
-  def emptyRequest = None
-
-  override def textRequest(docs: Documentation): Option[DocumentedRequestEntity] = Some(
-    DocumentedRequestEntity(docs, Map("text/plain" -> MediaType(Some(Schema.simpleString))))
-  )
+  lazy val textRequest = Map("text/plain" -> MediaType(Some(Schema.simpleString)))
 
   def request[A, B, C, AB, Out](
     method: Method,
     url: Url[A],
     entity: RequestEntity[B] = emptyRequest,
+    docs: Documentation = None,
     headers: RequestHeaders[C] = emptyHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
-    DocumentedRequest(method, url, headers, entity)
+    DocumentedRequest(method, url, headers, docs, entity)
 
   implicit lazy val reqEntityInvFunctor: endpoints.InvariantFunctor[RequestEntity] = new InvariantFunctor[RequestEntity] {
     def xmap[From, To](x: RequestEntity[From], map: From => To, contramap: To => From): RequestEntity[To] = x

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
@@ -13,6 +13,8 @@ trait Responses
   extends algebra.Responses
   with StatusCodes {
 
+  type ResponseEntity[A] = Map[String, MediaType]
+
   type Response[A] = List[DocumentedResponse]
 
   /**
@@ -22,11 +24,12 @@ trait Responses
     */
   case class DocumentedResponse(status: StatusCode, documentation: String, content: Map[String, MediaType])
 
-  def emptyResponse(docs: Documentation): Response[Unit] =
-    DocumentedResponse(OK, docs.getOrElse(""), Map.empty) :: Nil
+  def emptyResponse: ResponseEntity[Unit] = Map.empty
 
-  def textResponse(docs: Documentation): Response[String] =
-    DocumentedResponse(OK, docs.getOrElse(""), Map("text/plain" -> MediaType(Some(model.Schema.simpleString)))) :: Nil
+  def textResponse: ResponseEntity[String] = Map("text/plain" -> MediaType(Some(model.Schema.simpleString)))
+
+  def response[A](statusCode: StatusCode, entity: ResponseEntity[A], docs: Documentation = None): Response[A] =
+    DocumentedResponse(statusCode, docs.getOrElse(""), entity) :: Nil
 
   def wheneverFound[A](response: Response[A], notFoundDocs: Documentation): Response[Option[A]] =
     DocumentedResponse(NotFound, notFoundDocs.getOrElse(""), content = Map.empty) :: response

--- a/openapi/openapi/src/main/scala/endpoints/openapi/StatusCodes.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/StatusCodes.scala
@@ -11,11 +11,15 @@ trait StatusCodes extends endpoints.algebra.StatusCodes {
   type StatusCode = Int
 
   def OK = 200
+  def Created = 201
+  def Accepted = 202
+  def NoContent = 204
 
   def BadRequest = 400
-
   def Unauthorized = 401
-
+  def Forbidden = 403
   def NotFound = 404
+
+  def InternalServerError = 500
 
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -110,20 +110,20 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
 trait Fixtures extends algebra.Endpoints {
 
-  val foo = endpoint(get(path / "foo"), emptyResponse(Some("Foo response")), tags = List("foo"))
+  val foo = endpoint(get(path / "foo"), ok(emptyResponse, Some("Foo response")), tags = List("foo"))
 
-  val bar = endpoint(post(path / "foo", emptyRequest), emptyResponse(Some("Bar response")), tags = List("bar", "bxx"))
+  val bar = endpoint(post(path / "foo", emptyRequest), ok(emptyResponse, Some("Bar response")), tags = List("bar", "bxx"))
 
-  val baz = endpoint(get(path / "baz" / segment[Int]("quux")), emptyResponse(Some("Baz response")), tags = List("baz", "bxx"))
+  val baz = endpoint(get(path / "baz" / segment[Int]("quux")), ok(emptyResponse, Some("Baz response")), tags = List("baz", "bxx"))
 
-  val textRequestEndp = endpoint(post(path / "textRequestEndpoint", textRequest(docs = Some("Text Req"))), emptyResponse())
+  val textRequestEndp = endpoint(post(path / "textRequestEndpoint", textRequest, docs = Some("Text Req")), ok(emptyResponse))
 
-  val emptySegmentNameEndp = endpoint(post(path / "emptySegmentNameEndp" / segment[Int]() / "x" / segment[String](), textRequest()), emptyResponse())
+  val emptySegmentNameEndp = endpoint(post(path / "emptySegmentNameEndp" / segment[Int]() / "x" / segment[String](), textRequest), ok(emptyResponse))
 
-  val quux = endpoint(get(path / "quux" /? (qs[Double]("n") & qs[Option[String]]("lang") & qs[List[Long]]("ids"))), emptyResponse())
+  val quux = endpoint(get(path / "quux" /? (qs[Double]("n") & qs[Option[String]]("lang") & qs[List[Long]]("ids"))), ok(emptyResponse))
 
   val multipleSegmentsPath =
-    endpoint(get(path / "assets" / remainingSegments("file")), textResponse())
+    endpoint(get(path / "assets" / remainingSegments("file")), ok(textResponse))
 
 }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -35,9 +35,10 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
     implicit private val schemaBook: JsonSchema[Book] = genericJsonSchema[Book]
 
-    val listBooks = endpoint(get(path / "books"), jsonResponse[List[Book]](Some("Books list")), tags = List("Books"))
+    val listBooks = endpoint(get(path / "books"), ok(jsonResponse[List[Book]], Some("Books list")), tags = List("Books"))
 
-    val postBook = authenticatedEndpoint(Post, path / "books", emptyResponse(), jsonRequest[Book](docs = Some("Books list")), tags = List("Books"))
+    val postBook =
+      authenticatedEndpoint(Post, path / "books", ok(emptyResponse), jsonRequest[Book], requestDocs = Some("Books list"), tags = List("Books"))
   }
 
   "OpenApi" should {

--- a/play/client/src/main/scala/endpoints/play/client/BasicAuthentication.scala
+++ b/play/client/src/main/scala/endpoints/play/client/BasicAuthentication.scala
@@ -22,8 +22,8 @@ trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints 
     * Checks that the result is not `Forbidden`
     */
   private[endpoints] def authenticated[A](inner: Response[A], docs: Documentation): Response[Option[A]] =
-    resp =>
-      if (resp.status == 403) Right(None)
-      else inner(resp).right.map(Some(_))
+    (status, headers) =>
+      if (status == 403) _ => Right(None)
+      else wsResp => inner(status, headers)(wsResp).right.map(Some(_))
 
 }

--- a/play/client/src/main/scala/endpoints/play/client/JsonEntitiesFromCodec.scala
+++ b/play/client/src/main/scala/endpoints/play/client/JsonEntitiesFromCodec.scala
@@ -1,6 +1,6 @@
 package endpoints.play.client
 
-import endpoints.algebra.{Codec, Documentation}
+import endpoints.algebra.Codec
 import play.api.http.ContentTypes
 import play.api.libs.ws.{BodyWritable, InMemoryBody}
 
@@ -12,13 +12,13 @@ import play.api.libs.ws.{BodyWritable, InMemoryBody}
   */
 trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] = { (a, wsRequest) =>
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, wsRequest) =>
     val playCodec: play.api.mvc.Codec = implicitly[play.api.mvc.Codec]
     val writable = BodyWritable((s: String) => InMemoryBody(playCodec.encode(s)), ContentTypes.JSON)
     wsRequest.withBody(codec.encode(a))(writable)
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]): Response[A] =
-    response => codec.decode(response.body)
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] =
+    wsResp => codec.decode(wsResp.body)
 
 }

--- a/play/client/src/main/scala/endpoints/play/client/MuxEndpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/MuxEndpoints.scala
@@ -22,7 +22,7 @@ trait MuxEndpoints extends algebra.Endpoints { self: Endpoints =>
       decoder: Decoder[Transport, Resp]
     ): Future[req.Response] =
       request(encoder.encode(req)).flatMap { wsResponse =>
-        futureFromEither(response(wsResponse).right.flatMap { t =>
+        futureFromEither(response(wsResponse.status, wsResponse.headers)(wsResponse).right.flatMap { t =>
           decoder.decode(t).asInstanceOf[Either[Throwable, req.Response]]
         })
       }

--- a/play/client/src/main/scala/endpoints/play/client/StatusCodes.scala
+++ b/play/client/src/main/scala/endpoints/play/client/StatusCodes.scala
@@ -7,11 +7,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = Int
 
   def OK = 200
+  def Created = 201
+  def Accepted = 202
+  def NoContent = 204
 
   def BadRequest = 400
-
   def Unauthorized = 401
-
+  def Forbidden = 403
   def NotFound = 404
+
+  def InternalServerError = 500
 
 }

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
@@ -1,10 +1,10 @@
 package endpoints.play.server.circe
 
 import endpoints.algebra
-import endpoints.algebra.Documentation
 import endpoints.play.server.Endpoints
 import endpoints.play.server.circe.Util.circeJsonWriteable
-import io.circe.parser
+import io.circe.{Json, parser}
+import play.api.http.Writeable
 import play.api.mvc.Results
 
 /**
@@ -17,13 +17,14 @@ trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with 
   import playComponents.executionContext
 
 
-  def jsonRequest[A : JsonSchema](docs: Documentation): RequestEntity[A] =
+  def jsonRequest[A : JsonSchema]: RequestEntity[A] =
     playComponents.playBodyParsers.tolerantText.validate { text =>
       parser.parse(text)
         .right.flatMap(implicitly[JsonSchema[A]].decoder.decodeJson)
         .left.map(ignoredError => Results.BadRequest)
     }
 
-  def jsonResponse[A : JsonSchema](docs: Documentation): Response[A] = a => Results.Ok(implicitly[JsonSchema[A]].encoder.apply(a))
+  def jsonResponse[A : JsonSchema]: ResponseEntity[A] =
+    implicitly[Writeable[Json]].map(a => implicitly[JsonSchema[A]].encoder(a))
 
 }

--- a/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
+++ b/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
@@ -1,9 +1,9 @@
 package endpoints.play.server.playjson
 
 import endpoints.algebra
-import endpoints.algebra.Documentation
 import endpoints.play.server.Endpoints
-import play.api.libs.json.Json
+import play.api.http.Writeable
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Results
 
 /**
@@ -14,13 +14,13 @@ trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with 
 
   import playComponents.executionContext
 
-  def jsonRequest[A: JsonSchema](docs: Documentation): RequestEntity[A] =
+  def jsonRequest[A: JsonSchema]: RequestEntity[A] =
     playComponents.playBodyParsers.tolerantText.validate { text =>
       Json.parse(text).validate(implicitly[JsonSchema[A]].reads).asEither
         .left.map(ignoredError => Results.BadRequest)
     }
 
-  def jsonResponse[A: JsonSchema](docs: Documentation): Response[A] =
-    a => Results.Ok(implicitly[JsonSchema[A]].writes.writes(a))
+  def jsonResponse[A: JsonSchema]: ResponseEntity[A] =
+    implicitly[Writeable[JsValue]].map(a => implicitly[JsonSchema[A]].writes.writes(a))
 
 }

--- a/play/server/src/main/scala/endpoints/play/StatusCodes.scala
+++ b/play/server/src/main/scala/endpoints/play/StatusCodes.scala
@@ -9,11 +9,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = Results.Status
 
   def OK = Results.Ok
+  def Created = Results.Created
+  def Accepted = Results.Accepted
+  def NoContent = Results.Status(204)
 
   def BadRequest = Results.BadRequest
-
   def Unauthorized = Results.Unauthorized
-
+  def Forbidden = Results.Forbidden
   def NotFound = Results.NotFound
+
+  def InternalServerError = Results.InternalServerError
 
 }

--- a/play/server/src/main/scala/endpoints/play/server/JsonEntitiesFromCodec.scala
+++ b/play/server/src/main/scala/endpoints/play/server/JsonEntitiesFromCodec.scala
@@ -1,6 +1,6 @@
 package endpoints.play.server
 
-import endpoints.algebra.{Codec, Documentation}
+import endpoints.algebra.Codec
 import play.api.http.{ContentTypes, Writeable}
 import play.api.mvc.Results
 
@@ -14,14 +14,14 @@ trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitie
 
   import playComponents.executionContext
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] =
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] =
     playComponents.playBodyParsers.tolerantText.validate { body =>
       codec.decode(body).left.map(ignoredError => Results.BadRequest)
     }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]): Response[A] = { a =>
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = {
     val playCodec = implicitly[play.api.mvc.Codec]
-    Results.Ok(playCodec.encode(codec.encode(a)))(Writeable(s => s, Some(ContentTypes.JSON)))
+    Writeable((a: A) => playCodec.encode(codec.encode(a)), Some(ContentTypes.JSON))
   }
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
@@ -24,7 +24,7 @@ trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
     */
   private[endpoints] def authenticated[A](response: Response[A], docs: Documentation): Response[Option[A]] =
     resp =>
-      if (resp.code == 403) Right(None)
-      else response(resp).right.map(Some(_))
+      if (resp.code == 403) _ => Right(None)
+      else entity => response(resp)(entity).right.map(Some(_))
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
@@ -32,12 +32,16 @@ trait Endpoints extends algebra.Endpoints with Requests with Responses {
         }
       }
 
-    def callUnsafe(args: Req): Resp = response(request(args).asString) match {
-      case Left(ex) => throw ex
-      case Right(x) => x
-    }
+    def callUnsafe(args: Req): Resp =
+      call(args) match {
+        case Left(ex) => throw ex
+        case Right(x) => x
+      }
 
-    def call(args: Req): Either[Throwable, Resp] = response(request(args).asString)
+    def call(args: Req): Either[Throwable, Resp] = {
+      val resp = request(args).asString
+      response(resp)(resp.body)
+    }
   }
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
@@ -1,5 +1,5 @@
 package endpoints.scalaj.client
-import endpoints.algebra.{Codec, Documentation}
+import endpoints.algebra.Codec
 
 /**
   * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that encodes JSON requests
@@ -9,12 +9,12 @@ import endpoints.algebra.{Codec, Documentation}
   */
 trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] = (data, request) => {
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = (data, request) => {
     request.header("Content-Type", "application/json")
     request.postData(codec.encode(data))
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]): Response[A] =
-    resp => codec.decode(resp.body)
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] =
+    resp => codec.decode(resp)
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -40,7 +40,7 @@ trait Requests extends algebra.Requests with Urls with Methods {
 
   def emptyRequest: RequestEntity[Unit] = (x: Unit, req: HttpRequest) => req
 
-  def textRequest(docs: Option[String]): (String, HttpRequest) => scalaj.http.HttpRequest =
+  def textRequest: (String, HttpRequest) => scalaj.http.HttpRequest =
     (body, req) => req.postData(body)
 
   implicit def reqEntityInvFunctor: InvariantFunctor[RequestEntity] = new InvariantFunctor[RequestEntity] {
@@ -52,6 +52,7 @@ trait Requests extends algebra.Requests with Urls with Methods {
   def request[U, E, H, UE, Out](method: Method,
     url: Url[U],
     entity: RequestEntity[E] = emptyRequest,
+    docs: Documentation = None,
     headers: RequestHeaders[H] = emptyHeaders
   )(implicit tuplerUE: Tupler.Aux[U, E, UE], tuplerUEH: Tupler.Aux[UE, H, Out]): Request[Out] =
     (ueh) => {

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/StatusCodes.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/StatusCodes.scala
@@ -7,11 +7,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = Int
 
   def OK = 200
+  def Created = 201
+  def Accepted = 202
+  def NoContent = 204
 
   def BadRequest = 400
-
   def Unauthorized = 401
-
+  def Forbidden = 403
   def NotFound = 404
+
+  def InternalServerError = 500
 
 }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
@@ -1,6 +1,6 @@
 package endpoints.sttp.client
 
-import endpoints.algebra.{Codec, Documentation}
+import endpoints.algebra.Codec
 import com.softwaremill.sttp
 
 import scala.language.higherKinds
@@ -11,14 +11,14 @@ import scala.language.higherKinds
   */
 trait JsonEntitiesFromCodec[R[_]] extends endpoints.algebra.JsonEntitiesFromCodec { self: Endpoints[R] =>
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
+  def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
     req.body(codec.encode(a)).contentType("application/json")
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]): Response[A] = new SttpResponse[A] {
-    override type ReceivedBody = Either[Exception, A]
-    override def responseAs = sttp.asString.map(str => codec.decode(str))
-    override def validateResponse(response: sttp.Response[ReceivedBody]): R[A] = {
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = new SttpResponse[A] {
+    type ReceivedBody = Either[Exception, A]
+    def responseAs = sttp.asString.map(str => codec.decode(str))
+    def decodeEntity(response: sttp.Response[ReceivedBody]): R[A] = {
       response.unsafeBody match {
         case Right(a) => backend.responseMonad.unit(a)
         case Left(exception) => backend.responseMonad.error(exception)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
@@ -14,10 +14,10 @@ trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: Endpoints[R] =>
   class MuxEndpoint[Req <: algebra.MuxRequest, Resp, Transport](request: Request[Transport], response: Response[Transport]) {
 
     def apply(req: Req)(implicit encoder: Encoder[Req, Transport], decoder: Decoder[Transport, Resp]): R[req.Response] = {
-      val sttpRequest: sttp.Request[response.ReceivedBody, Nothing] = request(encoder.encode(req)).response(response.responseAs)
+      val sttpRequest: sttp.Request[response.entity.ReceivedBody, Nothing] = request(encoder.encode(req)).response(response.entity.responseAs)
       val result = self.backend.send(sttpRequest)
       self.backend.responseMonad.flatMap(result) { res =>
-        val transportR: R[Transport] = response.validateResponse(res)
+        val transportR: R[Transport] = response.decodeResponse(res)
         self.backend.responseMonad.flatMap(transportR) { transport =>
           decoder.decode(transport) match {
             case Right(r) => self.backend.responseMonad.unit(r.asInstanceOf[req.Response])

--- a/sttp/client/src/main/scala/endpoints/sttp/client/StatusCodes.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/StatusCodes.scala
@@ -7,11 +7,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = Int
 
   def OK = 200
+  def Created = 201
+  def Accepted = 202
+  def NoContent = 204
 
   def BadRequest = 400
-
   def Unauthorized = 401
-
+  def Forbidden = 403
   def NotFound = 404
+
+  def InternalServerError = 500
 
 }

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
@@ -19,12 +19,12 @@ trait JsonEntities extends Endpoints with algebra.JsonEntities {
   /** Decodes an `A` using circe’s [[io.circe.Decoder]] */
   type JsonResponse[A] = CirceDecoder[A]
 
-  def jsonRequest[A : JsonRequest](docs: Documentation): RequestEntity[A] = (a: A, xhr: XMLHttpRequest) => {
+  def jsonRequest[A : JsonRequest]: RequestEntity[A] = (a: A, xhr: XMLHttpRequest) => {
     xhr.setRequestHeader("Content-Type", "application/json")
     CirceEncoder[A].apply(a).noSpaces
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit decoder: CirceDecoder[A]): Response[A] =
+  def jsonResponse[A](implicit decoder: CirceDecoder[A]): ResponseEntity[A] =
     xhr => parser.parse(xhr.responseText).right.flatMap(decoder.decodeJson)
 
 }

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonSchemaEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonSchemaEntities.scala
@@ -1,6 +1,5 @@
 package endpoints.xhr.circe
 
-import endpoints.algebra.Documentation
 import endpoints.{algebra, circe, xhr}
 import io.circe.parser
 import org.scalajs.dom.XMLHttpRequest
@@ -13,13 +12,13 @@ trait JsonSchemaEntities
     with algebra.JsonSchemaEntities
     with circe.JsonSchemas {
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: JsonSchema[A]): RequestEntity[A] =
+  def jsonRequest[A](implicit codec: JsonSchema[A]): RequestEntity[A] =
     { (a: A, xhr: XMLHttpRequest) =>
       xhr.setRequestHeader("Content-Type", "application/json")
       codec.encoder.apply(a).noSpaces
     }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: JsonSchema[A]): Response[A] =
+  def jsonResponse[A](implicit codec: JsonSchema[A]): ResponseEntity[A] =
     xhr => parser.parse(xhr.responseText).right.flatMap(codec.decoder.decodeJson)
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/Assets.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Assets.scala
@@ -79,14 +79,12 @@ trait Assets extends algebra.Assets with Endpoints {
     }
 
   private def arrayBufferResponse: Response[ArrayBuffer] =
-    (xhr: XMLHttpRequest) => {
-      if (xhr.status < 300) {
-        try {
-          Right(xhr.response.asInstanceOf[ArrayBuffer])
-        } catch {
-          case exn: Exception => Left(exn)
-        }
-      } else Left(new Exception("Resource not found"))
+    ok { xhr =>
+      try {
+        Right(xhr.response.asInstanceOf[ArrayBuffer])
+      } catch {
+        case exn: Exception => Left(exn)
+      }
     }
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/BasicAuthentication.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/BasicAuthentication.scala
@@ -25,7 +25,7 @@ trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
   private[endpoints] def authenticated[A](response: Response[A], notFoundDocs: Documentation): Response[Option[A]] =
     xhr =>
       // We don’t care of 401 because we always set the Authorization header. We only care about 403.
-      if (xhr.status == 403) Right(None) // We use `Right` to make handling of authentication failures explicit
-      else response(xhr).right.map(Some(_))
+      if (xhr.status == 403) _ => Right(None) // We use `Right` to make handling of authentication failures explicit
+      else _ => response(xhr)(xhr).right.map(Some(_))
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/JsonEntitiesFromCodec.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/JsonEntitiesFromCodec.scala
@@ -11,12 +11,12 @@ import org.scalajs.dom.XMLHttpRequest
   */
 trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
 
-  def jsonRequest[A](docs: Documentation)(implicit codec: Codec[String, A]) = (a: A, xhr: XMLHttpRequest) => {
+  def jsonRequest[A](implicit codec: Codec[String, A]) = (a: A, xhr: XMLHttpRequest) => {
     xhr.setRequestHeader("Content-Type", "application/json")
     codec.encode(a)
   }
 
-  def jsonResponse[A](docs: Documentation)(implicit codec: Codec[String, A]) =
+  def jsonResponse[A](implicit codec: Codec[String, A]) =
     (xhr: XMLHttpRequest) => codec.decode(xhr.responseText)
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/LowLevelEndpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/LowLevelEndpoints.scala
@@ -21,6 +21,6 @@ trait LowLevelEndpoints extends algebra.LowLevelEndpoints with Endpoints {
   type RawResponseEntity = XMLHttpRequest
 
   /** Successfully returns the underlying XMLHttpRequest, whatever its status code is */
-  lazy val rawResponseEntity: Response[RawResponseEntity] = xhr => Right(xhr)
+  lazy val rawResponseEntity: Response[RawResponseEntity] = xhr => _ => Right(xhr)
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/StatusCodes.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/StatusCodes.scala
@@ -12,11 +12,15 @@ trait StatusCodes extends algebra.StatusCodes {
   type StatusCode = Int
 
   def OK = 200
+  def Created = 201
+  def Accepted = 202
+  def NoContent = 204
 
   def BadRequest = 400
-
   def Unauthorized = 401
-
+  def Forbidden = 403
   def NotFound = 404
+
+  def InternalServerError = 500
 
 }

--- a/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
+++ b/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
@@ -5,11 +5,11 @@ import org.scalatest.FreeSpec
 // Separation of the Algebra here is important, due to implementation details
 // of the underlying representation of header in the xhr algebra.
 trait FixturesAlgebra extends endpoints.algebra.Endpoints {
-  val foo = endpoint(get(path / "foo" / segment[String]()), emptyResponse())
-  val bar = endpoint(post(path / "bar" /? qs[Int]("quux"), emptyRequest), emptyResponse())
+  val foo = endpoint(get(path / "foo" / segment[String]()), ok(emptyResponse))
+  val bar = endpoint(post(path / "bar" /? qs[Int]("quux"), emptyRequest), ok(emptyResponse))
   // Currently, the fact that this line compiles is a test, as there's no way
   // to inspect the result of constructing headers at the moment.
-  val baz = endpoint(post(path / "baz", emptyRequest, header("quuz") ++ header("corge") ++ optHeader("grault")), emptyResponse())
+  val baz = endpoint(post(path / "baz", emptyRequest, headers = header("quuz") ++ header("corge") ++ optHeader("grault")), ok(emptyResponse))
 }
 
 object Fixtures extends FixturesAlgebra with thenable.Endpoints


### PR DESCRIPTION
As discussed face to face, let's create a PR for this so we can iterate on it and merge this :tada: 

This PR introduce `ResponseEntity`, which split the current behavior of `Response` with a entity part and the status code part. This allows us to return a response with different status codes and not only 200.