### PR TITLE
Support up to 6 tupled values

### DIFF
--- a/algebras/algebra/src/main/scala/endpoints/Tupler.scala
+++ b/algebras/algebra/src/main/scala/endpoints/Tupler.scala
@@ -17,16 +17,17 @@ package endpoints
   * }}}
   *
   * The following rules are implemented (by increasing priority):
-  *  - A, B              -> (A, B)
-  *  - A, (B, C)         -> (A, B, C)
-  *  - (A, B), C         -> (A, B, C)
-  *  - (A, B), (C, D)    -> (A, B, C, D)
-  *  - A, (B, C, D, E)   -> (A, B, C, D, E)
-  *  - (A, B), (C, D, E) -> (A, B, C, D, E)
-  *  - (A, B, C), D      -> (A, B, C, D)
-  *  - (A, B, C, D), E   -> (A, B, C, D, E)
-  *  - A, Unit           -> A
-  *  - Unit, A           -> A
+  *  - A, B               -> (A, B)
+  *  - A, (B, C)          -> (A, B, C)
+  *  - (A, B), C          -> (A, B, C)
+  *  - (A, B), (C, D)     -> (A, B, C, D)
+  *  - A, (B, C, D, E)    -> (A, B, C, D, E)
+  *  - (A, B), (C, D, E)  -> (A, B, C, D, E)
+  *  - (A, B, C), D       -> (A, B, C, D)
+  *  - (A, B, C, D), E    -> (A, B, C, D, E)
+  *  - (A, B, C, D, E), F -> (A, B, C, D, E, F)
+  *  - A, Unit            -> A
+  *  - Unit, A            -> A
   */
 //#definition
 trait Tupler[A, B] {
@@ -124,6 +125,17 @@ trait Tupler3 extends Tupler2 {
       def unapply(out: (A, B, C, D, E)): ((A, B, C, D), E) = {
         val (a, b, c, d, e) = out
         ((a, b, c, d), e)
+      }
+    }
+
+  implicit def tupler5And1[A, B, C, D, E, F]: Tupler[(A, B, C, D, E), F] { type Out = (A, B, C, D, E, F) } =
+    new Tupler[(A, B, C, D, E), F] {
+      type Out = (A, B, C, D, E, F)
+      def apply(abcde: (A, B, C, D, E), f: F): (A, B, C, D, E, F) =
+        (abcde._1, abcde._2, abcde._3, abcde._4, abcde._5, f)
+      def unapply(out: (A, B, C, D, E, F)): ((A, B, C, D, E), F) = {
+        val (a, b, c, d, e, f) = out
+        ((a, b, c, d, e), f)
       }
     }
 

--- a/algebras/algebra/src/test/scala/endpoints/TuplerTests.scala
+++ b/algebras/algebra/src/test/scala/endpoints/TuplerTests.scala
@@ -4,7 +4,7 @@ class TuplerTests {
 
   def tupling[A, B](a: A, b: B)(implicit tupler: Tupler[A, B]): tupler.Out = tupler(a, b)
 
-  def forall[A, B, C, D, E](a: A, b: B, c: C, d: D, e: E): Unit = {
+  def forall[A, B, C, D, E, F](a: A, b: B, c: C, d: D, e: E, f: F): Unit = {
     tupling(a, b): (A, B)
     tupling(a, (b, c)): (A, B, C)
     tupling((a, b), c): (A, B, C)
@@ -13,6 +13,7 @@ class TuplerTests {
     tupling((a, b), (c, d, e)): (A, B, C, D, E)
     tupling((a, b, c), d): (A, B, C, D)
     tupling((a, b, c, d), e): (A, B, C, D, E)
+    tupling((a, b, c, d, e), f): (A, B, C, D, E, F)
     tupling(a, ()): A
     tupling((), a): A
     tupling((), ()): Unit


### PR DESCRIPTION
Adding new rules like this obviously doesn’t scale. If we were using
an inductive structure (such as an `HList`) instead of flat tuples,
the rules would be much more simpler (and not limited to an arbitrary
arity!). Hopefully all of that will be simplified in Scala 3 where flat
tuples are unified with HLists.