### PR TITLE
Add support for type parameters in generic JsonSchemas

### DIFF
--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -26,6 +26,15 @@ class JsonSchemasTest extends FreeSpec {
     object Quux {
       implicit val schema: JsonSchema[Quux] = genericJsonSchema[Quux]
     }
+
+    case class GenericFoo[T](value : T)
+
+    object GenericFoo{
+      implicit def schemaPrimitive: JsonSchema[GenericFoo[Int]] = genericJsonSchema[GenericFoo[Int]]
+
+      implicit val fooSchema =  Foo.schema
+      implicit def schemaFoo: JsonSchema[GenericFoo[Foo]] = genericJsonSchema[GenericFoo[Foo]]
+    }
   }
 
   object FakeAlgebraJsonSchemas extends GenericSchemas with endpoints.algebra.JsonSchemas {
@@ -105,6 +114,16 @@ class JsonSchemasTest extends FreeSpec {
   "sealed trait" in {
     val expectedSchema = "'endpoints.generic.JsonSchemasTest.GenericSchemas.Quux'!('endpoints.generic.JsonSchemasTest.GenericSchemas.Quux'!('endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxA'!(ss:[string],$)@QuuxA|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxB'!(i:integer,$)@QuuxB|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxC'!(b:boolean,$)@QuuxC|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxD'!($)@QuuxD|'endpoints.generic.JsonSchemasTest.GenericSchemas.QuuxE'!($)@QuuxE))"
     assert(FakeAlgebraJsonSchemas.Quux.schema == expectedSchema)
+  }
+
+  "generic primitive parameters" in {
+    val expectedSchema = "'endpoints.generic.JsonSchemasTest.GenericSchemas.GenericFoo-int'!('endpoints.generic.JsonSchemasTest.GenericSchemas.GenericFoo-int'!(value:integer,$))"
+    assert(FakeAlgebraJsonSchemas.GenericFoo.schemaPrimitive == expectedSchema)
+  }
+
+  "generic type parameters" in {
+    val expectedSchema = "'endpoints.generic.JsonSchemasTest.GenericSchemas.GenericFoo-endpoints.generic.JsonSchemasTest.GenericSchemas.Foo'!('endpoints.generic.JsonSchemasTest.GenericSchemas.GenericFoo-endpoints.generic.JsonSchemasTest.GenericSchemas.Foo'!(value:'endpoints.generic.JsonSchemasTest.GenericSchemas.Foo'!('endpoints.generic.JsonSchemasTest.GenericSchemas.Foo'!(bar:string,baz:integer,qux:boolean?,$)),$))"
+    assert(FakeAlgebraJsonSchemas.GenericFoo.schemaFoo == expectedSchema)
   }
 
 }


### PR DESCRIPTION
When using generic JsonSchemas with classes using type parameters, the generated name will be the same for all typed classes
Documentation will be overwritten and be wrong for all but one reference.

This PR try to fix this by adding type parameters in the name of the schema if there are some.

For `case class GenericFoo[A, B]` in package `com` with type parameters `GenericFoo[Int, com.foo.Bar]` generated name will be `com.GenericFoo-int_com.foo.Bar`

I had to use a Manifest, couldn't import a TypeTag... probably some cross compilation problem ?

Happy reviewing