### PR TITLE
Add errors produced by endpoints to the documentation interpreter

### DIFF
--- a/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
+++ b/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
@@ -2,14 +2,14 @@ package endpoints.akkahttp.client.circe
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import endpoints._
-import endpoints.akkahttp.client.{Endpoints, EndpointsWithCustomErrors}
+import endpoints.akkahttp.client.EndpointsWithCustomErrors
 import io.circe.{Decoder, Encoder}
 import io.circe.syntax._
 import io.circe.parser.decode
 
 /**
-  * Interpreter for [[endpoints.algebra.JsonSchemaEntities]] that uses circe’s [[io.circe.Encoder]] to encode
-  * JSON entities in HTTP requests, and circe’s [[io.circe.Decoder]] to decode JSON entities
+  * Interpreter for [[endpoints.algebra.JsonSchemaEntities]] that uses circe’s `io.circe.Encoder` to encode
+  * JSON entities in HTTP requests, and circe’s `io.circe.Decoder` to decode JSON entities
   * in HTTP responses.
   *
   * @group interpreters

--- a/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
+++ b/akka-http/client-circe/src/main/scala/endpoints/akkahttp/client/circe/JsonSchemaEntities.scala
@@ -2,8 +2,8 @@ package endpoints.akkahttp.client.circe
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import endpoints._
-import endpoints.akkahttp.client.Endpoints
-import io.circe.{Encoder, Decoder}
+import endpoints.akkahttp.client.{Endpoints, EndpointsWithCustomErrors}
+import io.circe.{Decoder, Encoder}
 import io.circe.syntax._
 import io.circe.parser.decode
 
@@ -14,7 +14,7 @@ import io.circe.parser.decode
   *
   * @group interpreters
   */
-trait JsonSchemaEntities extends algebra.JsonSchemaEntities with circe.JsonSchemas { this: Endpoints =>
+trait JsonSchemaEntities extends algebra.JsonSchemaEntities with circe.JsonSchemas { this: EndpointsWithCustomErrors =>
 
   def jsonRequest[A: JsonSchema]: RequestEntity[A] = { (a, req) =>
     implicit def encoder: Encoder[A] = implicitly[JsonSchema[A]].encoder

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/BasicAuthentication.scala
@@ -8,7 +8,7 @@ import endpoints.algebra.Documentation
 /**
   * @group interpreters
   */
-trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints =>
+trait BasicAuthentication extends algebra.BasicAuthentication { self: EndpointsWithCustomErrors =>
 
   private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
     method: Method,

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/BuiltInErrors.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/BuiltInErrors.scala
@@ -1,0 +1,14 @@
+package endpoints.akkahttp.client
+
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] =
+    stringCodecResponse(invalidCodec)
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    mapResponseEntity(clientErrorsResponseEntity)(invalid => new Throwable(invalid.errors.mkString(". ")))
+
+}

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/JsonEntitiesFromCodec.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/JsonEntitiesFromCodec.scala
@@ -9,19 +9,12 @@ import endpoints.algebra.Codec
   *
   * @group interpreters
   */
-trait JsonEntitiesFromCodec extends endpoints.algebra.JsonEntitiesFromCodec { this: Endpoints =>
+trait JsonEntitiesFromCodec extends endpoints.algebra.JsonEntitiesFromCodec { this: EndpointsWithCustomErrors =>
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
     req.copy(entity = HttpEntity(ContentTypes.`application/json`, codec.encode(a)))
   }
 
-  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = { entity =>
-    for {
-      strictEntity <- entity.toStrict(settings.toStrictTimeout)
-    } yield {
-      codec.decode(settings.stringContentExtractor(strictEntity))
-        .fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
-    }
-  }
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = stringCodecResponse
 
 }

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/MuxEndpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/MuxEndpoints.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 /**
   * @group interpreters
   */
-trait MuxEndpoints extends algebra.MuxEndpoints { self: Endpoints =>
+trait MuxEndpoints extends algebra.MuxEndpoints { self: EndpointsWithCustomErrors =>
 
   class MuxEndpoint[Req <: algebra.MuxRequest, Resp, Transport](
     request: Request[Transport],
@@ -22,7 +22,7 @@ trait MuxEndpoints extends algebra.MuxEndpoints { self: Endpoints =>
     ): Future[req.Response] =
       request(encoder.encode(req)).flatMap { resp =>
         futureFromEither(
-          response(resp.status, resp.headers).toRight(new Throwable(s"Unexpected response status or headers"))
+          decodeResponse(response, resp).toRight({ resp.discardEntityBytes(); new Throwable(s"Unexpected response status or headers")})
         ).flatMap { entity =>
             entity(resp.entity).flatMap { t =>
               futureFromEither(t).flatMap(tt =>

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/StatusCodes.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/StatusCodes.scala
@@ -23,5 +23,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = AkkaStatusCodes.NotFound
 
   def InternalServerError = AkkaStatusCodes.InternalServerError
+  def NotImplemented = AkkaStatusCodes.NotImplemented
 
 }

--- a/akka-http/server-circe/src/main/scala/endpoints/akkahttp/server/circe/JsonSchemaEntities.scala
+++ b/akka-http/server-circe/src/main/scala/endpoints/akkahttp/server/circe/JsonSchemaEntities.scala
@@ -14,7 +14,7 @@ import io.circe.{Decoder, DecodingFailure, Encoder}
   *
   * @group interpreters
   */
-trait JsonSchemaEntities extends server.Endpoints with algebra.JsonSchemaEntities with circe.JsonSchemas {
+trait JsonSchemaEntities extends server.EndpointsWithCustomErrors with algebra.JsonSchemaEntities with circe.JsonSchemas {
 
   def jsonRequest[A : JsonSchema]: RequestEntity[A] = {
     implicit def decoder: Decoder[A] = implicitly[JsonSchema[A]].decoder

--- a/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
+++ b/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
@@ -14,7 +14,7 @@ import endpoints.{Invalid, algebra}
   *
   * @group interpreters
   */
-trait JsonSchemaEntities extends server.Endpoints with algebra.JsonSchemaEntities with endpoints.playjson.JsonSchemas {
+trait JsonSchemaEntities extends server.EndpointsWithCustomErrors with algebra.JsonSchemaEntities with endpoints.playjson.JsonSchemas {
 
   def jsonRequest[A: JsonSchema]: RequestEntity[A] = {
     Directives.entity[A](

--- a/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
+++ b/akka-http/server-playjson/src/main/scala/endpoints/akkahttp/server/playjson/JsonSchemaEntities.scala
@@ -8,8 +8,8 @@ import endpoints.akkahttp.server
 import endpoints.{Invalid, algebra}
 
 /**
-  * Interpreter for [[algebra.JsonEntities]] that uses Play JSON [[play.api.libs.json.Reads]] to decode
-  * JSON entities in HTTP requests, and [[play.api.libs.json.Writes]] to build JSON entities
+  * Interpreter for [[algebra.JsonEntities]] that uses Play JSON `play.api.libs.json.Reads` to decode
+  * JSON entities in HTTP requests, and `play.api.libs.json.Writes` to build JSON entities
   * in HTTP responses.
   *
   * @group interpreters

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/BasicAuthentication.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/BasicAuthentication.scala
@@ -10,7 +10,7 @@ import endpoints.algebra.Documentation
 /**
   * @group interpreters
   */
-trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
+trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWithCustomErrors {
 
   private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
     method: Method,

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/BuiltInErrors.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/BuiltInErrors.scala
@@ -1,0 +1,18 @@
+package endpoints.akkahttp.server
+
+import akka.http.scaladsl.marshalling.Marshaller
+import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] =
+    Marshaller.withFixedContentType(MediaTypes.`application/json`) { invalid =>
+      HttpEntity(MediaTypes.`application/json`, invalidCodec.encode(invalid))
+    }
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    clientErrorsResponseEntity.compose(throwable => Invalid(throwable.getMessage))
+
+}

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntities.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntities.scala
@@ -13,7 +13,7 @@ import endpoints._
   *
   * @group interpreters
   */
-trait JsonEntities extends algebra.JsonEntities with Endpoints {
+trait JsonEntities extends algebra.JsonEntities with EndpointsWithCustomErrors {
 
   type JsonRequest[A] = FromRequestUnmarshaller[A]
 

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntitiesFromCodec.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntitiesFromCodec.scala
@@ -13,7 +13,7 @@ import endpoints.algebra.Codec
   *
   * @group interpreters
   */
-trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
+trait JsonEntitiesFromCodec extends EndpointsWithCustomErrors with endpoints.algebra.JsonEntitiesFromCodec {
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = {
     implicit val fromEntityUnmarshaller: FromEntityUnmarshaller[Validated[A]] =

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/StatusCodes.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/StatusCodes.scala
@@ -23,5 +23,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = AkkaStatusCodes.NotFound
 
   def InternalServerError = AkkaStatusCodes.InternalServerError
+  def NotImplemented = AkkaStatusCodes.NotImplemented
 
 }

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
@@ -60,10 +60,8 @@ trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErro
   }
 
   /**
-    * @inheritdoc
-    *
     * Given a parameter name and a query string content, returns a decoded parameter
-    * value of type `T`, or `None` if decoding failed
+    * value of type `T`, or `Invalid` if decoding failed
     */
   type QueryStringParam[T] = (String, Map[String, Seq[String]]) => Validated[T]
 
@@ -182,7 +180,7 @@ trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErro
     }
 
   /**
-    * Simpler alternative to [[Directive.&()]] method
+    * Simpler alternative to `Directive.&()` method
     */
   protected def joinDirectives[T1, T2](dir1: Directive1[T1], dir2: Directive1[T2])(implicit tupler: Tupler[T1, T2]): Directive1[tupler.Out] = {
     Directive[Tuple1[tupler.Out]] { inner =>
@@ -197,7 +195,7 @@ trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErro
   /**
     * This method is called by ''endpoints'' when decoding a request failed.
     *
-    * The provided implementation calls [[clientErrorsResponse]] to complete
+    * The provided implementation calls `clientErrorsResponse` to complete
     * with a response containing the errors.
     *
     * This method can be overridden to customize the error reporting logic.

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
@@ -3,8 +3,6 @@ package endpoints.akkahttp.server
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
-
 import scala.collection.compat._
 import scala.language.higherKinds
 import akka.http.scaladsl.server._
@@ -18,7 +16,7 @@ import scala.collection.mutable
   *
   * @group interpreters
   */
-trait Urls extends algebra.Urls with StatusCodes {
+trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErrors =>
 
   trait Path[A] extends Url[A] {
     def validate(segments: List[String]): Option[(Validated[A], List[String])]
@@ -199,19 +197,12 @@ trait Urls extends algebra.Urls with StatusCodes {
   /**
     * This method is called by ''endpoints'' when decoding a request failed.
     *
-    * The default implementation is to return a route that completes with a
-    * Bad Request (400) response containing the error messages as a JSON array
-    * of string values.
+    * The provided implementation calls [[clientErrorsResponse]] to complete
+    * with a response containing the errors.
     *
     * This method can be overridden to customize the error reporting logic.
     */
   def handleClientErrors(invalid: Invalid): StandardRoute =
-    Directives.complete(HttpResponse(
-      BadRequest,
-      entity = HttpEntity(
-        ContentTypes.`application/json`,
-        s"[${invalid.errors.map(error => s""""${error.replaceAllLiterally("\\", "\\\\").replaceAllLiterally("\"", "\\\"")}"""").mkString(",")}]"
-      )
-    ))
+    StandardRoute(clientErrorsResponse(invalidToClientErrors(invalid)))
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Assets.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Assets.scala
@@ -5,7 +5,7 @@ package endpoints.algebra
   *
   * @group algebras
   */
-trait Assets extends Endpoints {
+trait Assets extends EndpointsWithCustomErrors {
 
   /** An HTTP request to retrieve an asset */
   type AssetRequest

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -11,7 +11,7 @@ import endpoints.algebra.BasicAuthentication.Credentials
   *
   * @group algebras
   */
-trait BasicAuthentication extends Endpoints {
+trait BasicAuthentication extends EndpointsWithCustomErrors {
 
   /**
     * A response that can either be Forbidden (403) or the given `Response[A]`.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BuiltInErrors.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BuiltInErrors.scala
@@ -1,0 +1,57 @@
+package endpoints.algebra
+
+import endpoints.{Invalid, Valid, Validated}
+
+/**
+  * Uses ''endpoints'' built-in error types:
+  *
+  * - [[Invalid]] for client errors,
+  *
+  * - and `Throwable` for server error.
+  *
+  * Both types of errors are serialized into a JSON array containing string error values.
+  */
+trait BuiltInErrors extends Errors { this: EndpointsWithCustomErrors =>
+
+  type ClientErrors = Invalid
+  type ServerError = Throwable
+
+  final def invalidToClientErrors(invalid: Invalid): ClientErrors = invalid
+  final def clientErrorsToInvalid(clientErrors: ClientErrors): Invalid = clientErrors
+
+  final def throwableToServerError(throwable: Throwable): ServerError = throwable
+  final def serverErrorToThrowable(serverError: ServerError): Throwable = serverError
+
+  /**
+    * Response entity format for [[Invalid]] values
+    */
+  def clientErrorsResponseEntity: ResponseEntity[Invalid]
+
+  /**
+    * Response entity format for `Throwable` values
+    */
+  def serverErrorResponseEntity: ResponseEntity[Throwable]
+
+}
+
+object InvalidCodec {
+
+  implicit val invalidCodec: Codec[String, Invalid] =
+    // TODO Make JSON encoding and decoding more robust
+    new Codec[String, Invalid] {
+      def decode(from: String): Validated[Invalid] = {
+        val errors =
+          from.drop(2).dropRight(2).split("(?<!\\\\)\",\"")
+            .map(error => error.replaceAllLiterally("\\\\", "\\").replaceAllLiterally("\\\"", "\"").replaceAllLiterally("\\n", "\n"))
+            .toIndexedSeq
+        Valid(Invalid(errors))
+      }
+      def encode(invalid: Invalid): String = {
+        // Manually encode JSON because we don’t want to have a dependency on a JSON library here
+        val jsonErrors =
+          invalid.errors.map(error => s""""${error.replaceAllLiterally("\\", "\\\\").replaceAllLiterally("\"", "\\\"").replaceAllLiterally("\n", "\\n")}"""")
+        s"[${jsonErrors.mkString(",")}]"
+      }
+    }
+
+}

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
@@ -17,9 +17,18 @@ import scala.language.higherKinds
   *   val example = endpoint(get(path / "foo"), emptyResponse)
   * }}}
   *
+  * This trait uses [[BuiltInErrors]] to model client and server errors.
+  *
   * @group algebras
   */
-trait Endpoints extends Requests with Responses {
+trait Endpoints extends EndpointsWithCustomErrors with BuiltInErrors
+
+/**
+  * Algebra interface for describing endpoints made of requests and responses.
+  *
+  * @group algebras
+  */
+trait EndpointsWithCustomErrors extends Requests with Responses with Errors {
 
   /**
     * Information carried by an HTTP endpoint

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Errors.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Errors.scala
@@ -1,0 +1,62 @@
+package endpoints.algebra
+
+import endpoints.Invalid
+
+/**
+  * Defines the error types used to model client and server errors.
+  *
+  * The `ClientErrors` type is used by ''endpoints'' to model errors coming
+  * from the client (missing query parameter, invalid entity, etc.).
+  *
+  * The `ServerError` type is used by ''endpoints'' to model errors coming from
+  * the server business logic.
+  *
+  * The `badRequest` and `internalServerError` operations defined in [[Responses]]
+  * define responses carrying entities of type `ClientErrors` and `ServerError`,
+  * respectively.
+  *
+  * Interpreters are expected to use the `clientErrorsResponse` and `serverErrorResponse`
+  * operations defined here to handle client and server errors, respectively.
+  *
+  * @see [[BuiltInErrors]]
+  */
+trait Errors { this: Responses =>
+
+  /** Errors in a request built by a client */
+  type ClientErrors
+  /** Error raised by the business logic of a server */
+  type ServerError
+
+  def invalidToClientErrors(invalid: Invalid): ClientErrors
+  def clientErrorsToInvalid(clientErrors: ClientErrors): Invalid
+
+  def throwableToServerError(throwable: Throwable): ServerError
+  def serverErrorToThrowable(serverError: ServerError): Throwable
+
+  /**
+    * Response used by the ''endpoints'' library when decoding
+    * a request fails.
+    *
+    * The provided implementation forwards to `badRequest`.
+    */
+  lazy val clientErrorsResponse: Response[ClientErrors] = badRequest(docs = Some("Client error"))
+
+  /**
+    * Format of the response entity carrying the client errors.
+    */
+  def clientErrorsResponseEntity: ResponseEntity[ClientErrors]
+
+  /**
+    * Response used by the ''endpoints'' library when the
+    * business logic of an endpoint fails.
+    *
+    * The provided implementation forwards to `internalServerError`
+    */
+  lazy val serverErrorResponse: Response[ServerError] = internalServerError(docs = Some("Server error"))
+
+  /**
+    * Format of the response entity carrying the server error.
+    */
+  def serverErrorResponseEntity: ResponseEntity[ServerError]
+
+}

--- a/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
@@ -17,7 +17,7 @@ import scala.language.higherKinds
   *
   * @group algebras
   */
-trait JsonEntities extends Endpoints {
+trait JsonEntities extends EndpointsWithCustomErrors {
 
 //#request-response-types
   /** Type class defining how to represent the `A` information as a JSON request entity */

--- a/algebras/algebra/src/main/scala/endpoints/algebra/LowLevelEndpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/LowLevelEndpoints.scala
@@ -29,7 +29,7 @@ package endpoints.algebra
   *     .map(response => println(response.responseText))
   * }}}
   */
-trait LowLevelEndpoints extends Endpoints {
+trait LowLevelEndpoints extends EndpointsWithCustomErrors {
 
   /** Low-level request entity */
   type RawRequestEntity

--- a/algebras/algebra/src/main/scala/endpoints/algebra/MuxEndpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/MuxEndpoints.scala
@@ -8,7 +8,7 @@ import scala.language.higherKinds
   *
   * @group algebras
   */
-trait MuxEndpoints extends Endpoints {
+trait MuxEndpoints extends EndpointsWithCustomErrors {
 
   /**
     * Information carried by a multiplexed HTTP endpoint.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -45,7 +45,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
   def emptyRequest: RequestEntity[Unit]
 
   /**
-    * Request with a [[String]] body.
+    * Request with a `String` body.
     */
   def textRequest: RequestEntity[String]
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
@@ -7,7 +7,7 @@ import scala.language.higherKinds
 /**
   * @group algebras
   */
-trait Responses extends StatusCodes with InvariantFunctorSyntax {
+trait Responses extends StatusCodes with InvariantFunctorSyntax { this: Errors =>
 
   /** An HTTP response (status, headers, and entity) carrying an information of type A */
   type Response[A]
@@ -53,10 +53,18 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax {
     response(OK, entity, docs)
 
   /**
-    * Bad Request (400) with the given entity
+    * Bad Request (400) response, with an entity of type `ClientErrors`.
+    * @see [[endpoints.algebra.Errors]] and [[endpoints.algebra.BuiltInErrors]]
     */
-  final def badRequest[A](entity: ResponseEntity[A], docs: Documentation = None): Response[A] =
-    response(BadRequest, entity, docs)
+  final def badRequest(docs: Documentation = None): Response[ClientErrors] =
+    response(BadRequest, clientErrorsResponseEntity, docs)
+
+  /**
+    * Internal Server Error (500) response, with an entity of type `ServerError`.
+    * @see [[endpoints.algebra.Errors]] and [[endpoints.algebra.BuiltInErrors]]
+    */
+  final def internalServerError(docs: Documentation = None): Response[ServerError] =
+    response(InternalServerError, serverErrorResponseEntity, docs)
 
   /**
     * Turns a `Response[A]` into a `Response[Option[A]]`.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/StatusCodes.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/StatusCodes.scala
@@ -8,7 +8,7 @@ trait StatusCodes {
   /** HTTP Status Code */
   type StatusCode
 
-  /** 2xx Success */
+  // 2xx Success
   def OK: StatusCode
 
   def Created: StatusCode
@@ -17,7 +17,12 @@ trait StatusCodes {
 
   def NoContent: StatusCode
 
-  /** 4xx Client Error */
+  // 4xx Client Error
+  /**
+    * @note You should use the `badRequest` constructor provided by the [[Responses]]
+    *       trait to ensure that errors produced by ''endponits'' are consistently
+    *       handled by interpreters.
+    */
   def BadRequest: StatusCode
 
   def Unauthorized: StatusCode
@@ -26,7 +31,14 @@ trait StatusCodes {
 
   def NotFound: StatusCode
 
-  /** 5xx Server Error */
+  // 5xx Server Error
+  /**
+    * @note You should use the `internalServerError` constructor provided by the
+    *       [[Responses]] trait to ensure that errors produced by ''endpoints''
+    *       are consistently handled by interpreters.
+    */
   def InternalServerError: StatusCode
+
+  def NotImplemented: StatusCode
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/InvalidCodecTest.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/InvalidCodecTest.scala
@@ -1,0 +1,17 @@
+package endpoints.algebra
+
+import endpoints.{Invalid, Valid}
+import org.scalatest.WordSpec
+
+class InvalidCodecTest extends WordSpec {
+
+  "InvalidCodec" should {
+    "Properly handle double quotes in strings" in {
+      val decoded = Invalid(Seq("foo", "bar\",", "", "ba\nz"))
+      val encoded = """["foo","bar\",","","ba\nz"]"""
+      assert(InvalidCodec.invalidCodec.encode(decoded) == encoded)
+      assert(InvalidCodec.invalidCodec.decode(encoded) == Valid(decoded))
+    }
+  }
+
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala
@@ -1,7 +1,5 @@
 package endpoints.algebra
 
-import endpoints.Validated
-
 trait JsonEntitiesDocs extends JsonEntities {
 
   type Error = String
@@ -29,15 +27,18 @@ trait JsonEntitiesDocs extends JsonEntities {
   //#response-or-not-found
 
   //#response-or-else
-  val validUserResponse: Response[Either[Seq[Error], User]] =
-    badRequest(jsonResponse[Seq[Error]]).orElse(ok(jsonResponse[User]))
+  val maybeUserResponse: Response[Either[Unit, User]] =
+    response(NotImplemented, emptyResponse).orElse(ok(jsonResponse[User]))
   //#response-or-else
 
   locally {
     //#response-xmap
-    val validUserResponse: Response[Validated[User]] =
-      badRequest(jsonResponse[Seq[Error]]).orElse(ok(jsonResponse[User]))
-        .xmap(Validated.fromEither)(_.toEither)
+    val maybeUserResponse: Response[Option[User]] =
+      response(NotImplemented, emptyResponse).orElse(ok(jsonResponse[User]))
+        .xmap {
+          case Left(()) => None
+          case Right(user) => Some(user)
+        }(_.toRight(()))
     //#response-xmap
   }
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
@@ -107,6 +107,16 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
         whenReady(call(client.emptyResponseSmokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unexpected response status: 501")
       }
 
+      "throw exception with a detailed error message when 500 is returned from server" in {
+        wireMockServer.stubFor(get(urlEqualTo("/user/userId/description?name=name1&age=18"))
+          .willReturn(aResponse()
+            .withStatus(500)
+            .withBody("[\"Unable to process your request\"]")))
+
+        whenReady(call(client.smokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unable to process your request")
+        whenReady(call(client.emptyResponseSmokeEndpoint, ("userId", "name1", 18)).failed)(x => x.getMessage shouldBe "Unable to process your request")
+      }
+
       "properly handle joined headers" in {
         val response = UUID.randomUUID().toString
         wireMockServer.stubFor(get(urlEqualTo("/joinedHeadersEndpoint"))

--- a/documentation/examples/cqrs/queries-endpoints/src/main/scala/cqrs/queries/QueriesEndpoints.scala
+++ b/documentation/examples/cqrs/queries-endpoints/src/main/scala/cqrs/queries/QueriesEndpoints.scala
@@ -2,7 +2,7 @@ package cqrs.queries
 
 import java.util.UUID
 
-import endpoints.algebra.{circe, MuxEndpoints, MuxRequest}
+import endpoints.algebra.{BuiltInErrors, MuxEndpoints, MuxRequest, circe}
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
@@ -15,7 +15,7 @@ import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
   *    entity gives way more details about failures than status codes.
   */
 //#mux-endpoint
-trait QueriesEndpoints extends MuxEndpoints with circe.JsonEntitiesFromCodec {
+trait QueriesEndpoints extends MuxEndpoints with BuiltInErrors with circe.JsonEntitiesFromCodec {
 
   val query: MuxEndpoint[QueryReq, QueryResp, Json] = {
     val request = post(path / "query", jsonRequest[Json])

--- a/documentation/examples/cqrs/queries/src/main/scala/cqrs/queries/Queries.scala
+++ b/documentation/examples/cqrs/queries/src/main/scala/cqrs/queries/Queries.scala
@@ -1,6 +1,6 @@
 package cqrs.queries
 
-import endpoints.play.server.{JsonEntitiesFromCodec, MuxEndpoints, PlayComponents}
+import endpoints.play.server.{BuiltInErrors, JsonEntitiesFromCodec, MuxEndpoints, PlayComponents}
 import play.api.routing.Router
 
 import scala.concurrent.Future
@@ -11,6 +11,7 @@ import scala.concurrent.Future
 class Queries(service: QueriesService, protected val playComponents: PlayComponents)
   extends QueriesEndpoints
     with MuxEndpoints
+    with BuiltInErrors
     with JsonEntitiesFromCodec {
 
   import playComponents.executionContext

--- a/documentation/examples/quickstart/server/src/main/scala/quickstart/CounterServer.scala
+++ b/documentation/examples/quickstart/server/src/main/scala/quickstart/CounterServer.scala
@@ -21,10 +21,10 @@ class CounterServer(protected val playComponents: PlayComponents)
 
   val routes: Router.Routes = routesFromEndpoints(
 
-    /** Implements the `currentValue` endpoint */
+    // Implements the `currentValue` endpoint
     currentValue.implementedBy(_ => Counter(counter.single.get)),
 
-    /** Implements the `increment` endpoint */
+    // Implements the `increment` endpoint
     //#endpoint-implementation
     increment.implementedBy(inc => counter.single += inc.step)
     //#endpoint-implementation

--- a/documentation/manual/src/doc/algebras/endpoints.md
+++ b/documentation/manual/src/doc/algebras/endpoints.md
@@ -149,17 +149,41 @@ by using the `orElse` operation:
 ~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala#response-or-else
 ~~~
 
-In this example, servers can produce a Bad Request (400) response by returning
-`Left(validationErrors)`, and an OK (200) response containing a user
-by returning `Right(user)`. Conversely, clients interpret a Bad Request response
-(with a valid `ValidationErrors` entity) as a `Left(validationErrors)` value,
+In this example, servers can produce a Not Implemented (501) response by returning
+`Left(())`, and an OK (200) response containing a user
+by returning `Right(user)`. Conversely, clients interpret a Not Implemented response
+as a `Left(())` value,
 and an OK response (with a valid user entity) as a `Right(user)` value.
 
 You can also transform the type produced by the alternative responses into
 a more convenient type to work with, by using the `xmap` operation. For instance,
-here is how to transform a `Response[Either[Seq[String], User]]` into a
-`Response[Validated[User]]`:
+here is how to transform a `Response[Either[Unit, User]]` into a
+`Response[Option[User]]`:
 
 ~~~ scala src=../../../../../algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesDocs.scala#response-xmap
 ~~~
 
+### Error Responses
+
+_endpoints_ server interpreters handle two kinds of errors:
+
+- when the server is unable to decode an incoming request (because, for instance,
+  a query parameter is missing, or the request entity has the wrong format).
+  In this case it is a “client error” ;
+- when the provided business logic throws an exception, or the server is
+  unable to serialize the result into a proper HTTP response. In this case it is
+  a “server error”.
+
+By default, client errors are reported as an
+[Invalid](unchecked:/api/endpoints/Invalid.html) value, serialized into
+a Bad Request (400) response, as a JSON array containing string messages.
+You can change the provided serialization format by overriding the
+[clientErrorsResponseEntity](unchecked:/api/endpoints/algebra/BuiltInErrors.html#clientErrorsResponseEntity:BuiltInErrors.this.ResponseEntity[endpoints.Invalid])
+operation.
+
+Similarly, by default server errors are reported as a `Throwable` value,
+serialized into an Internal Server Error (500) response, as a JSON array
+containing string messages. You can change the provided serialization format
+by overriding the
+[serverErrorResponseEntity](unchecked:/api/endpoints/algebra/BuiltInErrors.html#serverErrorResponseEntity:BuiltInErrors.this.ResponseEntity[Throwable])
+operation.

--- a/documentation/manual/src/doc/quick-start.md
+++ b/documentation/manual/src/doc/quick-start.md
@@ -164,47 +164,44 @@ the following:
 
 ~~~ javascript
 {
-  "components": {
-    "schemas": {
-      "quickstart.Counter": {
-        "required": [
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "quickstart.Increment": {
-        "required": [
-          "step"
-        ],
-        "type": "object",
-        "properties": {
-          "step": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      }
-    }
-  },
   "openapi": "3.0.0",
   "info": {
     "title": "API to manipulate a counter",
     "version": "1.0.0"
   },
+  "components": {
+    "schemas": {
+      "quickstart.Counter": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["value"]
+      },
+      "quickstart.Increment": {
+        "type": "object",
+        "properties": {
+          "step": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["step"]
+      },
+      "endpoints.Errors": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  },
   "paths": {
     "/increment": {
       "post": {
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -213,12 +210,57 @@ the following:
               }
             }
           }
+        },
+        "responses": {
+          "400": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/endpoints.Errors"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/endpoints.Errors"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": ""
+          }
         }
       }
     },
     "/current-value": {
       "get": {
         "responses": {
+          "400": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/endpoints.Errors"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/endpoints.Errors"
+                }
+              }
+            }
+          },
           "200": {
             "description": "",
             "content": {

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -10,8 +10,8 @@ import scala.collection.compat._
 import scala.language.higherKinds
 
 /**
-  * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces Play JSON [[play.api.libs.json.Reads]]
-  * and [[play.api.libs.json.Writes]].
+  * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces Play JSON `play.api.libs.json.Reads`
+  * and `play.api.libs.json.Writes`.
   */
 trait JsonSchemas
   extends algebra.JsonSchemas {

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
@@ -11,7 +11,7 @@ import endpoints.openapi.model._
   */
 trait Assets
   extends algebra.Assets
-    with Endpoints
+    with EndpointsWithCustomErrors
     with StatusCodes {
 
   type AssetRequest = Nothing

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -13,7 +13,7 @@ import endpoints.openapi.model.{SecurityRequirement, SecurityScheme}
   */
 trait BasicAuthentication
   extends algebra.BasicAuthentication
-    with Endpoints
+    with EndpointsWithCustomErrors
     with StatusCodes {
 
   def basicAuthenticationSchemeName: String = "HttpBasic"

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -6,7 +6,7 @@ import endpoints.algebra.Documentation
 import endpoints.openapi.model.{SecurityRequirement, SecurityScheme}
 
 /**
-  * Interpreter for [[algebra.BasicAuthentication]] that produces
+  * Interpreter for [[endpoints.algebra.BasicAuthentication]] that produces
   * OpenAPI documentation.
   *
   * @group interpreters

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
@@ -1,0 +1,15 @@
+package endpoints.openapi
+
+import endpoints.{Invalid, algebra}
+import endpoints.openapi.model.{MediaType, Schema}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  private lazy val invalidJsonEntity =
+    Map("application/json" -> MediaType(Some(Schema.Reference("endpoints.Errors", Some(Schema.Array(Schema.simpleString, None)), None))))
+
+  lazy val clientErrorsResponseEntity: ResponseEntity[Invalid] = invalidJsonEntity
+
+  lazy val serverErrorResponseEntity: ResponseEntity[Throwable] = invalidJsonEntity
+
+}

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -5,7 +5,7 @@ import endpoints.openapi.model._
 import endpoints.algebra.Documentation
 
 /**
-  * Interpreter for [[algebra.Endpoints]] that produces an [[OpenApi]] instance for endpoints,
+  * Interpreter for [[algebra.Endpoints]] that produces an [[endpoints.openapi.model.OpenApi]] instance for endpoints,
   * and uses [[algebra.BuiltInErrors]] to model client and server errors.
   *
   * @group interpreters
@@ -13,7 +13,7 @@ import endpoints.algebra.Documentation
 trait Endpoints extends algebra.Endpoints with EndpointsWithCustomErrors with BuiltInErrors
 
 /**
-  * Interpreter for [[algebra.Endpoints]] that produces an [[OpenApi]] instance for endpoints.
+  * Interpreter for [[algebra.Endpoints]] that produces an [[endpoints.openapi.model.OpenApi]] instance for endpoints.
   *
   * @group interpreters
   */
@@ -23,7 +23,7 @@ trait EndpointsWithCustomErrors
     with Responses {
 
   /**
-    * @return An [[OpenApi]] instance for the given endpoint descriptions
+    * @return An `OpenApi` instance for the given endpoint descriptions
     * @param info      General information about the documentation to generate
     * @param endpoints The endpoints to generate the documentation for
     */

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonEntities.scala
@@ -14,7 +14,7 @@ import endpoints.openapi.model.MediaType
   */
 trait JsonEntities
   extends algebra.JsonEntities
-    with Endpoints {
+    with EndpointsWithCustomErrors {
 
   def jsonRequest[A : JsonRequest]: RequestEntity[A] =
     Map("application/json" -> MediaType(None))

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -10,7 +10,7 @@ import endpoints.openapi.model.{MediaType, Schema}
   */
 trait JsonSchemaEntities
   extends algebra.JsonSchemaEntities
-    with Endpoints
+    with EndpointsWithCustomErrors
     with JsonSchemas {
 
   import DocumentedJsonSchema._

--- a/openapi/openapi/src/main/scala/endpoints/openapi/MuxEndpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/MuxEndpoints.scala
@@ -6,7 +6,7 @@ import endpoints.algebra
 /**
   * @group interpreters
   */
-trait MuxEndpoints extends algebra.MuxEndpoints with Endpoints {
+trait MuxEndpoints extends algebra.MuxEndpoints with EndpointsWithCustomErrors {
 
   type MuxEndpoint[Req <: MuxRequest, Resp, Transport] = DocumentedEndpoint
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
@@ -11,7 +11,7 @@ import endpoints.openapi.model.MediaType
   */
 trait Responses
   extends algebra.Responses
-  with StatusCodes {
+  with StatusCodes { this: algebra.Errors =>
 
   type ResponseEntity[A] = Map[String, MediaType]
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
@@ -20,7 +20,7 @@ trait Responses
   /**
     * @param status Response status code (e.g. OK or NotFound)
     * @param documentation Human readable documentation. Not optional because its required by openapi
-    * @param content Map that associates each possible content-type (e.g. “text/html”) with a [[MediaType]] description
+    * @param content Map that associates each possible content-type (e.g. “text/html”) with a `MediaType` description
     */
   case class DocumentedResponse(status: StatusCode, documentation: String, content: Map[String, MediaType])
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/StatusCodes.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/StatusCodes.scala
@@ -21,5 +21,6 @@ trait StatusCodes extends endpoints.algebra.StatusCodes {
   def NotFound = 404
 
   def InternalServerError = 500
+  def NotImplemented = 501
 
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -54,6 +54,26 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |    "/books" : {
         |      "get" : {
         |        "responses" : {
+        |          "400" : {
+        |            "description" : "Client error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
+        |          "500" : {
+        |            "description" : "Server error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
         |          "200" : {
         |            "description" : "Books list",
         |            "content" : {
@@ -84,6 +104,26 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |          "description" : "Books list"
         |        },
         |        "responses" : {
+        |          "400" : {
+        |            "description" : "Client error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
+        |          "500" : {
+        |            "description" : "Server error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
         |          "200" : {
         |            "description" : ""
         |          },
@@ -105,6 +145,28 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |  },
         |  "components" : {
         |    "schemas" : {
+        |      "endpoints.openapi.ReferencedSchemaTest.Storage.Online" : {
+        |        "allOf" : [
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
+        |          },
+        |          {
+        |            "type" : "object",
+        |            "properties" : {
+        |              "storageType" : {
+        |                "type" : "string"
+        |              },
+        |              "link" : {
+        |                "type" : "string"
+        |              }
+        |            },
+        |            "required" : [
+        |              "storageType",
+        |              "link"
+        |            ]
+        |          }
+        |        ]
+        |      },
         |      "endpoints.openapi.ReferencedSchemaTest.Book" : {
         |        "type" : "object",
         |        "properties" : {
@@ -162,6 +224,12 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |          }
         |        }
         |      },
+        |      "endpoints.Errors" : {
+        |        "type" : "array",
+        |        "items" : {
+        |          "type" : "string"
+        |        }
+        |      },
         |      "endpoints.openapi.ReferencedSchemaTest.Storage.Library" : {
         |        "allOf" : [
         |          {
@@ -188,28 +256,6 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |            ]
         |          }
         |        ]
-        |      },
-        |      "endpoints.openapi.ReferencedSchemaTest.Storage.Online" : {
-        |        "allOf" : [
-        |          {
-        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
-        |          },
-        |          {
-        |            "type" : "object",
-        |            "properties" : {
-        |              "storageType" : {
-        |                "type" : "string"
-        |              },
-        |              "link" : {
-        |                "type" : "string"
-        |              }
-        |            },
-        |            "required" : [
-        |              "storageType",
-        |              "link"
-        |            ]
-        |          }
-        |        ]
         |      }
         |    },
         |    "securitySchemes" : {
@@ -227,8 +273,9 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
       object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.circe.JsonSchemas
       import OpenApiEncoder.JsonSchema._
       import io.circe.syntax._
+      import io.circe.parser.parse
 
-      Fixtures.openApiDocument.asJson.spaces2 shouldBe expectedSchema
+      Fixtures.openApiDocument.asJson shouldBe parse(expectedSchema).right.get
     }
 
     "produce referenced schema with playjson" in {

--- a/play/client/src/main/scala/endpoints/play/client/BasicAuthentication.scala
+++ b/play/client/src/main/scala/endpoints/play/client/BasicAuthentication.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSAuthScheme
 /**
   * @group interpreters
   */
-trait BasicAuthentication extends algebra.BasicAuthentication { self: Endpoints =>
+trait BasicAuthentication extends algebra.BasicAuthentication { self: EndpointsWithCustomErrors =>
 
   private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
     method: Method,

--- a/play/client/src/main/scala/endpoints/play/client/BuiltInErrors.scala
+++ b/play/client/src/main/scala/endpoints/play/client/BuiltInErrors.scala
@@ -1,0 +1,14 @@
+package endpoints.play.client
+
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] =
+    wsResp => invalidCodec.decode(wsResp.body).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    mapResponseEntity(clientErrorsResponseEntity)(invalid => new Throwable(invalid.errors.mkString(". ")))
+
+}

--- a/play/client/src/main/scala/endpoints/play/client/JsonEntitiesFromCodec.scala
+++ b/play/client/src/main/scala/endpoints/play/client/JsonEntitiesFromCodec.scala
@@ -10,7 +10,7 @@ import play.api.libs.ws.{BodyWritable, InMemoryBody}
   *
   * @group interpreters
   */
-trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
+trait JsonEntitiesFromCodec extends EndpointsWithCustomErrors with endpoints.algebra.JsonEntitiesFromCodec {
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, wsRequest) =>
     val playCodec: play.api.mvc.Codec = implicitly[play.api.mvc.Codec]

--- a/play/client/src/main/scala/endpoints/play/client/StatusCodes.scala
+++ b/play/client/src/main/scala/endpoints/play/client/StatusCodes.scala
@@ -17,5 +17,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = 404
 
   def InternalServerError = 500
+  def NotImplemented = 501
 
 }

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
@@ -1,7 +1,7 @@
 package endpoints.play.server.circe
 
 import endpoints.{Invalid, algebra}
-import endpoints.play.server.Endpoints
+import endpoints.play.server.EndpointsWithCustomErrors
 import io.circe.{DecodingFailure, Json, ParsingFailure, parser, Decoder => CirceDecoder, Encoder => CirceEncoder}
 import Util.circeJsonWriteable
 import cats.Show
@@ -12,7 +12,7 @@ import play.api.http.Writeable
   * JSON entities in HTTP requests, and circe’s [[io.circe.Encoder]] to build JSON entities
   * in HTTP responses.
   */
-trait JsonEntities extends Endpoints with algebra.JsonEntities {
+trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
 
   import playComponents.executionContext
 

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonSchemaEntities.scala
@@ -2,7 +2,7 @@ package endpoints.play.server.circe
 
 import cats.Show
 import endpoints.{Invalid, algebra}
-import endpoints.play.server.Endpoints
+import endpoints.play.server.EndpointsWithCustomErrors
 import endpoints.play.server.circe.Util.circeJsonWriteable
 import io.circe.{DecodingFailure, Json, ParsingFailure, parser}
 import play.api.http.Writeable
@@ -12,7 +12,7 @@ import play.api.http.Writeable
   * JSON entities in HTTP requests, and circe’s [[io.circe.Encoder]] to build JSON entities
   * in HTTP responses.
   */
-trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.circe.JsonSchemas {
+trait JsonSchemaEntities extends EndpointsWithCustomErrors with algebra.JsonSchemaEntities with endpoints.circe.JsonSchemas {
 
   import playComponents.executionContext
 

--- a/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
+++ b/play/server-playjson/src/main/scala/endpoints/play/server/playjson/JsonSchemaEntities.scala
@@ -1,7 +1,7 @@
 package endpoints.play.server.playjson
 
 import endpoints.{Invalid, algebra}
-import endpoints.play.server.Endpoints
+import endpoints.play.server.EndpointsWithCustomErrors
 import play.api.http.Writeable
 import play.api.libs.json.{JsPath, JsValue, Json, JsonValidationError}
 
@@ -11,7 +11,7 @@ import scala.util.Try
   * Interpreter for [[algebra.JsonSchemaEntities]] that uses Play JSON [[play.api.libs.json.Reads]] to decode
   * JSON entities in HTTP requests, and [[play.api.libs.json.Writes]] to build JSON entities in HTTP responses.
   */
-trait JsonSchemaEntities extends Endpoints with algebra.JsonSchemaEntities with endpoints.playjson.JsonSchemas {
+trait JsonSchemaEntities extends EndpointsWithCustomErrors with algebra.JsonSchemaEntities with endpoints.playjson.JsonSchemas {
 
   import playComponents.executionContext
 

--- a/play/server/src/main/scala/endpoints/play/StatusCodes.scala
+++ b/play/server/src/main/scala/endpoints/play/StatusCodes.scala
@@ -19,5 +19,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = Results.NotFound
 
   def InternalServerError = Results.InternalServerError
+  def NotImplemented = Results.NotImplemented
 
 }

--- a/play/server/src/main/scala/endpoints/play/server/Assets.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Assets.scala
@@ -13,7 +13,7 @@ import play.mvc.Http.HeaderNames
   *
   * @group interpreters
   */
-trait Assets extends algebra.Assets with Endpoints {
+trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
 
   /**
     * @param assetPath Path of the requested asset

--- a/play/server/src/main/scala/endpoints/play/server/BasicAuthentication.scala
+++ b/play/server/src/main/scala/endpoints/play/server/BasicAuthentication.scala
@@ -13,7 +13,7 @@ import play.api.mvc.{BodyParser, Results}
 /**
   * @group interpreters
   */
-trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
+trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWithCustomErrors {
 
   import playComponents.executionContext
 

--- a/play/server/src/main/scala/endpoints/play/server/BuiltInErrors.scala
+++ b/play/server/src/main/scala/endpoints/play/server/BuiltInErrors.scala
@@ -1,0 +1,17 @@
+package endpoints.play.server
+
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+import play.api.http.{ContentTypes, Writeable}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] = {
+    val playCodec = implicitly[play.api.mvc.Codec]
+    Writeable(invalid => playCodec.encode(invalidCodec.encode(invalid)), Some(ContentTypes.JSON))
+  }
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    clientErrorsResponseEntity.map(throwable => Invalid(throwable.getMessage))
+
+}

--- a/play/server/src/main/scala/endpoints/play/server/JsonEntitiesFromCodec.scala
+++ b/play/server/src/main/scala/endpoints/play/server/JsonEntitiesFromCodec.scala
@@ -10,7 +10,7 @@ import play.api.http.{ContentTypes, Writeable}
   *
   * @group interpreters
   */
-trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
+trait JsonEntitiesFromCodec extends EndpointsWithCustomErrors with endpoints.algebra.JsonEntitiesFromCodec {
 
   import playComponents.executionContext
 

--- a/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
@@ -18,7 +18,7 @@ trait LowLevelEndpoints extends algebra.LowLevelEndpoints with Endpoints {
       accumulator.map(_.right.map(anyContent => Request(requestHeader, anyContent)))
     }
 
-  /** An HTTP response is a Play [[Result]] */
+  /** An HTTP response is a Play `Result` */
   type RawResponseEntity = Result
 
   lazy val rawResponseEntity: Result => Result = identity

--- a/play/server/src/main/scala/endpoints/play/server/Urls.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Urls.scala
@@ -6,7 +6,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import endpoints.{Invalid, PartialInvariantFunctor, Tupler, Valid, Validated, algebra}
 import endpoints.algebra.Documentation
 import play.api.libs.functional.{Applicative, Functor}
-import play.api.mvc.{RequestHeader, Result, Results}
+import play.api.mvc.{RequestHeader, Result}
 
 import scala.collection.compat._
 import scala.collection.mutable
@@ -17,7 +17,7 @@ import scala.language.higherKinds
   *
   * @group interpreters
   */
-trait Urls extends algebra.Urls {
+trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
 
   val utf8Name = UTF_8.name()
 
@@ -317,12 +317,12 @@ trait Urls extends algebra.Urls {
   /**
     * This method is called by ''endpoints'' when decoding a request failed.
     *
-    * The default implementation is to return a Bad Request (400) response
-    * containing the error messages as a JSON array of string values.
+    * The provided implementation calls [[clientErrorsResponse]] to construct
+    * a response containing the errors.
     *
     * This method can be overridden to customize the error reporting logic.
     */
   def handleClientErrors(invalid: Invalid): Result =
-    Results.BadRequest(Endpoints.invalidJsonEncoder.writes(invalid))
+    clientErrorsResponse(invalidToClientErrors(invalid))
 
 }

--- a/play/server/src/main/scala/endpoints/play/server/Urls.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Urls.scala
@@ -24,7 +24,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
   /**
     * Convenient type alias modeling the extraction of an `A` information from request headers.
     *
-    * This type has an instance of [[Applicative]].
+    * This type has an instance of `Applicative`.
     */
   // No Kleisli in play-functional…
   type RequestExtractor[A] = RequestHeader => Option[A]
@@ -317,7 +317,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
   /**
     * This method is called by ''endpoints'' when decoding a request failed.
     *
-    * The provided implementation calls [[clientErrorsResponse]] to construct
+    * The provided implementation calls `clientErrorsResponse` to construct
     * a response containing the errors.
     *
     * This method can be overridden to customize the error reporting logic.

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BasicAuthentication.scala
@@ -9,7 +9,7 @@ import endpoints.algebra.Documentation
 /**
   * @group interpreters
   */
-trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
+trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWithCustomErrors {
 
   private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
     method: Method,

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BuiltInErrors.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BuiltInErrors.scala
@@ -1,0 +1,14 @@
+package endpoints.scalaj.client
+
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] =
+    resp => invalidCodec.decode(resp).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    resp => clientErrorsResponseEntity(resp).right.map(invalid => new Throwable(invalid.errors.mkString(". ")))
+
+}

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/JsonEntitiesFromCodec.scala
@@ -7,7 +7,7 @@ import endpoints.algebra.Codec
   *
   * @group interpreters
   */
-trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
+trait JsonEntitiesFromCodec extends EndpointsWithCustomErrors with endpoints.algebra.JsonEntitiesFromCodec {
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = (data, request) => {
     request.header("Content-Type", "application/json")

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
@@ -7,7 +7,7 @@ import endpoints.algebra.Documentation
 /**
   * @group interpreters
   */
-trait Responses extends algebra.Responses with StatusCodes {
+trait Responses extends algebra.Responses with StatusCodes { this: algebra.Errors =>
 
   type Response[A] = HttpResponse[String] => Option[ResponseEntity[A]]
 

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/StatusCodes.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/StatusCodes.scala
@@ -17,5 +17,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = 404
 
   def InternalServerError = 500
+  def NotImplemented = 501
 
 }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/BasicAuthentication.scala
@@ -9,7 +9,7 @@ import scala.language.higherKinds
 /**
   * @group interpreters
   */
-trait BasicAuthentication[R[_]] extends algebra.BasicAuthentication { self: Endpoints[R] =>
+trait BasicAuthentication[R[_]] extends algebra.BasicAuthentication { self: EndpointsWithCustomErrors[R] =>
 
   private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
     method: Method,

--- a/sttp/client/src/main/scala/endpoints/sttp/client/BuiltInErrors.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/BuiltInErrors.scala
@@ -1,0 +1,15 @@
+package endpoints.sttp.client
+
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+
+import scala.language.higherKinds
+
+trait BuiltInErrors[R[_]] extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors[R] =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] = stringCodecResponse(invalidCodec)
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    mapResponseEntity(clientErrorsResponseEntity)(invalid => new Throwable(invalid.errors.mkString(". ")))
+
+}

--- a/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
@@ -9,23 +9,12 @@ import scala.language.higherKinds
   * Interpreter for [[endpoints.algebra.JsonEntitiesFromCodec]] that encodes JSON request
   * @group interpreters
   */
-trait JsonEntitiesFromCodec[R[_]] extends endpoints.algebra.JsonEntitiesFromCodec { self: Endpoints[R] =>
+trait JsonEntitiesFromCodec[R[_]] extends endpoints.algebra.JsonEntitiesFromCodec { self: EndpointsWithCustomErrors[R] =>
 
   def jsonRequest[A](implicit codec: Codec[String, A]): RequestEntity[A] = { (a, req) =>
     req.body(codec.encode(a)).contentType("application/json")
   }
 
-  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = new ResponseEntity[A] {
-    def decodeEntity(response: sttp.Response[String]): R[A] = {
-      response.body
-        .left.map(new Throwable(_))
-        .right.flatMap { entity =>
-        codec.decode(entity).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
-      } match {
-        case Right(a)        => backend.responseMonad.unit(a)
-        case Left(exception) => backend.responseMonad.error(exception)
-      }
-    }
-  }
+  def jsonResponse[A](implicit codec: Codec[String, A]): ResponseEntity[A] = stringCodecResponse
 
 }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/JsonEntitiesFromCodec.scala
@@ -1,7 +1,6 @@
 package endpoints.sttp.client
 
 import endpoints.algebra.Codec
-import com.softwaremill.sttp
 
 import scala.language.higherKinds
 

--- a/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/MuxEndpoints.scala
@@ -9,7 +9,7 @@ import scala.language.higherKinds
 /**
   * @group interpreters
   */
-trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: Endpoints[R] =>
+trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: EndpointsWithCustomErrors[R] =>
 
   class MuxEndpoint[Req <: algebra.MuxRequest, Resp, Transport](request: Request[Transport], response: Response[Transport]) {
 
@@ -17,15 +17,11 @@ trait MuxEndpoints[R[_]] extends algebra.Endpoints { self: Endpoints[R] =>
       val sttpRequest: sttp.Request[String, Nothing] = request(encoder.encode(req)).response(sttp.asString)
       val result = self.backend.send(sttpRequest)
       self.backend.responseMonad.flatMap(result) { res =>
-        response.decodeResponse(res) match {
-          case None => self.backend.responseMonad.error(new Throwable(s"Unexpected response status: ${res.code}"))
-          case Some(transportR) =>
-            self.backend.responseMonad.flatMap(transportR) { transport =>
-              decoder.decode(transport) match {
-                case Valid(r)        => self.backend.responseMonad.unit(r.asInstanceOf[req.Response])
-                case Invalid(errors) => self.backend.responseMonad.error(new Exception(errors.mkString(". ")))
-              }
-            }
+        self.backend.responseMonad.flatMap(decodeResponse(response, res)) { transport =>
+          decoder.decode(transport) match {
+            case Valid(r)        => self.backend.responseMonad.unit(r.asInstanceOf[req.Response])
+            case Invalid(errors) => self.backend.responseMonad.error(new Exception(errors.mkString(". ")))
+          }
         }
       }
     }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/StatusCodes.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/StatusCodes.scala
@@ -17,5 +17,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = 404
 
   def InternalServerError = 500
+  def NotImplemented = 501
 
 }

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
@@ -1,7 +1,7 @@
 package endpoints.xhr.circe
 
 import endpoints.algebra
-import endpoints.xhr.Endpoints
+import endpoints.xhr.EndpointsWithCustomErrors
 import io.circe.{parser, Decoder => CirceDecoder, Encoder => CirceEncoder}
 import org.scalajs.dom.XMLHttpRequest
 
@@ -10,7 +10,7 @@ import org.scalajs.dom.XMLHttpRequest
   * entities in HTTP requests, and circe’s [[io.circe.Decoder]] to decode JSON entities from
   * HTTP responses.
   */
-trait JsonEntities extends Endpoints with algebra.JsonEntities {
+trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
 
   /** Encode an `A` using circe’s [[io.circe.Encoder]] */
   type JsonRequest[A] = CirceEncoder[A]

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonSchemaEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonSchemaEntities.scala
@@ -8,7 +8,7 @@ import org.scalajs.dom.XMLHttpRequest
   * Interpreter for `JsonSchemaEntities` that uses the circe `JsonSchemas` interpreter.
   */
 trait JsonSchemaEntities
-  extends xhr.Endpoints
+  extends xhr.EndpointsWithCustomErrors
     with algebra.JsonSchemaEntities
     with circe.JsonSchemas {
 

--- a/xhr/client-faithful/src/main/scala/endpoints/xhr/faithful/Endpoints.scala
+++ b/xhr/client-faithful/src/main/scala/endpoints/xhr/faithful/Endpoints.scala
@@ -11,7 +11,7 @@ import faithful.{Future, Promise}
   */
 trait Endpoints extends xhr.Endpoints {
 
-  /** Maps `Result` to [[Future]] */
+  /** Maps `Result` to `Future` */
   type Result[A] = Future[A]
 
   def endpoint[A, B](

--- a/xhr/client/src/main/scala/endpoints/xhr/Assets.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Assets.scala
@@ -12,7 +12,7 @@ import scala.scalajs.js.typedarray.ArrayBuffer
   *
   * @group interpreters
   */
-trait Assets extends algebra.Assets with Endpoints {
+trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
 
   /**
     * As a client, we just need to give the path of the asset we are interested in, the web browser will

--- a/xhr/client/src/main/scala/endpoints/xhr/BasicAuthentication.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/BasicAuthentication.scala
@@ -8,7 +8,7 @@ import org.scalajs.dom.window.btoa
 /**
   * @group interpreters
   */
-trait BasicAuthentication extends algebra.BasicAuthentication with Endpoints {
+trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWithCustomErrors {
 
   private[endpoints] def authenticatedRequest[U, E, H, UE, HCred, Out](
     method: Method,

--- a/xhr/client/src/main/scala/endpoints/xhr/BuiltInErrors.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/BuiltInErrors.scala
@@ -1,0 +1,14 @@
+package endpoints.xhr
+
+import endpoints.algebra.InvalidCodec.invalidCodec
+import endpoints.{Invalid, algebra}
+
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] =
+    stringCodecResponse(invalidCodec)
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    mapResponseEntity(clientErrorsResponseEntity)(invalid => new Throwable(invalid.errors.mkString(". ")))
+
+}

--- a/xhr/client/src/main/scala/endpoints/xhr/JsonEntitiesFromCodec.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/JsonEntitiesFromCodec.scala
@@ -9,15 +9,13 @@ import org.scalajs.dom.XMLHttpRequest
   *
   * @group interpreters
   */
-trait JsonEntitiesFromCodec extends Endpoints with endpoints.algebra.JsonEntitiesFromCodec {
+trait JsonEntitiesFromCodec extends EndpointsWithCustomErrors with endpoints.algebra.JsonEntitiesFromCodec {
 
   def jsonRequest[A](implicit codec: Codec[String, A]) = (a: A, xhr: XMLHttpRequest) => {
     xhr.setRequestHeader("Content-Type", "application/json")
     codec.encode(a)
   }
 
-  def jsonResponse[A](implicit codec: Codec[String, A]) =
-    (xhr: XMLHttpRequest) =>
-      codec.decode(xhr.responseText).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
+  def jsonResponse[A](implicit codec: Codec[String, A]) = stringCodecResponse
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/LowLevelEndpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/LowLevelEndpoints.scala
@@ -7,7 +7,7 @@ import scala.scalajs.js
 
 /**
   * Interpreter for [[algebra.LowLevelEndpoints]] that represents the response as a
-  * [[XMLHttpRequest]] value.
+  * `XMLHttpRequest` value.
   */
 trait LowLevelEndpoints extends algebra.LowLevelEndpoints with EndpointsWithCustomErrors {
 

--- a/xhr/client/src/main/scala/endpoints/xhr/LowLevelEndpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/LowLevelEndpoints.scala
@@ -9,7 +9,7 @@ import scala.scalajs.js
   * Interpreter for [[algebra.LowLevelEndpoints]] that represents the response as a
   * [[XMLHttpRequest]] value.
   */
-trait LowLevelEndpoints extends algebra.LowLevelEndpoints with Endpoints {
+trait LowLevelEndpoints extends algebra.LowLevelEndpoints with EndpointsWithCustomErrors {
 
   /** Represents the request entity as a function that is passed the underlying XMLHttpRequest (so this one can be modified in place) and returns the actual entity to use */
   type RawRequestEntity = js.Function1[XMLHttpRequest, js.Any]

--- a/xhr/client/src/main/scala/endpoints/xhr/MuxEndpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/MuxEndpoints.scala
@@ -7,7 +7,7 @@ import org.scalajs.dom.XMLHttpRequest
 /**
   * @group interpreters
   */
-trait MuxEndpoints extends algebra.MuxEndpoints with Endpoints {
+trait MuxEndpoints extends algebra.MuxEndpoints with EndpointsWithCustomErrors {
 
   protected final def muxPerformXhr[Req <: MuxRequest, Resp, Transport](
     request: Request[Transport],

--- a/xhr/client/src/main/scala/endpoints/xhr/StatusCodes.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/StatusCodes.scala
@@ -22,5 +22,6 @@ trait StatusCodes extends algebra.StatusCodes {
   def NotFound = 404
 
   def InternalServerError = 500
+  def NotImplemented = 501
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/future/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/future/Endpoints.scala
@@ -19,7 +19,7 @@ trait Endpoints extends xhr.Endpoints with EndpointsWithCustomErrors
   */
 trait EndpointsWithCustomErrors extends xhr.EndpointsWithCustomErrors {
 
-  /** Maps `Result` to [[Future]] */
+  /** Maps `Result` to `Future` */
   type Result[A] = Future[A]
 
   def endpoint[A, B](

--- a/xhr/client/src/main/scala/endpoints/xhr/future/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/future/Endpoints.scala
@@ -6,11 +6,18 @@ import endpoints.xhr
 import scala.concurrent.{Future, Promise}
 
 /**
-  * Implements [[xhr.Endpoints]] by using Scala’s [[Future]]s.
+  * Implements [[xhr.Endpoints]] by using Scala’s `Futures`, and uses [[endpoints.algebra.BuiltInErrors]]
+  * to model client and server errors.
   *
   * @group interpreters
   */
-trait Endpoints extends xhr.Endpoints {
+trait Endpoints extends xhr.Endpoints with EndpointsWithCustomErrors
+
+/**
+  * Implements [[xhr.Endpoints]] by using Scala’s `Future`s.
+  * @group interpreters
+  */
+trait EndpointsWithCustomErrors extends xhr.EndpointsWithCustomErrors {
 
   /** Maps `Result` to [[Future]] */
   type Result[A] = Future[A]

--- a/xhr/client/src/main/scala/endpoints/xhr/thenable/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/thenable/Endpoints.scala
@@ -6,11 +6,18 @@ import endpoints.xhr
 import scala.scalajs.js
 
 /**
-  * Implements [[xhr.Endpoints]] by using JavaScript promises.
+  * Implements [[xhr.Endpoints]] by using JavaScript promises, and
+  * [[endpoints.algebra.BuiltInErrors]] to model client and server errors.
   *
   * @group interpreters
   */
-trait Endpoints extends xhr.Endpoints {
+trait Endpoints extends xhr.Endpoints with EndpointsWithCustomErrors
+
+/**
+  * Implements [[xhr.Endpoints]] by using JavaScript promises
+  * @group interpreters
+  */
+trait EndpointsWithCustomErrors extends xhr.EndpointsWithCustomErrors {
 
   /** Maps a `Result` to a [[js.Thenable]] */
   type Result[A] = js.Thenable[A]

--- a/xhr/client/src/main/scala/endpoints/xhr/thenable/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/thenable/Endpoints.scala
@@ -19,7 +19,7 @@ trait Endpoints extends xhr.Endpoints with EndpointsWithCustomErrors
   */
 trait EndpointsWithCustomErrors extends xhr.EndpointsWithCustomErrors {
 
-  /** Maps a `Result` to a [[js.Thenable]] */
+  /** Maps a `Result` to a `js.Thenable` */
   type Result[A] = js.Thenable[A]
 
   def endpoint[A, B](request: Request[A], response: Response[B], summary: Documentation, description: Documentation, tags: List[String]): Endpoint[A, B] =

--- a/xhr/client/src/main/scala/endpoints/xhr/thenable/MuxEndpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/thenable/MuxEndpoints.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js
 /**
   * @group interpreters
   */
-trait MuxEndpoints extends xhr.MuxEndpoints with Endpoints {
+trait MuxEndpoints extends xhr.MuxEndpoints with EndpointsWithCustomErrors {
 
   class MuxEndpoint[Req <: MuxRequest, Resp, Transport](
     request: Request[Transport],


### PR DESCRIPTION
Errors produced by endpoints (ie, client errors, when decoding a request failed, or server errors, when computing the response failed) are now part of the documentation produced by the `openapi` interpreter.

Users can customize the entity format used to serialize the errors.

For the sake of consistency, the `badRequest` response constructor now necessarily has type `Response[ClientErrors]` (so that both errors produced by endpoints and errors produced by the users have the same format). By default, the `ClientErrors` type is fixed to `case class Invalid(errors: Seq[String])`, but this default is opt-out: by using `EndpointsWithCustomErrors` instead of `Endpoints`, users can fix the `ClientErrors` type to be whatever they want (as long as they provide a bidirectional transformation to `Invalid`).

Similarly, the `internalServerError` response constructor now necessarily has type `Response[ServerError]`. By default, `ServerError` is fixed to `Throwable`, and is opt-out.

Fixes #369