### PR TITLE
Move endpoints.akkahttp.client.JsonSchemaEntities to a separate artifact

### DIFF
--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -27,8 +27,18 @@ val `akka-http-client` =
     )
     .dependsOn(`algebra-jvm` % "test->test;compile->compile")
     .dependsOn(`algebra-circe-jvm` % "test->test")
-    .dependsOn(`json-schema-circe-jvm`)
     .dependsOn(`json-schema-generic-jvm` % "test->test")
+
+val `akka-http-client-circe` =
+  project.in(file("client-circe"))
+    .settings(
+      publishSettings,
+      `scala 2.11 to 2.12`,
+      name := "endpoints-akka-http-client-circe"
+    ).dependsOn(
+      `akka-http-client` % "test->test;compile->compile",
+      `json-schema-circe-jvm`
+    )
 
 val `akka-http-server` =
   project.in(file("server"))

--- a/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
+++ b/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
@@ -1,7 +1,8 @@
-package endpoints.akkahttp.client
+package endpoints.akkahttp.client.circe
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import endpoints._
+import endpoints.akkahttp.client.Endpoints
 import io.circe.{Encoder, Decoder}
 import io.circe.syntax._
 import io.circe.parser.decode
@@ -27,4 +28,3 @@ trait JsonSchemaEntities extends algebra.JsonSchemaEntities with circe.JsonSchem
     } yield decode[A](settings.stringContentExtractor(strictEntity))
   }
 }
-

--- a/akka-http/client-circe/src/test/scala/endpoints/akkahttp/client/circe/EndpointsJsonSchemaTest.scala
+++ b/akka-http/client-circe/src/test/scala/endpoints/akkahttp/client/circe/EndpointsJsonSchemaTest.scala
@@ -1,7 +1,8 @@
-package endpoints.akkahttp.client
+package endpoints.akkahttp.client.circe
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
+import endpoints.akkahttp.client.{AkkaHttpRequestExecutor, BasicAuthentication, Endpoints, EndpointsSettings}
 import endpoints.algebra.client.{BasicAuthTestSuite, JsonTestSuite}
 import endpoints.algebra.{Address, BasicAuthTestApi, JsonTestApi, User}
 import endpoints.generic

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -13,6 +13,7 @@ val `play-server-circe` = LocalProject("play-server-circe")
 val `play-server-playjson` = LocalProject("play-server-playjson")
 
 val `akka-http-client` = LocalProject("akka-http-client")
+val `akka-http-client-circe` = LocalProject("akka-http-client-circe")
 val `akka-http-server` = LocalProject("akka-http-server")
 val `akka-http-server-circe` = LocalProject("akka-http-server-circe")
 val `akka-http-server-playjson` = LocalProject("akka-http-server-playjson")
@@ -47,7 +48,7 @@ val apiDoc =
       ),
       unidocProjectFilter in(ScalaUnidoc, unidoc) := inProjects(
         `algebra-jvm`, `algebra-circe-jvm`, `algebra-playjson-jvm`,
-        `akka-http-client`, `akka-http-server`, `akka-http-server-circe`, `akka-http-server-playjson`,
+        `akka-http-client`, `akka-http-client-circe`, `akka-http-server`, `akka-http-server-circe`, `akka-http-server-playjson`,
         `play-client`, `play-server`, `play-server-circe`, `play-server-playjson`,
         `xhr-client`, `xhr-client-circe`, `xhr-client-faithful`,
         `scalaj-client`,


### PR DESCRIPTION
Introduce an endpoints-akka-http-client-circe artifact that depends
on Circe, and remove circe dependency from endpoints-akka-http-client
artifact.

Fixes #303