### PR TITLE
Improve error messages reported by servers

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
@@ -1,20 +1,31 @@
 package endpoints.akkahttp.client
 
 import akka.http.scaladsl.model.headers._
-import endpoints.algebra
+import endpoints.{Tupler, algebra}
 import endpoints.algebra.BasicAuthentication.Credentials
+import endpoints.algebra.Documentation
 
 /**
   * @group interpreters
   */
 trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints =>
 
-  /**
-    * Supplies the credential into the request headers
-    */
-  private[endpoints] lazy val basicAuthenticationHeader: RequestHeaders[Credentials] =
-    (credentials, headers) => {
-      headers :+ Authorization(BasicHttpCredentials(credentials.username, credentials.password))
-    }
+  private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Request[Out] = {
+    val basicAuthenticationHeader: RequestHeaders[Credentials] =
+      (credentials, headers) => {
+        headers :+ Authorization(BasicHttpCredentials(credentials.username, credentials.password))
+      }
+    request(method, url, entity, requestDocs, headers ++ basicAuthenticationHeader)
+  }
 
 }

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/JsonEntitiesFromCodec.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/JsonEntitiesFromCodec.scala
@@ -18,7 +18,10 @@ trait JsonEntitiesFromCodec extends endpoints.algebra.JsonEntitiesFromCodec { th
   def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = { entity =>
     for {
       strictEntity <- entity.toStrict(settings.toStrictTimeout)
-    } yield codec.decode(settings.stringContentExtractor(strictEntity))
+    } yield {
+      codec.decode(settings.stringContentExtractor(strictEntity))
+        .fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
+    }
   }
 
 }

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/MuxEndpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/MuxEndpoints.scala
@@ -26,7 +26,10 @@ trait MuxEndpoints extends algebra.MuxEndpoints { self: Endpoints =>
         ).flatMap { entity =>
             entity(resp.entity).flatMap { t =>
               futureFromEither(t).flatMap(tt =>
-                futureFromEither(decoder.decode(tt)).map(_.asInstanceOf[req.Response])
+                futureFromEither(
+                  decoder.decode(tt)
+                    .fold(resp => Right(resp.asInstanceOf[req.Response]), errors => Left(new Exception(errors.mkString(". "))))
+                )
               )
             }
           }

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
@@ -5,7 +5,7 @@ import scala.collection.compat.Factory
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-import endpoints.{PartialInvariantFunctor, Tupler, algebra}
+import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import endpoints.algebra.Documentation
 
 /**
@@ -22,7 +22,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] =
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] =
       (b: B) => fa.encodeQueryString(g(b))
   }
 
@@ -49,7 +49,7 @@ trait Urls extends algebra.Urls {
   type QueryStringParam[A] = A => List[String]
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: A => List[String], f: A => Option[B], g: B => A): B => List[String] = fa compose g
+    def xmapPartial[A, B](fa: A => List[String], f: A => Validated[B], g: B => A): B => List[String] = fa compose g
   }
 
   implicit def optionalQueryStringParam[A](implicit param: QueryStringParam[A]): QueryStringParam[Option[A]] = {
@@ -67,7 +67,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
   }
 
   implicit lazy val stringSegment: Segment[String] = (s: String) => URLEncoder.encode(s, utf8Name)
@@ -75,7 +75,7 @@ trait Urls extends algebra.Urls {
   trait Path[A] extends Url[A]
 
   implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
   }
 
   def staticPathSegment(segment: String) = (_: Unit) => segment
@@ -95,7 +95,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
   }
 
   def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] =

--- a/akka-http/server-circe/src/main/scala/endpoints/akkahttp/server/circe/JsonSchemaEntities.scala
+++ b/akka-http/server-circe/src/main/scala/endpoints/akkahttp/server/circe/JsonSchemaEntities.scala
@@ -1,10 +1,11 @@
 package endpoints.akkahttp.server.circe
 
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Directives, MalformedRequestContentRejection, Rejection}
+import cats.Show
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import endpoints._
 import endpoints.akkahttp.server
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, DecodingFailure, Encoder}
 
 /**
   * Interpreter for [[algebra.JsonEntities]] that uses circe’s [[io.circe.Decoder]] to decode
@@ -18,6 +19,15 @@ trait JsonSchemaEntities extends server.Endpoints with algebra.JsonSchemaEntitie
   def jsonRequest[A : JsonSchema]: RequestEntity[A] = {
     implicit def decoder: Decoder[A] = implicitly[JsonSchema[A]].decoder
     Directives.entity[A](implicitly)
+      .recoverPF(Function.unlift { rejections: Seq[Rejection] =>
+        val decodingErrors =
+          rejections.collect {
+            case MalformedRequestContentRejection(_, DecodingFailures(errors)) =>
+              errors.map(Show[DecodingFailure].show).toList
+          }.flatten
+        if (decodingErrors.isEmpty) None
+        else Some(handleClientErrors(Invalid(decodingErrors)))
+      })
   }
 
   def jsonResponse[A : JsonSchema]: ResponseEntity[A] = {

--- a/akka-http/server-circe/src/test/scala/endpoints/akkahttp/server/circe/EndpointsJsonSchemaTest.scala
+++ b/akka-http/server-circe/src/test/scala/endpoints/akkahttp/server/circe/EndpointsJsonSchemaTest.scala
@@ -1,12 +1,13 @@
 package endpoints.akkahttp.server.circe
 
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, OK}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import endpoints.akkahttp.server.Endpoints
 import endpoints.algebra.User
 import endpoints.generic
+import io.circe.Json
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.language.reflectiveCalls
 
 class EndpointsJsonSchemaTestApi
   extends Endpoints
@@ -16,30 +17,69 @@ class EndpointsJsonSchemaTestApi
 
 class EndpointsJsonSchemaTest extends WordSpec with Matchers with ScalatestRouteTest {
 
-  val testRoutes = new EndpointsJsonSchemaTestApi {
+  object TestRoutes extends EndpointsJsonSchemaTestApi {
 
     implicit val userJsonSchema: JsonSchema[User] = genericJsonSchema[User]
 
     val singleStaticGetSegment = endpoint[Unit, User](
       get(path / "user"), ok(jsonResponse[User])
     ).implementedBy(_ => User("Bob", 30))
+
+    val updateUser =
+      endpoint(
+        put(path / "user" / segment[Long]("id"), jsonRequest[User]),
+        ok(jsonResponse[User])
+      ).implementedBy { case (_, user) => user }
   }
+
+  import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+  import TestRoutes.JsonSchema.toCirceDecoder
+  import TestRoutes.userJsonSchema
 
   "Single segment route" should {
 
-    import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-    import io.circe.generic.auto._
-
     "match single segment request" in {
-      Get("/user") ~> testRoutes.singleStaticGetSegment ~> check {
+      Get("/user") ~> TestRoutes.singleStaticGetSegment ~> check {
         responseAs[User] shouldEqual User("Bob", 30)
       }
     }
 
     "leave GET requests to other paths unhandled" in {
-      Get("/user/profile") ~> testRoutes.singleStaticGetSegment ~> check {
+      Get("/user/profile") ~> TestRoutes.singleStaticGetSegment ~> check {
         handled shouldBe false
       }
     }
+
+  }
+
+  "JSON entities" should {
+
+    "validate query parameters and headers before validating the entity" in {
+      def request(path: String, jsonEntity: String) =
+        Put(path)
+          .withEntity(ContentTypes.`application/json`, jsonEntity)
+
+      // Invalid URL and entity
+      request("/user/foo", "{\"name\":\"Alice\",\"age\":true}") ~> TestRoutes.updateUser ~> check {
+        handled shouldBe true
+        status shouldBe BadRequest
+        responseAs[Json] shouldBe Json.arr(Json.fromString("Invalid integer value 'foo' for segment 'id'"))
+      }
+
+      // Valid URL and invalid entity
+      request("/user/42", "{\"name\":\"Alice\",\"age\":true}") ~> TestRoutes.updateUser ~> check {
+        handled shouldBe true
+        status shouldBe BadRequest
+        responseAs[Json] shouldBe Json.arr(Json.fromString("DecodingFailure at .age: Int"))
+      }
+
+      // Valid URL and entity
+      request("/user/42", "{\"name\":\"Alice\",\"age\":55}") ~> TestRoutes.updateUser ~> check {
+        handled shouldBe true
+        status shouldBe OK
+        responseAs[Json] shouldBe Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(55))
+      }
+    }
+
   }
 }

--- a/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
+++ b/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
@@ -1,10 +1,11 @@
 package endpoints.akkahttp.server.playjson
 
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Directives, Rejection, ValidationRejection}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
+import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport.PlayJsonError
 import endpoints.akkahttp.server
-import endpoints.algebra
+import endpoints.{Invalid, algebra}
 
 /**
   * Interpreter for [[algebra.JsonEntities]] that uses Play JSON [[play.api.libs.json.Reads]] to decode
@@ -18,7 +19,19 @@ trait JsonSchemaEntities extends server.Endpoints with algebra.JsonSchemaEntitie
   def jsonRequest[A: JsonSchema]: RequestEntity[A] = {
     Directives.entity[A](
       Unmarshaller.messageUnmarshallerFromEntityUnmarshaller(
-        PlayJsonSupport.unmarshaller(implicitly[JsonSchema[A]].reads)))
+        PlayJsonSupport.unmarshaller(implicitly[JsonSchema[A]].reads))
+    ).recoverPF(Function.unlift { rejections: Seq[Rejection] =>
+      val decodingErrors =
+        rejections.collect {
+          case ValidationRejection(_, Some(PlayJsonError(error))) =>
+            for {
+              (path, pathErrors) <- error.errors.iterator
+              error <- pathErrors
+            } yield s"${error.message} for ${path.toJsonString}"
+        }.flatten
+      if (decodingErrors.isEmpty) None
+      else Some(handleClientErrors(Invalid(decodingErrors)))
+    })
   }
 
   def jsonResponse[A: JsonSchema]: ResponseEntity[A] =

--- a/akka-http/server-playjson/src/test/scala/endpoints/akkahttp/server/playjson/EndpointsJsonSchemaTest.scala
+++ b/akka-http/server-playjson/src/test/scala/endpoints/akkahttp/server/playjson/EndpointsJsonSchemaTest.scala
@@ -1,10 +1,13 @@
 package endpoints.akkahttp.server.playjson
 
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, OK}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import endpoints.akkahttp.server.Endpoints
 import endpoints.algebra.User
 import endpoints.generic
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsNumber, JsString, JsValue, Json}
 
 import scala.language.reflectiveCalls
 
@@ -23,6 +26,12 @@ class EndpointsJsonSchemaTest extends WordSpec with Matchers with ScalatestRoute
     val singleStaticGetSegment = endpoint[Unit, User](
       get(path / "user"), ok(jsonResponse[User])
     ).implementedBy(_ => User("Bob", 30))
+
+    val updateUser =
+      endpoint(
+        put(path / "user" / segment[Long]("id"), jsonRequest[User]),
+        ok(jsonResponse[User])
+      ).implementedBy { case (_, user) => user }
   }
 
   "Single segment route" should {
@@ -42,4 +51,36 @@ class EndpointsJsonSchemaTest extends WordSpec with Matchers with ScalatestRoute
       }
     }
   }
+
+  "JSON entities" should {
+
+    "validate query parameters and headers before validating the entity" in {
+      def request(path: String, jsonEntity: String) =
+        Put(path)
+          .withEntity(ContentTypes.`application/json`, jsonEntity)
+
+      // Invalid URL and entity
+      request("/user/foo", "{\"name\":\"Alice\",\"age\":true}") ~> testRoutes.updateUser ~> check {
+        handled shouldBe true
+        status shouldBe BadRequest
+        responseAs[JsValue] shouldBe Json.arr(JsString("Invalid integer value 'foo' for segment 'id'"))
+      }
+
+      // Valid URL and invalid entity
+      request("/user/42", "{\"name\":\"Alice\",\"age\":true}") ~> testRoutes.updateUser ~> check {
+        handled shouldBe true
+        status shouldBe BadRequest
+        responseAs[JsValue] shouldBe Json.arr(JsString("error.expected.jsnumber for obj.age"))
+      }
+
+      // Valid URL and entity
+      request("/user/42", "{\"name\":\"Alice\",\"age\":55}") ~> testRoutes.updateUser ~> check {
+        handled shouldBe true
+        status shouldBe OK
+        responseAs[JsValue] shouldBe Json.obj("name" -> JsString("Alice"), "age" -> JsNumber(55))
+      }
+    }
+
+  }
+
 }

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/BasicAuthentication.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/BasicAuthentication.scala
@@ -1,35 +1,53 @@
 package endpoints.akkahttp.server
 
-import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, HttpChallenges}
-import akka.http.scaladsl.model.{HttpHeader, HttpResponse, StatusCodes=>AkkaStatusCodes}
-import akka.http.scaladsl.server.{Directive, Directives}
-import endpoints.algebra
+import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, HttpChallenges, `WWW-Authenticate`}
+import akka.http.scaladsl.model.{HttpHeader, HttpResponse, StatusCodes => AkkaStatusCodes}
+import akka.http.scaladsl.server.{Directive, Directive1, Directives}
+import endpoints.{Tupler, algebra}
 import endpoints.algebra.BasicAuthentication.Credentials
+import endpoints.algebra.Documentation
 
 /**
   * @group interpreters
   */
 trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
 
-  /**
-    * Extracts the credentials from the request headers.
-    * In case of absence of credentials rejects request
-    */
-  private[endpoints] lazy val basicAuthenticationHeader: RequestHeaders[Credentials] =
-  Directives.optionalHeaderValue(extractCredentials).flatMap {
-    case Some(credentials) => Directives.pass.tmap(_ => credentials)
-    case None => Directive[Tuple1[Credentials]] { _ => //inner is ignored
-      import akka.http.scaladsl.model.headers
-      Directives.complete(HttpResponse(
-        AkkaStatusCodes.Unauthorized,
-        scala.collection.immutable.Seq[HttpHeader](headers.`WWW-Authenticate`(HttpChallenges.basic("Realm")))
-      ))
+  private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Request[Out] = {
+    val extractCredentials: HttpHeader => Option[Credentials] = {
+      case Authorization(BasicHttpCredentials(username, password)) => Some(Credentials(username, password))
+      case _ => None
     }
-  }
 
-  private def extractCredentials: HttpHeader => Option[Credentials] = {
-    case Authorization(BasicHttpCredentials(username, password)) => Some(Credentials(username, password))
-    case _ => None
+    val authHeader: Directive1[Credentials] =
+      Directives.optionalHeaderValue(extractCredentials).flatMap {
+        case Some(credentials) => Directives.provide(credentials)
+        case None => Directive[Tuple1[Credentials]] { _ => //inner is ignored
+          Directives.complete(HttpResponse(
+            AkkaStatusCodes.Unauthorized,
+            collection.immutable.Seq[HttpHeader](`WWW-Authenticate`(HttpChallenges.basic("Realm")))
+          ))
+        }
+      }
+    joinDirectives(
+      joinDirectives(
+        joinDirectives(
+          convToDirective1(Directives.method(method)),
+          url.directive
+        ),
+        entity
+      ),
+      headers ++ authHeader
+    )
   }
 
 }

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -1,13 +1,14 @@
 package endpoints.akkahttp.server
 
 import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller, ToResponseMarshaller}
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.server.{Directive1, Directives, Route}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import akka.http.scaladsl.server.{Directive1, Directives, ExceptionHandler, Route, StandardRoute}
 import akka.http.scaladsl.unmarshalling._
 import endpoints.algebra.Documentation
 import endpoints.{InvariantFunctor, Semigroupal, Tupler, algebra}
 
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
 /**
@@ -32,15 +33,24 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] = fa compose g
     }
 
-  case class Endpoint[A, B](request: Request[A], response: Response[B]) {
-    def implementedBy(implementation: A => B): Route = request { arguments =>
-      response(implementation(arguments))
-    }
+  private val endpointsExceptionHandler =
+    ExceptionHandler { case NonFatal(t) => handleServerError(t) }
 
-    def implementedByAsync(implementation: A => Future[B]): Route = request { arguments =>
-      Directives.onComplete(implementation(arguments)) {
-        case Success(result) => response(result)
-        case Failure(ex) => Directives.complete(ex)
+  case class Endpoint[A, B](request: Request[A], response: Response[B]) {
+    def implementedBy(implementation: A => B): Route =
+      Directives.handleExceptions(endpointsExceptionHandler) {
+        request { arguments =>
+          response(implementation(arguments))
+        }
+      }
+
+    def implementedByAsync(implementation: A => Future[B]): Route =
+      Directives.handleExceptions(endpointsExceptionHandler) {
+        request { arguments =>
+          Directives.onComplete(implementation(arguments)) {
+            case Success(result) => response(result)
+            case Failure(ex)     => throw ex
+          }
       }
     }
   }
@@ -101,15 +111,10 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
     headers: RequestHeaders[C] = emptyHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] = {
     val methodDirective = convToDirective1(Directives.method(method))
-    // we use Directives.pathPrefix to construct url directives, so now we close it
-    val urlDirective = joinDirectives(url.directive, convToDirective1(Directives.pathEndOrSingleSlash))
-    joinDirectives(
-      joinDirectives(
-        joinDirectives(
-          methodDirective,
-          urlDirective),
-        entity),
-      headers)
+    val matchDirective = methodDirective & url.directive & headers
+    matchDirective.tflatMap { case (_, a, c) =>
+      entity.map(b => tuplerABC(tuplerAB(a, b), c))
+    }
   }
 
   def endpoint[A, B](
@@ -121,7 +126,26 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
   ): Endpoint[A, B] = Endpoint(request, response)
 
   lazy val directive1InvFunctor: InvariantFunctor[Directive1] = new InvariantFunctor[Directive1] {
-    override def xmap[From, To](f: Directive1[From], map: From => To, contramap: To => From): Directive1[To] = f.map(map)
+    def xmap[From, To](f: Directive1[From], map: From => To, contramap: To => From): Directive1[To] = f.map(map)
   }
+
+  /**
+    * This method is called by ''endpoints'' when an exception is thrown during
+    * request processing.
+    *
+    * The default implementation is to return a route that completes with an
+    * Internal Server Error (500) response containing the error messages as a
+    * JSON array of string values.
+    *
+    * This method can be overridden to customize the error reporting logic.
+    */
+  def handleServerError(throwable: Throwable): StandardRoute =
+    Directives.complete(HttpResponse(
+      InternalServerError,
+      entity = HttpEntity(
+        ContentTypes.`application/json`,
+        s"""["${throwable.getMessage.toString.replaceAllLiterally("\\", "\\\\").replaceAllLiterally("\"", "\\\"")}"]"""
+      )
+    ))
 
 }

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntitiesFromCodec.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntitiesFromCodec.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
+import endpoints.{Invalid, Valid, Validated}
 import endpoints.algebra.Codec
 
 /**
@@ -15,11 +16,14 @@ import endpoints.algebra.Codec
 trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = {
-    implicit val fromEntityUnmarshaller: FromEntityUnmarshaller[A] =
+    implicit val fromEntityUnmarshaller: FromEntityUnmarshaller[Validated[A]] =
       Unmarshaller.stringUnmarshaller
         .forContentTypes(MediaTypes.`application/json`)
-        .map(data => codec.decode(data).fold(throw _, identity))
-    Directives.entity[A](implicitly)
+        .map(data => codec.decode(data))
+    Directives.entity[Validated[A]](implicitly).flatMap {
+      case Valid(a)     => Directives.provide(a)
+      case inv: Invalid => handleClientErrors(inv)
+    }
   }
 
   def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] =

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
@@ -1,12 +1,15 @@
 package endpoints.akkahttp.server
 
-import akka.http.scaladsl.model.HttpResponse
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 
 import scala.collection.compat._
 import scala.language.higherKinds
 import akka.http.scaladsl.server._
 import endpoints.algebra.Documentation
-import endpoints.{PartialInvariantFunctor, Tupler, algebra}
+import endpoints.{Invalid, PartialInvariantFunctor, Tupler, Valid, Validated, algebra}
 
 import scala.collection.mutable
 
@@ -17,39 +20,45 @@ import scala.collection.mutable
   */
 trait Urls extends algebra.Urls with StatusCodes {
 
-  import akka.http.scaladsl.server.Directives._
-
-  class Path[T](val pathPrefix: Directive1[T]) extends Url[T](
-    // Make sure that `this` path is an URL that has no remaining path segments
-    joinDirectives(pathPrefix, Directives.pathEndOrSingleSlash.tmap(Tuple1(_)))
-  )
-
-  implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] =
-      new Path(fa.pathPrefix.flatMap { a =>
-        f(a) match {
-          case Some(b) => Directives.provide(b)
-          case None    => malformedRequest
-        }
-      })
-    override def xmap[A, B](fa: Path[A], f: A => B, g: B => A): Path[B] =
-      new Path(fa.directive.map(f))
+  trait Path[A] extends Url[A] {
+    def validate(segments: List[String]): Option[(Validated[A], List[String])]
+    final def validateUrl(path: List[String], query: Map[String, List[String]]): Option[Validated[A]] =
+      validate(path).flatMap {
+        case (validA, Nil) => Some(validA)
+        case (_, _)        => None
+      }
   }
 
-  class Url[T](val directive: Directive1[T])
+  implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] =
+      segments => fa.validate(segments).map { case (validA, ss) => (validA.flatMap(f), ss) }
+    override def xmap[A, B](fa: Path[A], f: A => B, g: B => A): Path[B] =
+      segments => fa.validate(segments).map { case (validA, ss) => (validA.map(f), ss) }
+  }
 
-  class QueryString[T](val directive: Directive1[T])
+  trait Url[A] {
+    def validateUrl(segments: List[String], query: Map[String, List[String]]): Option[Validated[A]]
+
+    final def directive: Directive1[A] = {
+      (Directives.path(Directives.Segments) & Directives.parameterMultiMap).tflatMap { case (segments, query) =>
+        validateUrl(segments, query) match {
+          case None               => Directives.reject
+          case Some(inv: Invalid) => handleClientErrors(inv)
+          case Some(Valid(a))     => Directives.provide(a)
+        }
+      }
+    }
+  }
+
+  trait QueryString[T] {
+    def validate(params: Map[String, List[String]]): Validated[T]
+  }
 
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] =
-      new QueryString(fa.directive.flatMap { a =>
-        f(a) match {
-          case Some(b) => Directives.provide(b)
-          case None    => malformedRequest
-        }
-      })
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] =
+      params => fa.validate(params).flatMap(f)
     override def xmap[A, B](fa: QueryString[A], f: A => B, g: B => A): QueryString[B] =
-      new QueryString(fa.directive.map(f))
+      params => fa.validate(params).map(f)
   }
 
   /**
@@ -58,28 +67,31 @@ trait Urls extends algebra.Urls with StatusCodes {
     * Given a parameter name and a query string content, returns a decoded parameter
     * value of type `T`, or `None` if decoding failed
     */
-  type QueryStringParam[T] = (String, Map[String, Seq[String]]) => Option[T]
+  type QueryStringParam[T] = (String, Map[String, Seq[String]]) => Validated[T]
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Option[B], g: B => A): QueryStringParam[B] =
+    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Validated[B], g: B => A): QueryStringParam[B] =
       (name, qs) => fa(name, qs).flatMap(f)
     override def xmap[A, B](fa: QueryStringParam[A], f: A => B, g: B => A): QueryStringParam[B] =
       (name, qs) => fa(name, qs).map(f)
   }
-  def refineQueryStringParam[A, B](pa: QueryStringParam[A])(f: A => Option[B])(g: B => A): QueryStringParam[B] =
-    (name, map) => pa(name, map).flatMap(f)
 
-  type Segment[T] = PathMatcher1[T]
-
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] =
-      fa.tflatMap[Tuple1[B]]((a: Tuple1[A]) => f(a._1).map(Tuple1.apply))
-    override def xmap[A, B](fa: Segment[A], f: A => B, g: B => A): Segment[B] =
-      fa.map(f)
+  trait Segment[A] {
+    def validate(s: String): Validated[A]
   }
 
-  def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] = {
-    new Url(joinDirectives(path.directive, qs.directive))
+  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] =
+      s => fa.validate(s).flatMap(f)
+    override def xmap[A, B](fa: Segment[A], f: A => B, g: B => A): Segment[B] =
+      s => fa.validate(s).map(f)
+  }
+
+  def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] = { (segments: List[String], query: Map[String, List[String]]) =>
+    path.validate(segments).flatMap {
+      case (validA, Nil) => Some(validA.tuple(qs.validate(query)))
+      case (_, _)        => None
+    }
   }
 
   //***************
@@ -87,88 +99,89 @@ trait Urls extends algebra.Urls with StatusCodes {
   //***************
 
   implicit lazy val stringQueryString: QueryStringParam[String] =
-    (name, map) => map.get(name).flatMap(vs => vs.headOption)
+    (name, map) => {
+      val maybeValue = map.get(name).flatMap(_.headOption)
+      Validated.fromOption(maybeValue)("Missing value")
+    }
 
-  def qs[A](name: String, docs: Documentation)(implicit param: QueryStringParam[A]): QueryString[A] =
-    new QueryString[A](Directives.parameterMultiMap.flatMap { kvs =>
-      param(name, kvs) match {
-        case Some(a) => Directives.provide(a)
-        case None    => malformedRequest
-      }
-    })
+  def qs[A](name: String, docs: Documentation)(implicit param: QueryStringParam[A]): QueryString[A] = { kvs =>
+    param(name, kvs).mapErrors(_.map(error => s"$error for query parameter '$name'"))
+  }
 
   implicit def optionalQueryStringParam[A](implicit param: QueryStringParam[A]): QueryStringParam[Option[A]] =
     (name, qs) =>
       qs.get(name) match {
-        case None    => Some(None)
+        case None => Valid(None)
         case Some(_) => param(name, qs).map(Some(_))
       }
 
   implicit def repeatedQueryStringParam[A, CC[X] <: Iterable[X]](implicit param: QueryStringParam[A], factory: Factory[A, CC[A]]): QueryStringParam[CC[A]] =
     (name, qs) =>
       qs.get(name) match {
-        case None     => Some(factory.newBuilder.result())
+        case None => Valid(factory.newBuilder.result())
         case Some(vs) =>
-          vs.foldLeft[Option[mutable.Builder[A, CC[A]]]](Some(factory.newBuilder)) {
-            case (None, _) => None
-            case (Some(b), v) =>
+          vs.foldLeft[Validated[mutable.Builder[A, CC[A]]]](Valid(factory.newBuilder)) {
+            case (inv: Invalid, v) =>
+              // Pretend that this was the query string and delegate to the `A` query string param
+              param(name, Map(name -> (v :: Nil)))
+                .fold(_ => inv, errors => Invalid(inv.errors ++ errors))
+            case (Valid(b), v) =>
               // Pretend that this was the query string and delegate to the `A` query string param
               param(name, Map(name -> (v :: Nil))).map(b += _)
           }.map(_.result())
       }
 
-  def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] = {
-    new QueryString(joinDirectives(first.directive, second.directive))
+  def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] = { (params: Map[String, List[String]]) =>
+    first.validate(params).tuple(second.validate(params))
   }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] =
-      new Url(fa.directive.flatMap { a =>
-        f(a) match {
-          case Some(b) => Directives.provide(b)
-          case None    => malformedRequest
-        }
-      })
-    override def xmap[A, B](fa: Url[A], f: A => B, g: B => A): Url[B] =
-      new Url(fa.directive.map(f))
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = { (segments: List[String], query: Map[String, List[String]]) =>
+      fa.validateUrl(segments, query).map(_.flatMap(f))
+    }
+    override def xmap[A, B](fa: Url[A], f: A => B, g: B => A): Url[B] = { (segments: List[String], query: Map[String, List[String]]) =>
+      fa.validateUrl(segments, query).map(_.map(f))
+    }
   }
 
   // ********
   // Paths
   // ********
 
-  implicit def stringSegment: Segment[String] = Segment
+  implicit def stringSegment: Segment[String] = Valid(_)
 
   def segment[A](name: String, docs: Documentation)(implicit s: Segment[A]): Path[A] = {
-    // If there is no segment, the path must not match
-    // for instance, given the `path / foo / segment[Int]` definition,
-    // an incoming request `"/foo"` or `"/foo/"` does not match,
-    // whereas `"/foo/42"` matches and succeeds, and `"/foo/bar"` matches and fails.
-    val directive: Directive1[A] =
-      Directives.extract { ctx =>
-        (Slash.? ~ PathEnd).apply(ctx.unmatchedPath)
-      }.flatMap {
-        case _: PathMatcher.Matched[_] => Directives.reject
-        case PathMatcher.Unmatched => Directives.pathPrefix(s) | malformedRequest
+    case head :: tail =>
+      val validatedA =
+        s.validate(head)
+          .mapErrors(_.map(error => s"$error for segment${ if (name.isEmpty) "" else s" '$name'" }"))
+      Some((validatedA, tail))
+    case Nil => None
+  }
+
+  def remainingSegments(name: String, docs: Documentation): Path[String] = { segments =>
+    if (segments.isEmpty) None
+    else Some((Valid(segments.map(URLEncoder.encode(_, UTF_8.name())).mkString("/")), Nil))
+  }
+
+  def staticPathSegment(segment: String): Path[Unit] = { segments =>
+    if (segment.isEmpty) Some((Valid(()), segments))
+    else {
+      segments match {
+        case `segment` :: tail => Some((Valid(()), tail))
+        case _ => None
       }
-    new Path(directive)
+    }
   }
 
-  def remainingSegments(name: String, docs: Documentation): Path[String] =
-    new Path(Directives.path(PathMatchers.Remaining))
-
-  def staticPathSegment(segment: String): Path[Unit] = {
-    val directive = if(segment.isEmpty) // We cannot use Directives.pathPrefix("") because it consumes also a leading slash
-      Directives.pass
-    else
-      Directives.pathPrefix(segment)
-    new Path(convToDirective1(directive))
-  }
-
-  def chainPaths[A, B](first: Path[A], second: Path[B])(implicit tupler: Tupler[A, B]): Path[tupler.Out] = {
-    new Path(joinDirectives(first.pathPrefix, second.pathPrefix))
-  }
-
+  def chainPaths[A, B](first: Path[A], second: Path[B])(implicit tupler: Tupler[A, B]): Path[tupler.Out] =
+    (p1: List[String]) => {
+      first.validate(p1).flatMap { case (validA, p2) =>
+        second.validate(p2).map { case (validB, p3) =>
+          (validA.tuple(validB), p3)
+        }
+      }
+    }
 
   /**
     * Simpler alternative to [[Directive.&()]] method
@@ -183,12 +196,22 @@ trait Urls extends algebra.Urls with StatusCodes {
     directive.tmap(_ => Tuple1(()))
   }
 
-  implicit class Directive0Ops(val dir0: Directive0) {
-    def dir1: Directive1[Unit] = convToDirective1(dir0)
-  }
-
-  // TODO Improve error reporting
-  private def malformedRequest: StandardRoute =
-    Directives.complete(HttpResponse(BadRequest))
+  /**
+    * This method is called by ''endpoints'' when decoding a request failed.
+    *
+    * The default implementation is to return a route that completes with a
+    * Bad Request (400) response containing the error messages as a JSON array
+    * of string values.
+    *
+    * This method can be overridden to customize the error reporting logic.
+    */
+  def handleClientErrors(invalid: Invalid): StandardRoute =
+    Directives.complete(HttpResponse(
+      BadRequest,
+      entity = HttpEntity(
+        ContentTypes.`application/json`,
+        s"[${invalid.errors.map(error => s""""${error.replaceAllLiterally("\\", "\\\\").replaceAllLiterally("\"", "\\\"")}"""").mkString(",")}]"
+      )
+    ))
 
 }

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
@@ -1,11 +1,13 @@
 package endpoints.akkahttp.server
 
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, Forbidden, InternalServerError, OK, Unauthorized}
+import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import endpoints.algebra
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.language.reflectiveCalls
+import scala.concurrent.Future
 
 /* defines the common api to implement */
 trait EndpointsTestApi extends Endpoints
@@ -17,29 +19,99 @@ trait EndpointsTestApi extends Endpoints
 class EndpointsEntitiesTestApi extends EndpointsTestApi
   with JsonEntities
 
-//TODO use EndpointsApi from algebra tests
 class EndpointsTest extends WordSpec with Matchers with ScalatestRouteTest {
 
-  val testRoutes = new Endpoints {
+  object TestRoutes extends EndpointsEntitiesTestApi {
+
     val singleStaticGetSegment = endpoint[Unit, Unit](
       get(path / "segment1"),
       (_: Unit) => complete("Ok")
     ).implementedBy(_ => ())
+
+    val protectedEndpointRoute =
+      protectedEndpoint.implementedBy(credentials => if (credentials.username == "admin") Some("Hello!") else None)
+
+    val protectedEndpointWithParameterRoute =
+      protectedEndpointWithParameter.implementedBy { case (id, credentials) =>
+        if (credentials.username == "admin") Some(s"Requested user $id") else None
+      }
+
+    val smokeEndpointSyncRoute =
+      smokeEndpoint.implementedBy(_ => sys.error("Sorry."))
+
+    val smokeEndpointAsyncRoute =
+      smokeEndpoint.implementedByAsync(_ => Future.failed(new Exception("Sorry.")))
+
   }
 
   "Single segment route" should {
 
     "match single segment request" in {
       // tests:
-      Get("/segment1") ~> testRoutes.singleStaticGetSegment ~> check {
+      Get("/segment1") ~> TestRoutes.singleStaticGetSegment ~> check {
         responseAs[String] shouldEqual "Ok"
       }
     }
     "leave GET requests to other paths unhandled" in {
-      Get("/segment1/segment2") ~> testRoutes.singleStaticGetSegment ~> check {
+      Get("/segment1/segment2") ~> TestRoutes.singleStaticGetSegment ~> check {
         handled shouldBe false
       }
     }
 
   }
+
+  "Authenticated routes" should {
+
+    "reject unauthenticated requests" in {
+      Get("/users") ~> TestRoutes.protectedEndpointRoute ~> check {
+        handled shouldBe true
+        status shouldBe Unauthorized
+        header("www-authenticate").map(_.value()) shouldBe Some("Basic realm=\"Realm\",charset=UTF-8")
+        responseAs[String] shouldBe ""
+      }
+    }
+
+    "accept authenticated requests" in {
+      Get("/users").withHeaders(Authorization(BasicHttpCredentials("admin", "foo"))) ~> TestRoutes.protectedEndpointRoute ~> check {
+        handled shouldBe true
+        status shouldBe OK
+        responseAs[String] shouldBe "Hello!"
+      }
+    }
+
+    "forbid authenticated requests with insufficient rights" in {
+      Get("/users").withHeaders(Authorization(BasicHttpCredentials("alice", "foo"))) ~> TestRoutes.protectedEndpointRoute ~> check {
+        handled shouldBe true
+        status shouldBe Forbidden
+        responseAs[String] shouldBe ""
+      }
+    }
+
+    "reject unauthenticated requests with invalid parameters before handling authorization" in {
+      Get("/users/foo") ~> TestRoutes.protectedEndpointWithParameterRoute ~> check {
+        handled shouldBe true
+        status shouldBe BadRequest
+        responseAs[String] shouldBe "[\"Invalid integer value 'foo' for segment 'id'\"]"
+      }
+    }
+
+  }
+
+  "Routes" should {
+
+    "Handle exceptions by default" in {
+      Get("/user/foo/description?name=a&age=1") ~> TestRoutes.smokeEndpointSyncRoute ~> check {
+        handled shouldBe true
+        status shouldBe InternalServerError
+        responseAs[String] shouldBe "[\"Sorry.\"]"
+      }
+      Get("/user/foo/description?name=a&age=1") ~> TestRoutes.smokeEndpointAsyncRoute ~> check {
+        handled shouldBe true
+        status shouldBe InternalServerError
+        responseAs[String] shouldBe "[\"Sorry.\"]"
+      }
+    }
+
+  }
+
 }

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterBaseTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterBaseTest.scala
@@ -36,7 +36,7 @@ class ServerInterpreterBaseTest(val serverApi: EndpointsTestApi)
     import java.io._
 
     val directive =
-      url.directive.map(a => DecodedUrl.Matched(a)) |[Tuple1[DecodedUrl[A]]] Directives.extract(_ => DecodedUrl.NotMatched)
+      url.directive.map(a => DecodedUrl.Matched(a)) |[Tuple1[DecodedUrl[A]]] Directives.provide(DecodedUrl.NotMatched)
     val route = directive { decodedA => req =>
       val baos = new ByteArrayOutputStream
       val oos = new ObjectOutputStream(baos)
@@ -52,7 +52,9 @@ class ServerInterpreterBaseTest(val serverApi: EndpointsTestApi)
     val request = HttpRequest(uri = Uri(rawValue))
     request ~> route ~> check {
       if (status == StatusCodes.BadRequest) {
-        DecodedUrl.Malformed
+        val s = responseAs[String]
+        val errors = s.drop(2).dropRight(2).split("\",\"")
+        DecodedUrl.Malformed(errors)
       } else {
         val bs = responseAs[Array[Byte]]
         val bais = new ByteArrayInputStream(bs)

--- a/algebras/algebra/src/main/scala/endpoints/InvariantFunctor.scala
+++ b/algebras/algebra/src/main/scala/endpoints/InvariantFunctor.scala
@@ -29,11 +29,11 @@ trait InvariantFunctorSyntax {
   }
 }
 
-/** Given a type constructor `F`, a partial function `A => Option[B]`
+/** Given a type constructor `F`, a partial function `A => Validated[B]`
   * and a total function `B => A`, turns an `F[A]` into an `F[B]`.
   *
   * A partial invariant functor is an invariant functor whose covariant
-  * transformation function is total (ie, `A => Some[B]`).
+  * transformation function is total (ie, `A => Valid[B]`).
   */
 trait PartialInvariantFunctor[F[_]] extends InvariantFunctor[F] {
   /**
@@ -44,8 +44,8 @@ trait PartialInvariantFunctor[F[_]] extends InvariantFunctor[F] {
     *
     * @see [[http://julienrf.github.io/endpoints/algebras/endpoints.html#transforming-and-refining-url-constituents Some examples]]
     */
-  def xmapPartial[A, B](fa: F[A], f: A => Option[B], g: B => A): F[B]
-  def xmap[A, B](fa: F[A], f: A => B, g: B => A): F[B] = xmapPartial[A, B](fa, a => Some(f(a)), g)
+  def xmapPartial[A, B](fa: F[A], f: A => Validated[B], g: B => A): F[B]
+  def xmap[A, B](fa: F[A], f: A => B, g: B => A): F[B] = xmapPartial[A, B](fa, a => Valid(f(a)), g)
 }
 
 trait PartialInvariantFunctorSyntax extends InvariantFunctorSyntax {
@@ -58,6 +58,6 @@ trait PartialInvariantFunctorSyntax extends InvariantFunctorSyntax {
       *
       * @see [[http://julienrf.github.io/endpoints/algebras/endpoints.html#transforming-and-refining-url-constituents Some examples]]
       */
-    def xmapPartial[B](f: A => Option[B])(g: B => A): F[B] = ev.xmapPartial(fa, f, g)
+    def xmapPartial[B](f: A => Validated[B])(g: B => A): F[B] = ev.xmapPartial(fa, f, g)
   }
 }

--- a/algebras/algebra/src/main/scala/endpoints/Validated.scala
+++ b/algebras/algebra/src/main/scala/endpoints/Validated.scala
@@ -1,0 +1,106 @@
+package endpoints
+
+/**
+  * A validated value of type `A` can either be `Valid` or `Invalid`
+  * @tparam A Type of the validated value
+  */
+sealed trait Validated[+A] {
+
+  /**
+    * Transforms this validated value into a value of type `B`
+    */
+  def fold[B](valid: A => B, invalid: Seq[String] => B): B = this match {
+    case Valid(value)    => valid(value)
+    case Invalid(errors) => invalid(errors)
+  }
+
+  /**
+    * Transforms a valid value of type `A` into a valid value of type `B`.
+    * An invalid value is returned as it is.
+    */
+  def map[B](f: A => B): Validated[B] = this match {
+    case Valid(value)     => Valid(f(value))
+    case invalid: Invalid => invalid
+  }
+
+  /**
+    * Transforms the error list of an invalid value.
+    * A valid value is returned as it is.
+    */
+  def mapErrors(f: Seq[String] => Seq[String]): Validated[A] = this match {
+    case valid: Valid[A] => valid
+    case Invalid(errors) => Invalid(f(errors))
+  }
+
+  /**
+    * Subsequently validates this valid value.
+    * An invalid value is returned as it is.
+    */
+  def flatMap[B](f: A => Validated[B]): Validated[B] = this match {
+    case Valid(value)     => f(value)
+    case invalid: Invalid => invalid
+  }
+
+  /**
+    * Tuples together two validated values
+    *
+    * @see [[tuple]]
+    */
+  def zip[B](that: Validated[B]): Validated[(A, B)] = this.tuple(that)
+
+  /**
+    * Tuples together two validated values and tries to return a flat tuple instead of nested tuples. Also strips
+    * out `Unit` values in the tuples.
+    *
+    * If `this` and `that` are both invalid values, this operation returns an `Invalid` value containing both
+    * `this` error messages and `that` error messages.
+    *
+    * @see [[Tupler]]
+    */
+  def tuple[A0 >: A, B](that: Validated[B])(implicit tupler: Tupler[A0, B]): Validated[tupler.Out] = (this, that) match {
+    case (Valid(a), Valid(b))             => Valid(tupler(a, b))
+    case (_: Valid[A], invalid: Invalid)  => invalid
+    case (invalid: Invalid, _: Valid[B])  => invalid
+    case (Invalid(errs1), Invalid(errs2)) => Invalid(errs1 ++ errs2)
+  }
+
+  /**
+    * Transforms this `Validated[A]` value into an `Either[Seq[String], A]` value.
+    */
+  def toEither: Either[Seq[String], A] = this match {
+    case Invalid(errors) => Left(errors)
+    case Valid(a)        => Right(a)
+  }
+
+}
+
+/** A valid value of type `A` */
+case class Valid[A](value: A) extends Validated[A]
+/** A list of validation errors */
+case class Invalid(errors: Seq[String]) extends Validated[Nothing]
+
+object Invalid {
+  /** An invalid value due to a single error */
+  def apply(error: String): Invalid = Invalid(error :: Nil)
+}
+
+object Validated {
+
+  /**
+    * Turns `None` into an invalid value, using the given `error` message.
+    * Turns a `Some[A]` value into a `Valid[A]` value.
+    */
+  def fromOption[A](maybeA: Option[A])(error: => String): Validated[A] = maybeA match {
+    case Some(value) => Valid(value)
+    case None        => Invalid(error)
+  }
+
+  /**
+    * Turns an `Either[Seq[String], A]` into a `Validated[A]`
+    */
+  def fromEither[A](either: Either[Seq[String], A]): Validated[A] = either match {
+    case Left(errors) => Invalid(errors)
+    case Right(a)     => Valid(a)
+  }
+
+}

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Codec.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Codec.scala
@@ -1,11 +1,27 @@
 package endpoints.algebra
 
+import endpoints.Validated
+
+/**
+  * A way to decode a `From` value into a `To` value.
+  */
 trait Decoder[-From, +To] {
-  def decode(from: From): Either[Exception, To] // TODO Make the error type more useful
+  /**
+    * @return The decoded `To` value, or the validation errors in case of failure.
+    */
+  def decode(from: From): Validated[To]
 }
 
+/**
+  * A way to encode a `From` value into a `To` value
+  */
 trait Encoder[-From, +To] {
   def encode(from: From): To
 }
 
+/**
+  * A way to encode and decode values
+  * @tparam E Type of encoded values
+  * @tparam D Type of decoded values
+  */
 trait Codec[E, D] extends Decoder[E, D] with Encoder[D, E]

--- a/algebras/algebra/src/test/scala/endpoints/algebra/BasicAuthTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/BasicAuthTestApi.scala
@@ -11,4 +11,10 @@ trait BasicAuthTestApi extends algebra.Endpoints with algebra.BasicAuthenticatio
     ok(textResponse)
   )
 
+  val protectedEndpointWithParameter = authenticatedEndpoint(
+    Get,
+    path / "users" / segment[Long]("id"),
+    ok(textResponse)
+  )
+
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
@@ -1,6 +1,6 @@
 package endpoints.algebra
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 trait EndpointsDocs extends Endpoints {
 
@@ -86,7 +86,13 @@ trait EndpointsDocs extends Endpoints {
 
   //#xmap-partial
   import java.time.LocalDate
+  import endpoints.{Invalid, Valid}
   implicit def localDateSegment(implicit string: Segment[String]): Segment[LocalDate] =
-    string.xmapPartial(s => Try(LocalDate.parse(s)).toOption)(_.toString)
+    string.xmapPartial { s =>
+      Try(LocalDate.parse(s)) match {
+        case Failure(_)    => Invalid(s"Invalid date value '$s'")
+        case Success(date) => Valid(date)
+      }
+    }(_.toString)
   //#xmap-partial
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala
@@ -1,28 +1,17 @@
 package endpoints.algebra
 
+import endpoints.Validated
+
 trait JsonEntitiesDocs extends JsonEntities {
+
+  type Error = String
 
   case class User(id: Long, name: String)
   case class CreateUser(name: String)
-  trait Error
-  sealed trait Validated[+A] extends Product with Serializable {
-    def toEither: Either[Seq[Error], A] = this match {
-      case Invalid(errors) => Left(errors)
-      case Valid(a)        => Right(a)
-    }
-  }
-  case class Valid[+A](a: A) extends Validated[A]
-  case class Invalid(errors: Seq[Error]) extends Validated[Nothing]
-  object Validated {
-    def fromEither[A](either: Either[Seq[Error], A]): Validated[A] = either match {
-      case Left(errors) => Invalid(errors)
-      case Right(a)     => Valid(a)
-    }
-  }
 
   implicit def createUserJsonRequest: JsonRequest[CreateUser]
   implicit def userJsonResponse: JsonResponse[User]
-  implicit def errorsJsonResponse: JsonResponse[Seq[Error]]
+  implicit def errorsJsonResponse: JsonResponse[Seq[String]]
 
   //#json-entities
   endpoint(

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
@@ -2,6 +2,8 @@ package endpoints.algebra.server
 
 import java.util.UUID
 
+import endpoints.{Invalid, Valid}
+
 trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBase[T] {
 
   def urlsTestSuite() = {
@@ -25,13 +27,17 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
         decodeUrl(path / s[Double]())      ("/42.0")      shouldEqual Matched(42.0)
         decodeUrl(path / s[Int]())         ("/")          shouldEqual NotMatched
         decodeUrl(path / s[Int]())         ("/42/bar")    shouldEqual NotMatched
-        decodeUrl(path / s[Int]())         ("/foo")       shouldEqual Malformed
+        decodeUrl(path / s[Int]())         ("/foo")       shouldEqual Malformed(Seq(
+          "Invalid integer value 'foo' for segment"
+        ))
         decodeUrl(path / s[String]())      ("/foo%20bar") shouldEqual Matched("foo bar")
         decodeUrl(path / s[String]())      ("/foo/bar")   shouldEqual NotMatched
         decodeUrl(path / s[Int]() / "baz") ("/42/baz")    shouldEqual Matched(42)
-        decodeUrl(path / s[Int]() / "baz") ("/foo/baz")   shouldEqual Malformed
+        decodeUrl(path / s[Int]() / "baz") ("/foo/baz")   shouldEqual Malformed(Seq(
+          "Invalid integer value 'foo' for segment"
+        ))
         decodeUrl(path / s[Int]() / "baz") ("/42")        shouldEqual NotMatched
-//        decodeUrl(path / s[Int]() / "baz") ("/foo")       shouldEqual NotMatched
+        decodeUrl(path / s[Int]() / "baz") ("/foo")       shouldEqual NotMatched
         decodeUrl(path / "foo" / remainingSegments()) ("/foo/bar%2Fbaz/quux") shouldEqual Matched("bar%2Fbaz/quux")
         decodeUrl(path / "foo" / remainingSegments()) ("/foo")                shouldEqual NotMatched
       }
@@ -39,13 +45,15 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
       "transformed" in {
         val itemId = s[String]("itemId").xmapPartial { rawId =>
           val sep = rawId.indexOf("-")
-          if (sep == -1) None else {
+          if (sep == -1) Invalid(s"Invalid item id value '$rawId' for segment 'itemId'") else {
             val (id, name) = rawId.splitAt(sep)
-            Some(Item(name.drop(1), id))
+            Valid(Item(name.drop(1), id))
           }
         }(item => s"${item.id}-${item.name}")
         decodeUrl(path / itemId)("/42-programming-in-scala") shouldEqual Matched(Item("programming-in-scala", "42"))
-        decodeUrl(path / itemId)("/foo")                     shouldEqual Malformed
+        decodeUrl(path / itemId)("/foo")                     shouldEqual Malformed(Seq(
+          "Invalid item id value 'foo' for segment 'itemId'"
+        ))
 
         val file = s[String]("file").xmap(new java.io.File(_))(_.getPath)
         decodeUrl(path / "assets" / file)("/assets/favicon.png") shouldEqual Matched(new java.io.File("favicon.png"))
@@ -61,22 +69,34 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
         decodeUrl(path / "foo" /? qs[String]("s"))  ("/foo?s=bar")   shouldEqual Matched("bar")
         decodeUrl(path / "foo" /? qs[Boolean]("b")) ("/foo?b=true")  shouldEqual Matched(true)
         decodeUrl(path / "foo" /? qs[Boolean]("b")) ("/foo?b=false") shouldEqual Matched(false)
-        decodeUrl(path / "foo" /? qs[Int]("n"))     ("/foo")         shouldEqual Malformed
-        decodeUrl(path / "foo" /? qs[Int]("n"))     ("/foo?n=bar")   shouldEqual Malformed
+        decodeUrl(path / "foo" /? qs[Int]("n"))     ("/foo")         shouldEqual Malformed(Seq(
+          "Missing value for query parameter 'n'"
+        ))
+        decodeUrl(path / "foo" /? qs[Int]("n"))     ("/foo?n=bar")   shouldEqual Malformed(Seq(
+          "Invalid integer value 'bar' for query parameter 'n'"
+        ))
       }
 
       "optional" in {
         val url = path /? qs[Option[Int]]("n")
         decodeUrl(url)("/")       shouldEqual Matched(None)
         decodeUrl(url)("/?n=42")  shouldEqual Matched(Some(42))
-        decodeUrl(url)("/?n=bar") shouldEqual Malformed
+        decodeUrl(url)("/?n=bar") shouldEqual Malformed(Seq(
+          "Invalid integer value 'bar' for query parameter 'n'"
+        ))
       }
 
       "list" in {
         val url = path /? qs[List[Int]]("xs")
         decodeUrl(url)("/")             shouldEqual Matched(Nil)
         decodeUrl(url)("/?xs=1&xs=2")   shouldEqual Matched(1 :: 2 :: Nil)
-        decodeUrl(url)("/?xs=1&xs=two") shouldEqual Malformed
+        decodeUrl(url)("/?xs=1&xs=two") shouldEqual Malformed(Seq(
+          "Invalid integer value 'two' for query parameter 'xs'"
+        ))
+        decodeUrl(url)("/?xs=one&xs=two") shouldEqual Malformed(Seq(
+          "Invalid integer value 'one' for query parameter 'xs'",
+          "Invalid integer value 'two' for query parameter 'xs'"
+        ))
       }
 
       "transformed" in {
@@ -84,7 +104,9 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
           intQueryString.xmap(Page)(_.number)
         val url = path /? qs[Page]("page")
         decodeUrl(url)("/?page=42")  shouldEqual Matched(Page(42))
-        decodeUrl(url)("/?page=foo") shouldEqual Malformed
+        decodeUrl(url)("/?page=foo") shouldEqual Malformed(Seq(
+          "Invalid integer value 'foo' for query parameter 'page'"
+        ))
       }
 
     }
@@ -95,8 +117,14 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
         val paginatedUrl =
           (path /? (qs[Int]("from") & qs[Int]("limit")))
             .xmap(Page2.tupled)(p => (p.from, p.limit))
-        decodeUrl(paginatedUrl)("/?from=1&limit=10")   shouldEqual Matched(Page2(1, 10))
-        decodeUrl(paginatedUrl)("/?from=one&limit=10") shouldEqual Malformed
+        decodeUrl(paginatedUrl)("/?from=1&limit=10")    shouldEqual Matched(Page2(1, 10))
+        decodeUrl(paginatedUrl)("/?from=one&limit=10")  shouldEqual Malformed(Seq(
+          "Invalid integer value 'one' for query parameter 'from'"
+        ))
+        decodeUrl(paginatedUrl)("/?from=one&limit=ten") shouldEqual Malformed(Seq(
+          "Invalid integer value 'one' for query parameter 'from'",
+          "Invalid integer value 'ten' for query parameter 'limit'"
+        ))
       }
 
     }
@@ -105,7 +133,6 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
 
       "xmap urls of locations" in {
         
-
         val locationQueryString =
           (qs[Double]("lon") & qs[Double]("lat"))
             .xmap[Location] {
@@ -121,18 +148,27 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
         decodeUrl(locationUrl)("/?lon=12&lat=32") shouldEqual Matched(Location(12, 32))
         decodeUrl(locationUrl)("/?lat=32.0&lon=12.0") shouldEqual Matched(Location(12.0, 32.0))
 
-        decodeUrl(locationUrl)("/?lon=12,0&lat=32.0") shouldEqual Malformed
-        decodeUrl(locationUrl)("/?lon=a&lat=32") shouldEqual Malformed
-        decodeUrl(locationUrl)("/?let=12.0&lat=32.0") shouldEqual Malformed
-        decodeUrl(locationUrl)("/?lon=12.0") shouldEqual Malformed
+        decodeUrl(locationUrl)("/?lon=12,0&lat=32.0") shouldEqual Malformed(Seq(
+          "Invalid number value '12,0' for query parameter 'lon'"
+        ))
+        decodeUrl(locationUrl)("/?lon=a&lat=32") shouldEqual Malformed(Seq(
+          "Invalid number value 'a' for query parameter 'lon'"
+        ))
+        decodeUrl(locationUrl)("/?let=12.0&lat=32.0") shouldEqual Malformed(Seq(
+          "Missing value for query parameter 'lon'"
+        ))
+        decodeUrl(locationUrl)("/?lon=12.0") shouldEqual Malformed(Seq(
+          "Missing value for query parameter 'lat'"
+        ))
       }
 
       "xmapPartial urls of blogids" in {
         val blogIdQueryString: QueryString[BlogId] =
           (qs[Option[UUID]]("uuid") & qs[Option[String]]("slug"))
-            .xmapPartial {
-              case (maybeUuid, maybeSlug) =>
-                maybeUuid.map[BlogId](BlogUuid).orElse(maybeSlug.map[BlogId](BlogSlug))
+            .xmapPartial[BlogId] {
+              case (Some(uuid), _)    => Valid(BlogUuid(uuid))
+              case (None, Some(slug)) => Valid(BlogSlug(slug))
+              case (None, None)       => Invalid("Missing either query parameter 'uuid' or 'slug'")
             } {
               case BlogUuid(uuid) => (Some(uuid), None)
               case BlogSlug(slug) => (None, Some(slug))
@@ -149,10 +185,26 @@ trait EndpointsTestSuite[T <: endpoints.algebra.Endpoints] extends ServerTestBas
         decodeUrl(path /? blogIdQueryString)(s"/?slug=$testSlug&uuid=$testUUID") shouldEqual Matched(BlogUuid(testUUID))
         decodeUrl(path /? blogIdQueryString)(s"/?slug=") shouldEqual Matched(BlogSlug(""))
 
-        decodeUrl(path /? blogIdQueryString)(s"/?uuid=$testMalformedUUID1") shouldEqual Malformed
-        decodeUrl(path /? blogIdQueryString)(s"/?uuid=$testMalformedUUID2") shouldEqual Malformed
+        decodeUrl(path /? blogIdQueryString)(s"/?uuid=$testMalformedUUID1") shouldEqual Malformed(Seq(
+          s"Invalid UUID value '$testMalformedUUID1' for query parameter 'uuid'"
+        ))
+        decodeUrl(path /? blogIdQueryString)(s"/?uuid=$testMalformedUUID2") shouldEqual Malformed(Seq(
+          s"Invalid UUID value '$testMalformedUUID2' for query parameter 'uuid'"
+        ))
+        decodeUrl(path /? blogIdQueryString)(s"/") shouldEqual Malformed(Seq(
+          "Missing either query parameter 'uuid' or 'slug'"
+        ))
       }
 
+    }
+
+    "multiple errors" should {
+      "be accumulated" in {
+        decodeUrl(path / s[Int]() /? qs[Int]("x"))("/foo?x=bar") shouldEqual Malformed(Seq(
+          "Invalid integer value 'foo' for segment",
+          "Invalid integer value 'bar' for query parameter 'x'"
+        ))
+      }
     }
 
   }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/ServerTestBase.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/ServerTestBase.scala
@@ -33,9 +33,9 @@ trait ServerTestBase[T <: algebra.Endpoints] extends WordSpec
 sealed trait DecodedUrl[+A] extends Serializable
 object DecodedUrl {
   /** The URL candidate matched the given URL definition, and a `A` value was extracted from it */
-  case class  Matched[+A](value: A) extends DecodedUrl[A]
+  case class  Matched[+A](value: A)         extends DecodedUrl[A]
   /** The URL candidate didn’t match the given URL definition */
-  case object NotMatched            extends DecodedUrl[Nothing]
+  case object NotMatched                    extends DecodedUrl[Nothing]
   /** The URL candidate matched the given URL definition, but the decoding process failed */
-  case object Malformed             extends DecodedUrl[Nothing]
+  case class Malformed(errors: Seq[String]) extends DecodedUrl[Nothing]
 }

--- a/documentation/manual/src/doc/algebras/endpoints.md
+++ b/documentation/manual/src/doc/algebras/endpoints.md
@@ -95,8 +95,9 @@ the carried type. As an example, here is how you can define a `Segment[LocalDate
 ~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala#xmap-partial
 ~~~
 
-The first function passed to the `xmapPartial` operation returns an `Option[LocalDate]`. Returning `None` means
-that there is no representation of the source type in the target type.
+The first function passed to the `xmapPartial` operation returns a
+[`Validated[LocalDate]`](unchecked:/api/endpoints/Validated.html) value. Returning an
+`Invalid` value means that there is no representation of the source type in the target type.
 
 ## Response
 
@@ -156,7 +157,7 @@ and an OK response (with a valid user entity) as a `Right(user)` value.
 
 You can also transform the type produced by the alternative responses into
 a more convenient type to work with, by using the `xmap` operation. For instance,
-here is how to transform a `Response[Either[Seq[Error], User]]` into a
+here is how to transform a `Response[Either[Seq[String], User]]` into a
 `Response[Validated[User]]`:
 
 ~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala#response-xmap

--- a/documentation/manual/src/doc/guides/custom-authentication.md
+++ b/documentation/manual/src/doc/guides/custom-authentication.md
@@ -235,7 +235,7 @@ the token is not found or is invalid.
 ### Algebra
 
 To define protected endpoints, we need to enrich the `Authentication` algebra
-with additional vocabulary. First, we need a way to define that request headers
+with additional vocabulary. First, we need a way to define that requests that must
 contain the authentication token. Second, we need a way to define that responses
 might be `Unauthorized`. Last, we need a convenient `Endpoint` constructor that
 puts all the pieces together.
@@ -243,8 +243,9 @@ puts all the pieces together.
 ~~~ scala src=../../../../../documentation/examples/authentication/src/main/scala/authentication/Authentication.scala#protected-endpoints-algebra
 ~~~
 
-The `authenticationTokenRequestHeaders` method defines request headers containing the
-authentication token. The `wheneverAuthenticated` method transforms a given `Response[A]`
+The `authenticatedRequest` method defines a request expecting an authentication token
+to be provided in the `Authorization` header. The `wheneverAuthenticated` method transforms
+a given `Response[A]`
 into another `Response[A]` that can be an `Unauthorized` HTTP response in case the
 client was not authenticated. Note that, in contrast with the previously defined
 `wheneverValid` method, we return a `Response[A]` rather than a `Response[Option[A]]`.
@@ -252,8 +253,8 @@ This is because we assume that requests will be built by using the same algebra,
 which will make them correctly authenticated by construction.
 
 The last operation we have introduced is `authenticatedEndpoint`, which takes
-a request and a response and adds the `authenticationTokenRequestHeaders` to the
-request headers, and wraps the response into the `wheneverAuthenticated` combinator.
+a request and a response and wraps the request constituents into the `authenticatedRequest`
+constructor, and wraps the response into the `wheneverAuthenticated` combinator.
 
 This `authenticatedEndpoint` operation is final, and it is the only user-facing operation
 for defining protected endpoints (the two other operations are private). It guarantees
@@ -261,11 +262,11 @@ that the request will always have the authentication token in its headers, and t
 response can always be `Unauthorized`.
 
 > {.note}
-> The `authenticatedEndpoint` operation takes several type parameters.
+> The `authenticatedRequest` operation takes several type parameters.
 > In particular, they model the type of the request URL (`U`) and entity
 > (`E`). These types must be tracked by the type system so that, eventually,
 > an `Endpoint[Req, Resp]` is built, where the `Req` type is a tuple of
-> all the information (URL, entitiy and headers) carried by the request.
+> all the information (URL and entity) carried by the request.
 > In this example we enrich the request headers with the authentication
 > token. However, instead of simply returning nested tuples (e.g.
 > `((U, E), AuthenticationToken)`), we rely on implicit `Tupler` instances to

--- a/documentation/manual/src/doc/interpreters/akka-http.md
+++ b/documentation/manual/src/doc/interpreters/akka-http.md
@@ -47,3 +47,30 @@ It can be implemented as follows:
 
 ~~~ scala src=../../../../../akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsDocs.scala#implementation
 ~~~
+
+### Error handling
+
+When the server processes requests, three kinds of errors can happen: the incoming request doesn’t match
+any endpoint, the request does match an endpoint but is invalid (e.g. one parameter has a wrong type), or
+an exception is thrown.
+
+#### The incoming request doesn’t match any endpoint
+
+In that case, the routes constructed by *endpoints* can’t do anything. You have to deal with such
+errors in the usual Akka HTTP way: by using an implicit `akka.http.scaladsl.server.RejectionHandler`
+having a `handleNotFound` clause.
+
+#### The incoming request is invalid
+
+In that case, *endpoints* returns a “Bad Request” (400) response reporting all the errors in a
+JSON array. You can change this behavior by overriding the
+[handleClientErrors](unchecked:/api/endpoints/akkahttp/server/Urls.html#handleClientErrors(invalid:endpoints.Invalid):akka.http.scaladsl.server.StandardRoute)
+method.
+
+#### An exception is thrown
+
+If an exception is thrown during request decoding, or when running the business logic, or when
+encoding the response, *endpoints* returns an “Internal Server Error” (500) response reporting
+the error in a JSON array. You can change this behavior by overriding the
+[handleServerError](unchecked:/api/endpoints/akkahttp/server/Endpoints.html#handleServerError(throwable:Throwable):akka.http.scaladsl.server.StandardRoute)
+method.

--- a/documentation/manual/src/doc/interpreters/play.md
+++ b/documentation/manual/src/doc/interpreters/play.md
@@ -53,3 +53,29 @@ parameter. An HTTP server can then be started as in the following example:
 
 ~~~ scala src=../../../../../documentation/examples/quickstart/server/src/main/scala/quickstart/Main.scala#main-only
 ~~~
+
+### Error handling
+
+When the server processes requests, three kinds of errors can happen: the incoming request doesn’t match
+any endpoint, the request does match an endpoint but is invalid (e.g. one parameter has a wrong type), or
+an exception is thrown.
+
+#### The incoming request doesn’t match any endpoint
+
+In that case, the router constructed by *endpoints* can’t do anything. You have to deal with such
+errors in the usual Play way: by using a custom `play.api.http.HttpErrorHandler`.
+
+#### The incoming request is invalid
+
+In that case, *endpoints* returns a “Bad Request” (400) response reporting all the errors in a
+JSON array. You can change this behavior by overriding the
+[handleClientErrors](unchecked:/api/endpoints/play/server/Urls.html#handleClientErrors(invalid:endpoints.Invalid):play.api.mvc.Result)
+method.
+
+#### An exception is thrown
+
+If an exception is thrown during request decoding, or when running the business logic, or when
+encoding the response, *endpoints* returns an “Internal Server Error” (500) response reporting
+the error in a JSON array. You can change this behavior by overriding the
+[handleServerError](unchecked:/api/endpoints/play/server/Endpoints.html#handleServerError(throwable:Throwable):play.api.mvc.Result)
+method.

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -16,10 +16,20 @@ trait BasicAuthentication
     with Endpoints
     with StatusCodes {
 
-  private[endpoints] def basicAuthenticationHeader: RequestHeaders[Credentials] =
-    DocumentedHeaders(Nil) // supported by OAS3 security schemes
-
   def basicAuthenticationSchemeName: String = "HttpBasic"
+
+  private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Request[Out] =
+    request(method, url, entity, requestDocs, headers) // Documentation about authentication is done below by overriding authenticatedEndpoint
 
   override def authenticatedEndpoint[U, E, R, H, UE, HCred, Out](
     method: Method,

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
@@ -45,11 +45,11 @@ trait Urls extends algebra.Urls {
     DocumentedQueryStringParam(Schema.Array(param.schema, description = None), isRequired = false)
   
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] = fa
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] = fa
   }
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Option[B], g: B => A): QueryStringParam[B] = fa
+    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Validated[B], g: B => A): QueryStringParam[B] = fa
   }
 
   def stringQueryString: QueryStringParam[String] = DocumentedQueryStringParam(Schema.simpleString, isRequired = true)
@@ -67,7 +67,7 @@ trait Urls extends algebra.Urls {
   type Segment[A] = Schema
 
   implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] = fa
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] = fa
   }
 
   def stringSegment: Segment[String] = Schema.simpleString
@@ -83,7 +83,7 @@ trait Urls extends algebra.Urls {
   type Path[A] = DocumentedUrl
 
   implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] = fa
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] = fa
   }
 
   def staticPathSegment(segment: String): Path[Unit] = DocumentedUrl(Left(segment) :: Nil, Nil)
@@ -111,7 +111,7 @@ trait Urls extends algebra.Urls {
   type Url[A] = DocumentedUrl
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] = fa
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = fa
   }
 
 

--- a/play/build.sbt
+++ b/play/build.sbt
@@ -14,7 +14,9 @@ val `play-server` =
       name := "endpoints-play-server",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play-netty-server" % playVersion,
-        "com.typesafe.play" %% "play-test" % playVersion % Test
+        "com.typesafe.play" %% "play-test" % playVersion % Test,
+        "com.typesafe.play" %% "play-ahc-ws" % playVersion % Test,
+        "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0" % Test, // See https://github.com/playframework/play-ws/issues/371
       )
     )
     .dependsOn(`algebra-jvm` % "test->test;compile->compile")

--- a/play/client/src/main/scala/endpoints/play/client/JsonEntitiesFromCodec.scala
+++ b/play/client/src/main/scala/endpoints/play/client/JsonEntitiesFromCodec.scala
@@ -19,6 +19,6 @@ trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitie
   }
 
   def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] =
-    wsResp => codec.decode(wsResp.body)
+    wsResp => codec.decode(wsResp.body).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
 
 }

--- a/play/client/src/main/scala/endpoints/play/client/MuxEndpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/MuxEndpoints.scala
@@ -26,7 +26,8 @@ trait MuxEndpoints extends algebra.Endpoints { self: Endpoints =>
           response(wsResponse.status, wsResponse.headers)
             .toRight(new Throwable(s"Unexpected response status: ${wsResponse.status}")).right.flatMap { entity =>
               entity(wsResponse).right.flatMap { t =>
-                decoder.decode(t).asInstanceOf[Either[Throwable, req.Response]]
+                decoder.decode(t)
+                  .fold(resp => Right(resp.asInstanceOf[req.Response]), errors => Left(new Exception(errors.mkString(". "))))
               }
             }
         )

--- a/play/client/src/main/scala/endpoints/play/client/Urls.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Urls.scala
@@ -3,10 +3,10 @@ package endpoints.play.client
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-import endpoints.{PartialInvariantFunctor, Tupler, algebra}
+import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import endpoints.algebra.Documentation
-import scala.collection.compat.Factory
 
+import scala.collection.compat.Factory
 import scala.language.higherKinds
 
 /**
@@ -23,7 +23,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] = 
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] =
       (b: B) => fa.encodeQueryString(g(b))
   }
 
@@ -50,7 +50,7 @@ trait Urls extends algebra.Urls {
   type QueryStringParam[A] = A => List[String]
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: A => List[String], f: A => Option[B], g: B => A): B => List[String] =
+    def xmapPartial[A, B](fa: A => List[String], f: A => Validated[B], g: B => A): B => List[String] =
       (b: B) => fa(g(b))
   }
 
@@ -69,7 +69,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
   }
 
   implicit lazy val stringSegment: Segment[String] = (s: String) => URLEncoder.encode(s, utf8Name)
@@ -77,7 +77,7 @@ trait Urls extends algebra.Urls {
   trait Path[A] extends Url[A]
 
   implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
   }
 
   def staticPathSegment(segment: String): Path[Unit] = (_: Unit) => segment
@@ -108,7 +108,7 @@ trait Urls extends algebra.Urls {
     }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
   }
 
 }

--- a/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
+++ b/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
@@ -1,10 +1,11 @@
 package endpoints.play.server.playjson
 
-import endpoints.algebra
+import endpoints.{Invalid, algebra}
 import endpoints.play.server.Endpoints
 import play.api.http.Writeable
-import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.Results
+import play.api.libs.json.{JsPath, JsValue, Json, JsonValidationError}
+
+import scala.util.Try
 
 /**
   * Interpreter for [[algebra.JsonSchemaEntities]] that uses Play JSON [[play.api.libs.json.Reads]] to decode
@@ -16,8 +17,18 @@ trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with 
 
   def jsonRequest[A: JsonSchema]: RequestEntity[A] =
     playComponents.playBodyParsers.tolerantText.validate { text =>
-      Json.parse(text).validate(implicitly[JsonSchema[A]].reads).asEither
-        .left.map(ignoredError => Results.BadRequest)
+      Try(Json.parse(text)).toEither.left.map(_ => Invalid("Unable to parse entity as JSON"))
+        .right.flatMap { json =>
+          def showErrors(errors: collection.Seq[(JsPath, collection.Seq[JsonValidationError])]): Invalid =
+            Invalid((
+              for {
+                (path, pathErrors) <- errors.iterator
+                error <- pathErrors
+              } yield s"${error.message} for ${path.toJsonString}"
+            ).toSeq)
+          json.validate(implicitly[JsonSchema[A]].reads).asEither.left.map(showErrors)
+        }
+        .left.map(handleClientErrors)
     }
 
   def jsonResponse[A: JsonSchema]: ResponseEntity[A] =

--- a/play/server/src/main/scala/endpoints/play/server/Assets.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Assets.scala
@@ -2,7 +2,7 @@ package endpoints.play.server
 
 import akka.stream.scaladsl.{Source, StreamConverters}
 import akka.util.ByteString
-import endpoints.algebra
+import endpoints.{Invalid, Valid, algebra}
 import endpoints.algebra.Documentation
 import play.api.http.{ContentTypes, HttpEntity}
 import play.api.mvc.Results
@@ -100,8 +100,8 @@ trait Assets extends algebra.Assets with Endpoints {
             val i = s.lastIndexOf('-')
             if (i > 0) {
               val (name, digest) = s.splitAt(i)
-              Some(Right((AssetPath(p.reverse, digest.drop(1), name), Nil)))
-            } else Some(Left(Results.BadRequest))
+              Some((Valid(AssetPath(p.reverse, digest.drop(1), name)), Nil))
+            } else Some((Invalid("Invalid asset segments"), Nil))
           case Nil => None
         }
       def encode(s: AssetPath) =
@@ -110,7 +110,7 @@ trait Assets extends algebra.Assets with Endpoints {
   }
 
   private lazy val gzipSupport: RequestHeaders[Boolean] =
-    headers => Right(headers.get(HeaderNames.ACCEPT_ENCODING).exists(_.contains("gzip")))
+    headers => Valid(headers.get(HeaderNames.ACCEPT_ENCODING).exists(_.contains("gzip")))
 
   /**
     * An endpoint for serving assets.

--- a/play/server/src/main/scala/endpoints/play/server/BasicAuthentication.scala
+++ b/play/server/src/main/scala/endpoints/play/server/BasicAuthentication.scala
@@ -3,34 +3,64 @@ package endpoints.play.server
 import java.util.Base64
 
 import endpoints.algebra.BasicAuthentication.Credentials
-import endpoints.algebra
+import endpoints.algebra.Documentation
+import endpoints.{Tupler, Valid, algebra}
 import play.api.http.HeaderNames
 import play.api.http.HeaderNames.AUTHORIZATION
-import play.api.mvc.Results
+import play.api.libs.streams.Accumulator
+import play.api.mvc.{BodyParser, Results}
 
 /**
   * @group interpreters
   */
 trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
 
+  import playComponents.executionContext
+
   /**
     * Extracts the credentials from the request headers.
     * In case of absence of credentials, returns an `Unauthorized` result.
     */
-  private[endpoints] lazy val basicAuthenticationHeader: RequestHeaders[Credentials] =
+  private lazy val basicAuthenticationHeader: RequestHeaders[Option[Credentials]] =
     headers =>
-      headers.get(AUTHORIZATION)
-        .filter(h => h.startsWith("Basic ")) // FIXME case sensitivity?
-        .flatMap { h =>
-          val userPassword =
-            new String(Base64.getDecoder.decode(h.drop(6)))
-          val i = userPassword.indexOf(':')
-          if (i < 0) None
-          else {
-            val (user, password) = userPassword.splitAt(i)
-            Some(Credentials(user, password.drop(1)))
+      Valid(
+        headers.get(AUTHORIZATION)
+          .filter(h => h.startsWith("Basic ")) // FIXME case sensitivity?
+          .flatMap { h =>
+            val userPassword =
+              new String(Base64.getDecoder.decode(h.drop(6)))
+            val i = userPassword.indexOf(':')
+            if (i < 0) None
+            else {
+              val (user, password) = userPassword.splitAt(i)
+              Some(Credentials(user, password.drop(1)))
+            }
           }
-        }
-        .toRight(Results.Unauthorized.withHeaders(HeaderNames.WWW_AUTHENTICATE -> "Basic realm=\"Some custom name\"")) // TODO Make the realm extensible
+      )
+
+  def authenticatedRequest[U, E, H, UE, HC, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHC: Tupler.Aux[H, Credentials, HC],
+    tuplerUEHC: Tupler.Aux[UE, HC, Out]
+  ): Request[Out] = {
+    extractMethodUrlAndHeaders(method, url, headers ++ basicAuthenticationHeader)
+      .toRequest[Out] {
+        case (_, (_, None)) =>
+          BodyParser(_ => Accumulator.done(Left(Results.Unauthorized.withHeaders(HeaderNames.WWW_AUTHENTICATE -> "Basic realm=Realm"))))
+        case (u, (h, Some(credentials))) =>
+          entity.map(e => tuplerUEHC(tuplerUE(u, e), tuplerHC(h, credentials)))
+      } { out =>
+        val (ue, hc) = tuplerUEHC.unapply(out)
+        val (u, _) = tuplerUE.unapply(ue)
+        val (h, c) = tuplerHC.unapply(hc)
+        (u, (h, Some(c)))
+      }
+  }
 
 }

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -1,15 +1,17 @@
 package endpoints.play.server
 
 import endpoints.algebra.Documentation
-import endpoints.{Semigroupal, Tupler, algebra}
+import endpoints.{Invalid, Semigroupal, Tupler, Valid, Validated, algebra}
 import play.api.http.Writeable
 import play.api.libs.functional.InvariantFunctor
+import play.api.libs.json.Writes
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{Handler => PlayHandler, _}
 import play.twirl.api.Html
 
 import scala.concurrent.Future
 import scala.language.implicitConversions
+import scala.util.control.NonFatal
 
 /**
   * Interpreter for [[algebra.Endpoints]] that performs routing using Play framework.
@@ -55,32 +57,28 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
     * to early return an HTTP response if a header is wrong (e.g. if
     * an authentication information is missing)
     */
-  type RequestHeaders[A] = Headers => Either[Result, A]
+  type RequestHeaders[A] = Headers => Validated[A]
 
   /** Always succeeds in extracting no information from the headers */
-  lazy val emptyHeaders: RequestHeaders[Unit] = _ => Right(())
+  lazy val emptyHeaders: RequestHeaders[Unit] = _ => Valid(())
 
-  def header(name: String,docs: Option[String]): Headers => Either[Result,String] =
+  def header(name: String,docs: Option[String]): Headers => Validated[String] =
     headers => headers.get(name) match {
-      case Some(value) => Right(value)
-      case None => Left(Results.BadRequest) // TODO bad request or throw an exception ?
+      case Some(value) => Valid(value)
+      case None        => Invalid(s"Missing header $name")
     }
 
-  def optHeader(name: String,docs: Option[String]): Headers => Either[Result,Option[String]] =
-    headers => Right(headers.get(name))
+  def optHeader(name: String,docs: Option[String]): Headers => Validated[Option[String]] =
+    headers => Valid(headers.get(name))
 
   implicit lazy val reqHeadersInvFunctor: endpoints.InvariantFunctor[RequestHeaders] = new endpoints.InvariantFunctor[RequestHeaders] {
-    override def xmap[From, To](f: Headers => Either[Result, From], map: From => To, contramap: To => From): Headers => Either[Result, To] =
-      headers => f(headers).right.map(map)
+    def xmap[A, B](fa: RequestHeaders[A], f: A => B, g: B => A): RequestHeaders[B] =
+      headers => fa(headers).map(f)
   }
 
   implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] = new Semigroupal[RequestHeaders] {
-    override def product[A, B](fa: Headers => Either[Result, A], fb: Headers => Either[Result, B])(implicit tupler: Tupler[A, B]): Headers => Either[Result, tupler.Out] =
-      headers => {
-        val a = fa(headers)
-        val b = fb(headers)
-        a.right.flatMap(aV => b.right.map(bV => tupler.apply(aV, bV)))
-      }
+    def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(implicit tupler: Tupler[A, B]): RequestHeaders[tupler.Out] =
+      headers => fa(headers).tuple(fb(headers))
   }
 
   /**
@@ -120,13 +118,13 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
     /**
       * Attempts to extract an `A` from an incoming request.
       *
-      * Two kinds of failures can happen:
+      * Two kinds of situations can happen:
       * 1. The incoming request URL does not match `this` definition: nothing
       *    is extracted (the `RequestExtractor` returns `None`) ;
-      * 2. The incoming request URL matches `this` definition but the headers
-      *    are erroneous: the `RequestExtractor` returns a `Left(result)`.
+      * 2. The incoming request URL matches `this` definition but the headers or parameters
+      *    are erroneous: the `RequestExtractor` returns a `Some(Invalid(...))`.
       */
-    def decode: RequestExtractor[Either[Result, A]]
+    def decode: RequestExtractor[Validated[A]]
 
     /**
       * Reverse routing.
@@ -146,8 +144,8 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
         def decode: RequestExtractor[BodyParser[B]] =
           request =>
             parent.decode(request).map {
-              case Left(result) => BodyParser(_ => Accumulator.done(Left(result)))
-              case Right(a) => toB(a)
+              case inv: Invalid => BodyParser(_ => Accumulator.done(Left(handleClientErrors(inv))))
+              case Valid(a) => toB(a)
             }
         def encode(b: B): Call = parent.encode(toA(b))
       }
@@ -161,20 +159,16 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
   lazy val textRequest: BodyParser[String] = playComponents.playBodyParsers.text
 
   implicit def reqEntityInvFunctor: endpoints.InvariantFunctor[RequestEntity] = new endpoints.InvariantFunctor[RequestEntity] {
-    override def xmap[From, To](f: BodyParser[From], map: From => To, contramap: To => From): BodyParser[To] =
+    def xmap[From, To](f: BodyParser[From], map: From => To, contramap: To => From): BodyParser[To] =
       f.map(map)
   }
 
-
-  private def extractMethodUrlAndHeaders[A, B](method: Method, url: Url[A], headers: RequestHeaders[B]): UrlAndHeaders[(A, B)] =
+  protected def extractMethodUrlAndHeaders[A, B](method: Method, url: Url[A], headers: RequestHeaders[B]): UrlAndHeaders[(A, B)] =
     new UrlAndHeaders[(A, B)] {
-      val decode: RequestExtractor[Either[Result, (A, B)]] =
+      val decode: RequestExtractor[Validated[(A, B)]] =
         request => method.extract(request).flatMap { _ =>
-          url.decodeUrl(request).map { maybeA =>
-            for {
-              a <- maybeA.right
-              b <- headers(request.headers).right
-            } yield (a, b)
+          url.decodeUrl(request).map { validatedA =>
+            validatedA.zip(headers(request.headers))
           }
         }
       def encode(ab: (A, B)): Call = Call(method.value, url.encodeUrl(ab._1))
@@ -276,14 +270,28 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
       * the `endpoint` definition.
       */
     def playHandler(header: RequestHeader): Option[PlayHandler] =
-      endpoint.request.decode(header)
-        .map { bodyParser =>
-          playComponents.defaultActionBuilder.async(bodyParser) { request =>
-            service(request.body).map { b =>
-              endpoint.response(b)
+      try {
+        endpoint.request.decode(header)
+          .map { bodyParser =>
+            EssentialAction { headers =>
+              try {
+                val action =
+                  playComponents.defaultActionBuilder.async(bodyParser) { request =>
+                    service(request.body).map { b =>
+                      endpoint.response(b)
+                    }
+                  }
+                action(headers).recover {
+                  case NonFatal(t) => handleServerError(t)
+                }
+              } catch {
+                case NonFatal(t) => Accumulator.done(handleServerError(t))
+              }
             }
           }
-        }
+      } catch {
+        case NonFatal(t) => Some(playComponents.defaultActionBuilder(_ => handleServerError(t)))
+      }
   }
 
   def endpoint[A, B](
@@ -316,5 +324,27 @@ trait Endpoints extends algebra.Endpoints with Urls with Methods with StatusCode
 
   implicit def EmptyEndpointToPlayHandler[A, B](endpoint: Endpoint[A, B])(implicit ev: Unit =:= B): ToPlayHandler =
     endpoint.implementedBy(_ => ())
+
+  /**
+    * This method is called by ''endpoints'' when an exception is thrown during
+    * request processing.
+    *
+    * The default implementation is to return an Internal Server Error (500)
+    * response containing the error messages as a JSON array of string values.
+    *
+    * This method can be overridden to customize the error reporting logic.
+    */
+  def handleServerError(throwable: Throwable): Result =
+    InternalServerError(Endpoints.invalidJsonEncoder.writes(Invalid(throwable.getMessage())))
+
+}
+
+object Endpoints {
+
+  /**
+    * Encodes `Invalid` values as a JSON array of string values.
+    */
+  implicit val invalidJsonEncoder: Writes[Invalid] =
+    Writes.seq[String].contramap[Invalid](_.errors)
 
 }

--- a/play/server/src/main/scala/endpoints/play/server/JsonEntitiesFromCodec.scala
+++ b/play/server/src/main/scala/endpoints/play/server/JsonEntitiesFromCodec.scala
@@ -1,8 +1,8 @@
 package endpoints.play.server
 
+import endpoints.{Invalid, Valid}
 import endpoints.algebra.Codec
 import play.api.http.{ContentTypes, Writeable}
-import play.api.mvc.Results
 
 /**
   * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that decodes JSON requests
@@ -16,7 +16,10 @@ trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitie
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] =
     playComponents.playBodyParsers.tolerantText.validate { body =>
-      codec.decode(body).left.map(ignoredError => Results.BadRequest)
+      codec.decode(body) match {
+        case Valid(value) => Right(value)
+        case inv: Invalid => Left(handleClientErrors(inv))
+      }
     }
 
   def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = {

--- a/play/server/src/test/resources/logback.xml
+++ b/play/server/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+  -->
+<!-- The default logback configuration that Play uses in dev mode if no other configuration is provided -->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%logger{15} - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
@@ -1,35 +1,110 @@
 package endpoints.play.server
 
+import akka.actor.CoordinatedShutdown.UnknownReason
+import endpoints.{Invalid, Valid}
 import endpoints.algebra.server.{DecodedUrl, EndpointsTestSuite}
+import play.api.libs.ws.ahc.AhcWSComponents
+import play.api.libs.ws.{WSAuthScheme, WSResponse}
 import play.api.Mode
 import play.api.routing.Router
 import play.api.test.FakeRequest
+import play.api.test.Helpers._
 import play.core.server.{DefaultNettyServerComponents, ServerConfig}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
-class ServerInterpreterTest extends EndpointsTestSuite[Endpoints] with DefaultNettyServerComponents {
+class ServerInterpreterTest
+  extends EndpointsTestSuite[Endpoints]
+    with DefaultNettyServerComponents
+    with PlayComponents
+    with AhcWSComponents {
 
-  override lazy val serverConfig = ServerConfig(mode = Mode.Test)
-  lazy val router = Router.empty // We don’t use the server, we just want the BuiltInComponents to be wired for us
-  lazy val playComponents = PlayComponents.fromBuiltInComponents(this)
-  lazy val serverApi: Endpoints = new EndpointsTestApi(playComponents, Map.empty)
+  override lazy val serverConfig = ServerConfig(mode = Mode.Test, port = Some(testServerPort))
+  object serverApi extends EndpointsTestApi(this, Map.empty) {
+    val routes = routesFromEndpoints(
+      protectedEndpoint.implementedBy { credentials =>
+        if (credentials.username == "admin") Some("Hello!") else None
+      },
+      protectedEndpointWithParameter.implementedBy { case (id, credentials) =>
+        if (credentials.username == "admin") Some(s"Requested user $id") else None
+      },
+      smokeEndpoint.implementedBy(_ => sys.error("Sorry."))
+    )
+  }
+  lazy val router = Router.from(serverApi.routes)
+
+  // Make sure the server is started
+  server
 
   def decodeUrl[A](url: serverApi.Url[A])(rawValue: String): DecodedUrl[A] = {
     val request = FakeRequest("GET", rawValue)
     url.decodeUrl(request) match {
-      case None           => DecodedUrl.NotMatched
-      case Some(Left(_))  => DecodedUrl.Malformed
-      case Some(Right(a)) => DecodedUrl.Matched(a)
+      case None                  => DecodedUrl.NotMatched
+      case Some(Invalid(errors)) => DecodedUrl.Malformed(errors)
+      case Some(Valid(a))        => DecodedUrl.Matched(a)
     }
+  }
+
+  override protected def afterAll(): Unit = {
+    Await.ready(coordinatedShutdown.run(UnknownReason), 10.seconds)
+    super.afterAll()
   }
 
   urlsTestSuite()
 
-  override protected def afterAll(): Unit = {
-    Await.ready(actorSystem.terminate(), 10.seconds)
-    super.afterAll()
+  "Authenticated routes" should {
+
+    "reject unauthenticated requests" in {
+      val response: WSResponse =
+        await(wsClient.url(s"http://localhost:$testServerPort/users").get())
+      response.status shouldBe UNAUTHORIZED
+      response.headers.get("www-authenticate").flatMap(_.headOption) shouldBe Some("Basic realm=Realm")
+      response.body shouldBe ""
+    }
+
+    "accept authenticated requests" in {
+      val response: WSResponse =
+        await(
+          wsClient
+            .url(s"http://localhost:$testServerPort/users")
+            .withAuth("admin", "foo", WSAuthScheme.BASIC)
+            .get()
+        )
+      response.status shouldBe OK
+      response.body shouldBe "Hello!"
+    }
+
+    "forbid authenticated requests with insufficient rights" in {
+      val response: WSResponse =
+        await(
+          wsClient
+            .url(s"http://localhost:$testServerPort/users")
+            .withAuth("alice", "foo", WSAuthScheme.BASIC)
+            .get()
+        )
+      response.status shouldBe FORBIDDEN
+      response.body shouldBe ""
+    }
+
+    "reject unauthenticated requests with invalid parameters before handling authorization" in {
+      val response: WSResponse =
+        await(wsClient.url(s"http://localhost:$testServerPort/users/foo").get())
+      response.status shouldBe BAD_REQUEST
+      response.body shouldBe "[\"Invalid integer value 'foo' for segment 'id'\"]"
+    }
+
+  }
+
+  "Routes" should {
+
+    "Handle exceptions by default" in {
+      val response: WSResponse =
+        await(wsClient.url(s"http://localhost:$testServerPort/user/foo/description?name=a&age=1").get())
+      response.status shouldBe INTERNAL_SERVER_ERROR
+      response.body shouldBe "[\"Sorry.\"]"
+    }
+
   }
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
@@ -2,20 +2,32 @@ package endpoints.scalaj.client
 
 import java.util.Base64
 
-import endpoints.algebra
+import endpoints.{Tupler, algebra}
 import endpoints.algebra.BasicAuthentication.Credentials
+import endpoints.algebra.Documentation
 
 /**
   * @group interpreters
   */
 trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
 
-  /**
-    * Supplies the credential into the request headers
-    */
-  private[endpoints] lazy val basicAuthenticationHeader: RequestHeaders[Credentials] =
-    (credentials) => {
-      Seq(("Authorization", "Basic " + new String(Base64.getEncoder.encode((credentials.username + ":" + credentials.password).getBytes))))
-    }
+  private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Request[Out] = {
+    val basicAuthenticationHeader: RequestHeaders[Credentials] =
+      (credentials) => {
+        Seq(("Authorization", "Basic " + new String(Base64.getEncoder.encode((credentials.username + ":" + credentials.password).getBytes))))
+      }
+
+    request(method, url, entity, requestDocs, headers ++ basicAuthenticationHeader)
+  }
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
@@ -15,6 +15,6 @@ trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitie
   }
 
   def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] =
-    resp => codec.decode(resp)
+    resp => codec.decode(resp).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Urls.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Urls.scala
@@ -4,7 +4,7 @@ import java.net.URLEncoder
 
 import scala.collection.compat.Factory
 import scala.language.higherKinds
-import endpoints.{PartialInvariantFunctor, Tupler, algebra}
+import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import endpoints.algebra.Documentation
 import scalaj.http.{Http, HttpRequest}
 
@@ -24,17 +24,17 @@ trait Urls extends algebra.Urls {
   case class Path[A](toStr: A => String) extends Url(toStr.andThen(url => Http(protocol + address + "/" + url)))
 
   implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] = Path(fa.toStr compose g)
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] = Path(fa.toStr compose g)
   }
 
   class Url[A](val toReq: A => HttpRequest)
   
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] = fa compose g
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] = fa compose g
   }
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Option[B], g: B => A): QueryStringParam[B] = fa compose g
+    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Validated[B], g: B => A): QueryStringParam[B] = fa compose g
   }
 
    implicit def stringQueryString: QueryStringParam[String] = _ :: Nil
@@ -47,7 +47,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] = fa compose g
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] = fa compose g
   }
 
    implicit def stringSegment: Segment[String] = s => URLEncoder.encode(s, "utf8")
@@ -89,7 +89,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] = new Url((b: B) => fa.toReq(g(b)))
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = new Url((b: B) => fa.toReq(g(b)))
   }
 
 }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
@@ -22,8 +22,8 @@ trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: Endpoints[R] =>
           case Some(transportR) =>
             self.backend.responseMonad.flatMap(transportR) { transport =>
               decoder.decode(transport) match {
-                case Right(r) => self.backend.responseMonad.unit(r.asInstanceOf[req.Response])
-                case Left(exception) => self.backend.responseMonad.error(exception)
+                case Valid(r)        => self.backend.responseMonad.unit(r.asInstanceOf[req.Response])
+                case Invalid(errors) => self.backend.responseMonad.error(new Exception(errors.mkString(". ")))
               }
             }
         }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
@@ -6,7 +6,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
 import endpoints.algebra.Documentation
-import endpoints.{PartialInvariantFunctor, Tupler, algebra}
+import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 
 /**
   * @group interpreters
@@ -19,7 +19,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] = 
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] =
       (b: B) => fa.encodeQueryString(g(b))
   }
 
@@ -46,7 +46,7 @@ trait Urls extends algebra.Urls {
   type QueryStringParam[A] = A => List[String]
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: A => List[String], f: A => Option[B], g: B => A): B => List[String] =
+    def xmapPartial[A, B](fa: A => List[String], f: A => Validated[B], g: B => A): B => List[String] =
       (b: B) => fa(g(b))
   }
 
@@ -65,7 +65,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
   }
 
   implicit lazy val stringSegment: Segment[String] = (s: String) => URLEncoder.encode(s, utf8Name)
@@ -73,7 +73,7 @@ trait Urls extends algebra.Urls {
   trait Path[A] extends Url[A]
 
   implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
   }
 
   def staticPathSegment(segment: String) = (_: Unit) => segment
@@ -104,7 +104,7 @@ trait Urls extends algebra.Urls {
     }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
   }
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/BasicAuthentication.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/BasicAuthentication.scala
@@ -1,7 +1,8 @@
 package endpoints.xhr
 
-import endpoints.algebra
+import endpoints.{Tupler, algebra}
 import endpoints.algebra.BasicAuthentication.Credentials
+import endpoints.algebra.Documentation
 import org.scalajs.dom.window.btoa
 
 /**
@@ -9,13 +10,22 @@ import org.scalajs.dom.window.btoa
   */
 trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
 
-  /**
-    * Supplies the credential into the request headers
-    */
-  private[endpoints] lazy val basicAuthenticationHeader: RequestHeaders[Credentials] =
-    (credentials, xhr) => {
+  private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHCred: Tupler.Aux[H, Credentials, HCred],
+    tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
+  ): Request[Out] = {
+    val basicAuthenticationHeader: RequestHeaders[Credentials] = { (credentials, xhr) =>
       xhr.setRequestHeader("Authorization", "Basic " + btoa(credentials.username + ":" + credentials.password))
       ()
     }
+    request(method, url, entity, requestDocs, headers ++ basicAuthenticationHeader)
+  }
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/JsonEntitiesFromCodec.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/JsonEntitiesFromCodec.scala
@@ -17,6 +17,7 @@ trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitie
   }
 
   def jsonResponse[A](implicit codec: Codec[String, A]) =
-    (xhr: XMLHttpRequest) => codec.decode(xhr.responseText)
+    (xhr: XMLHttpRequest) =>
+      codec.decode(xhr.responseText).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/Urls.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Urls.scala
@@ -3,7 +3,7 @@ package endpoints.xhr
 import scala.collection.compat.Factory
 import scala.language.higherKinds
 import endpoints.algebra.Documentation
-import endpoints.{PartialInvariantFunctor, Tupler, algebra}
+import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 
 import scala.scalajs.js
 
@@ -23,7 +23,7 @@ trait Urls extends algebra.Urls {
   //#segment
 
   implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] = new PartialInvariantFunctor[Segment] {
-    def xmapPartial[A, B](fa: Segment[A], f: A => Option[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] = (b: B) => fa.encode(g(b))
   }
 
   implicit lazy val stringSegment: Segment[String] =
@@ -38,7 +38,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
-    def xmapPartial[A, B](fa: QueryString[A], f: A => Option[B], g: B => A): QueryString[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] = (b: B) => fa.encode(g(b))
   }
 
   def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
@@ -66,7 +66,7 @@ trait Urls extends algebra.Urls {
   }
 
   implicit lazy val queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] = new PartialInvariantFunctor[QueryStringParam] {
-    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Option[B], g: B => A): QueryStringParam[B] =
+    def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Validated[B], g: B => A): QueryStringParam[B] =
       (b: B) => fa.encode(g(b))
   }
 
@@ -85,7 +85,7 @@ trait Urls extends algebra.Urls {
   trait Path[A] extends Url[A]
 
   implicit lazy val pathPartialInvariantFunctor: PartialInvariantFunctor[Path] = new PartialInvariantFunctor[Path] {
-    def xmapPartial[A, B](fa: Path[A], f: A => Option[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] = (b: B) => fa.encode(g(b))
   }
 
   def staticPathSegment(segment: String) = (_: Unit) => segment
@@ -115,7 +115,7 @@ trait Urls extends algebra.Urls {
     }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
-    def xmapPartial[A, B](fa: Url[A], f: A => Option[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
+    def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = (b: B) => fa.encode(g(b))
   }
 
 }


### PR DESCRIPTION
Instead of just returning a Bad Request (400) response with no entity in case of client error, we now return a list of error messages. Fixes #307.

You can see examples of returned errors in these tests: https://github.com/julienrf/endpoints/pull/370/files#diff-faf871b4ab8cf8b1acb20fffb13206cf

It also standardizes the behavior of the server interpreters: first, they tests whether an incoming request matches a given endpoint definition by checking whether its URL has the same number of segments as the endpoint and if the static segments of the endpoint have the same value in the request URL. Second, the request parameters (dynamic URL segments, query string parameters and header values) are decoded. Third, the request entity is decoded. These three steps are run sequentially: the request parameters are decoded only after the servers have checked that the request matches the endpoint definition, and the request entity is decoded only after the servers have successfully decoded the request parameters. But within a step, the validations are run independently of each others: a request that contains both an invalid path segment and an invalid query string parameter will produce two error messages.

As a consequence, authentication handling has to be done at the level of `Request[A]` instead of `RequestHeaders[A]` (the latter doesn’t anymore have the power of returning an HTTP response). In practice, this means that the `BasicAuthentication` trait now defines a custom `authenticatedRequest` constructor instead of a `basicAuthenticationHeader` constructor.