### PR TITLE
Bump Scala version to 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       scala: 2.12.8
       script: sbt ++$TRAVIS_SCALA_VERSION test manual/makeSite
     - stage: test
-      scala: 2.13.0-M5
+      scala: 2.13.0
       script: sbt "++ $TRAVIS_SCALA_VERSION test"
 
     - stage: coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ or for faster feedback loop:
 ~~~ sh
 $ sbt "++ 2.11.12 test"
 $ sbt "++ 2.12.8 test"
-$ sbt "++ 2.13.0-M5 test"
+$ sbt "++ 2.13.0 test"
 ~~~
 
 

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -9,7 +9,7 @@ val `json-schema` =
       `scala 2.11 to latest`,
       name := "endpoints-algebra-json-schema",
       addScalaTestCrossDependency,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "0.3.0"
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.1"
     )
 
 val `json-schema-js` = `json-schema`.js
@@ -19,7 +19,7 @@ lazy val `json-schema-generic` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("json-schema-generic"))
     .settings(
       publishSettings,
-      `scala 2.11 to 2.12`,
+      `scala 2.11 to latest`,
       name := "endpoints-json-schema-generic",
       libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.3",
       addScalaTestCrossDependency

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -18,13 +18,11 @@ object EndpointsSettings {
       "-unchecked",
       "-Xlint",
       "-Ywarn-dead-code",
-      "-Ywarn-numeric-widen",
-      "-Ywarn-value-discard",
-      "-Xfuture"
+      "-Ywarn-numeric-widen"
     ) ++
     (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, n)) if n >= 13 => Seq("-Xsource:2.14")
-      case _ => Seq("-Yno-adapted-args", "-Ywarn-unused-import", "-Xexperimental")
+      case _ => Seq("-Yno-adapted-args", "-Ywarn-unused-import", "-Xexperimental", "-Xfuture", "-Ywarn-value-discard")
     })
   )
   val `scala 2.11` = Seq(
@@ -37,7 +35,7 @@ object EndpointsSettings {
   )
   val `scala 2.11 to latest` = Seq(
     scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-M5")
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
   )
 
   val publishSettings = commonSettings ++ Seq(
@@ -67,7 +65,7 @@ object EndpointsSettings {
 
   val noPublishSettings = commonSettings ++ Seq(
     publishArtifact := false,
-    publish := ()
+    publish := { () }
     //  publishLocal := ()
   )
 
@@ -78,7 +76,7 @@ object EndpointsSettings {
   val playVersion = "2.6.21"
   val sttpVersion = "1.5.15"
 
-  val scalaTestVersion = "3.0.7"
+  val scalaTestVersion = "3.0.8"
   val scalaTestDependency = "org.scalatest" %% "scalatest" % scalaTestVersion % Test
   val addScalaTestCrossDependency = libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")


### PR DESCRIPTION
Only the algebra does target 2.13.

Upgrading the interpreters is a work in progress that can be seen in #279.