### PR TITLE
Support documenting webhooks

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -156,7 +156,11 @@ trait EndpointsWithCustomErrors
   type Endpoint[A, B] = A => Future[B]
   //#endpoint-type
 
-  def endpoint[A, B](request: Request[A], response: Response[B], summary: Documentation, description: Documentation, tags: List[String]): Endpoint[A, B] =
+  def endpoint[A, B](
+    request: Request[A],
+    response: Response[B],
+    docs: EndpointDocs = EndpointDocs()
+  ): Endpoint[A, B] =
     a =>
       request(a).flatMap { httpResponse =>
         decodeResponse(response, httpResponse) match {

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -127,9 +127,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
-    summary: Documentation = None,
-    description: Documentation = None,
-    tags: List[String] = Nil
+    docs: EndpointDocs = EndpointDocs()
   ): Endpoint[A, B] = Endpoint(request, response)
 
   lazy val directive1InvFunctor: InvariantFunctor[Directive1] = new InvariantFunctor[Directive1] {

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -59,9 +59,7 @@ trait BasicAuthentication extends EndpointsWithCustomErrors {
     requestHeaders: RequestHeaders[H] = emptyHeaders,
     unauthenticatedDocs: Documentation = None,
     requestDocs: Documentation = None,
-    summary: Documentation = None,
-    description: Documentation = None,
-    tags: List[String] = Nil
+    endpointDocs: EndpointDocs = EndpointDocs()
   )(implicit
     tuplerUE: Tupler.Aux[U, E, UE],
     tuplerHCred: Tupler.Aux[H, Credentials, HCred],
@@ -70,9 +68,7 @@ trait BasicAuthentication extends EndpointsWithCustomErrors {
     endpoint(
       authenticatedRequest(method, url, requestEntity, requestHeaders, requestDocs),
       authenticated(response, unauthenticatedDocs),
-      summary,
-      description,
-      tags
+      endpointDocs
     )
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
@@ -43,16 +43,43 @@ trait EndpointsWithCustomErrors extends Requests with Responses with Errors {
     *
     * @param request  Request
     * @param response Response
-    * @param summary optional summary documentation
-    * @param description optional description documentation
-    * @param tags list of OpenApi tags
+    * @param docs     Documentation (used by documentation interpreters)
     */
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
+    docs: EndpointDocs = EndpointDocs()
+  ): Endpoint[A, B]
+
+  /**
+    * @param summary     Short description
+    * @param description Detailed description
+    * @param tags        OpenAPI tags
+    * @param callbacks   Callbacks indexed by event name
+    */
+  case class EndpointDocs(
     summary: Documentation = None,
     description: Documentation = None,
-    tags: List[String] = Nil
-  ): Endpoint[A, B]
+    tags: List[String] = Nil,
+    callbacks: Map[String, CallbacksDocs] = Map.empty
+  )
+
+  /**
+    * Callbacks indexed by URL pattern
+    * @see [["Swagger Documentation" https://swagger.io/docs/specification/callbacks/]]
+    */
+  type CallbacksDocs = Map[String, CallbackDocs]
+
+  /**
+    * @param method   HTTP method used for the callback
+    * @param entity   Contents of the callback message
+    * @param response Expected response
+    */
+  case class CallbackDocs(
+    method: Method,
+    entity: RequestEntity[_],
+    response: Response[_],
+    requestDocs: Documentation = None
+  )
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
@@ -18,7 +18,7 @@ trait EndpointsDocs extends Endpoints {
   endpoint(
     get(path / "some-resource"),
     ok(textResponse),
-    description = Some("The contents of some resource")
+    docs = EndpointDocs(description = Some("The contents of some resource"))
   )
   //#with-docs
 

--- a/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
+++ b/documentation/examples/basic/shared/src/main/scala/sample/algebra/DocumentedApi.scala
@@ -31,7 +31,7 @@ trait DocumentedApi
       path / "admin",
       requestEntity = emptyRequest,
       response = ok(emptyResponse, Some("Administration page")),
-      summary = Some("Authentication endpoint")
+      endpointDocs = EndpointDocs(summary = Some("Authentication endpoint"))
     )
 
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -39,14 +39,12 @@ trait BasicAuthentication
     requestHeaders: RequestHeaders[H] = emptyHeaders,
     unauthenticatedDocs: Documentation = None,
     requestDocs: Documentation = None,
-    summary: Documentation = None,
-    description: Documentation = None,
-    tags: List[String] = Nil
+    endpointDocs: EndpointDocs = EndpointDocs()
   )(implicit
     tuplerUE: Tupler.Aux[U, E, UE],
     tuplerHCred: Tupler.Aux[H, Credentials, HCred],
     tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
   ): Endpoint[Out, Option[R]] =
-    super.authenticatedEndpoint(method, url, response, requestEntity, requestHeaders, unauthenticatedDocs, requestDocs, summary, description, tags)
+    super.authenticatedEndpoint(method, url, response, requestEntity, requestHeaders, unauthenticatedDocs, requestDocs, endpointDocs)
       .withSecurity(SecurityRequirement(basicAuthenticationSchemeName, SecurityScheme.httpBasic))
 }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
@@ -28,7 +28,8 @@ case class Operation(
   requestBody: Option[RequestBody],
   responses: Map[String, Response],
   tags: List[String],
-  security: List[SecurityRequirement]
+  security: List[SecurityRequirement],
+  callbacks: Map[String, Map[String, PathItem]]
 )
 
 case class SecurityRequirement(name: String,

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -110,13 +110,28 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
 trait Fixtures extends algebra.Endpoints {
 
-  val foo = endpoint(get(path / "foo"), ok(emptyResponse, Some("Foo response")), tags = List("foo"))
+  val foo = endpoint(
+    get(path / "foo"),
+    ok(emptyResponse, Some("Foo response")),
+    docs = EndpointDocs(tags = List("foo"))
+  )
 
-  val bar = endpoint(post(path / "foo", emptyRequest), ok(emptyResponse, Some("Bar response")), tags = List("bar", "bxx"))
+  val bar = endpoint(
+    post(path / "foo", emptyRequest),
+    ok(emptyResponse, Some("Bar response")),
+    docs = EndpointDocs(tags = List("bar", "bxx"))
+  )
 
-  val baz = endpoint(get(path / "baz" / segment[Int]("quux")), ok(emptyResponse, Some("Baz response")), tags = List("baz", "bxx"))
+  val baz = endpoint(
+    get(path / "baz" / segment[Int]("quux")),
+    ok(emptyResponse, Some("Baz response")),
+    docs = EndpointDocs(tags = List("baz", "bxx"))
+  )
 
-  val textRequestEndp = endpoint(post(path / "textRequestEndpoint", textRequest, docs = Some("Text Req")), ok(emptyResponse))
+  val textRequestEndp = endpoint(
+    post(path / "textRequestEndpoint", textRequest, docs = Some("Text Req")),
+    ok(emptyResponse)
+  )
 
   val emptySegmentNameEndp = endpoint(post(path / "emptySegmentNameEndp" / segment[Int]() / "x" / segment[String](), textRequest), ok(emptyResponse))
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -35,10 +35,11 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
     implicit private val schemaBook: JsonSchema[Book] = genericJsonSchema[Book]
 
-    val listBooks = endpoint(get(path / "books"), ok(jsonResponse[List[Book]], Some("Books list")), tags = List("Books"))
+    val listBooks = endpoint(get(path / "books"), ok(jsonResponse[List[Book]], Some("Books list")), docs = EndpointDocs(tags = List("Books")))
 
     val postBook =
-      authenticatedEndpoint(Post, path / "books", ok(emptyResponse), jsonRequest[Book], requestDocs = Some("Books list"), tags = List("Books"))
+      authenticatedEndpoint(
+        Post, path / "books", ok(emptyResponse), jsonRequest[Book], requestDocs = Some("Books list"), endpointDocs = EndpointDocs(tags = List("Books")))
   }
 
   "OpenApi" should {

--- a/openapi/openapi/src/test/scala/endpoints/openapi/WebhooksTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/WebhooksTest.scala
@@ -1,0 +1,156 @@
+package endpoints.openapi
+
+import endpoints.openapi.model.{Info, OpenApi}
+import endpoints.{algebra, openapi}
+import org.scalatest.{Matchers, WordSpec}
+
+class WebhooksTest extends WordSpec with Matchers {
+
+  case class Message(value: String)
+
+  trait Webhooks extends algebra.Endpoints with algebra.JsonSchemaEntities {
+
+    implicit lazy val messageSchema: JsonSchema[Message] =
+      named(field[String]("message"), "webhook.Message")
+        .xmap(Message(_))(_.value)
+
+    val subscribe: Endpoint[String, Unit] = endpoint(
+      post(path / "subscribe" /? qs[String]("callbackURL"), emptyRequest),
+      ok(emptyResponse),
+      docs = EndpointDocs(
+        callbacks = Map(
+          "message" -> Map(
+            "{$request.query.callbackURL}" -> CallbackDocs(
+              Post,
+              jsonRequest[Message],
+              ok(emptyResponse)
+            )
+          )
+        )
+      )
+    )
+
+  }
+
+  object WebhooksDocumentation extends Webhooks with openapi.Endpoints with openapi.JsonSchemaEntities {
+
+    val api: OpenApi = openApi(
+      Info(title = "Example of API using callbacks", version = "0.0.0")
+    )(subscribe)
+
+  }
+
+  "Callbacks" should {
+
+    val expectedSchema =
+      """{
+        |  "openapi" : "3.0.0",
+        |  "info" : {
+        |    "title" : "Example of API using callbacks",
+        |    "version" : "0.0.0"
+        |  },
+        |  "paths" : {
+        |    "/subscribe" : {
+        |      "post" : {
+        |        "parameters" : [
+        |          {
+        |            "name" : "callbackURL",
+        |            "in" : "query",
+        |            "schema" : {
+        |              "type" : "string"
+        |            },
+        |            "required" : true
+        |          }
+        |        ],
+        |        "responses" : {
+        |          "400" : {
+        |            "description" : "Client error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
+        |          "500" : {
+        |            "description" : "Server error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
+        |          "200" : {
+        |            "description" : ""
+        |          }
+        |        },
+        |        "callbacks" : {
+        |          "message" : {
+        |            "{$request.query.callbackURL}" : {
+        |              "post" : {
+        |                "requestBody" : {
+        |                  "content" : {
+        |                    "application/json" : {
+        |                      "schema" : {
+        |                        "$ref" : "#/components/schemas/webhook.Message"
+        |                      }
+        |                    }
+        |                  }
+        |                },
+        |                "responses" : {
+        |                  "200" : {
+        |                    "description" : ""
+        |                  }
+        |                }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  },
+        |  "components" : {
+        |    "schemas" : {
+        |      "endpoints.Errors" : {
+        |        "type" : "array",
+        |        "items" : {
+        |          "type" : "string"
+        |        }
+        |      },
+        |      "webhook.Message" : {
+        |        "type" : "object",
+        |        "properties" : {
+        |          "message" : {
+        |            "type" : "string"
+        |          }
+        |        },
+        |        "required" : ["message"]
+        |      }
+        |    },
+        |    "securitySchemes" : {}
+        |  }
+        |}""".stripMargin
+
+    "be documented with circe" in {
+      object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.circe.JsonSchemas
+      import OpenApiEncoder.JsonSchema._
+      import io.circe.syntax._
+      import io.circe.parser.parse
+
+      WebhooksDocumentation.api.asJson shouldBe parse(expectedSchema).right.get
+    }
+
+    "be documented with playjson" in {
+      object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.playjson.JsonSchemas
+      import OpenApiEncoder.JsonSchema._
+      import play.api.libs.json.Json
+
+      Json.toJson(WebhooksDocumentation.api) shouldBe Json.parse(expectedSchema)
+    }
+
+  }
+
+}

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -145,9 +145,7 @@ trait EndpointsWithCustomErrors
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
-    summary: Documentation,
-    description: Documentation,
-    tags: List[String]
+    docs: EndpointDocs = EndpointDocs()
   ): Endpoint[A, B] =
     a =>
       request(a).flatMap { wsResp =>

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -303,9 +303,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
-    summary: Documentation,
-    description: Documentation,
-    tags: List[String]
+    docs: EndpointDocs = EndpointDocs()
   ): Endpoint[A, B] =
     Endpoint(request, response)
 

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
@@ -1,7 +1,6 @@
 package endpoints.scalaj.client
 
 import endpoints.algebra
-import endpoints.algebra.Documentation
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,9 +17,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with R
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
-    summary: Documentation,
-    description: Documentation,
-    tags: List[String]
+    docs: EndpointDocs = EndpointDocs()
   ): Endpoint[A, B] = {
     Endpoint(request, response)
   }

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -175,7 +175,11 @@ trait EndpointsWithCustomErrors[R[_]] extends algebra.EndpointsWithCustomErrors
   type Endpoint[A, B] = A => R[B]
   //#endpoint-type
 
-  def endpoint[A, B](request: Request[A], response: Response[B], summary: Documentation, description: Documentation, tags: List[String]): Endpoint[A, B] =
+  def endpoint[A, B](
+    request: Request[A],
+    response: Response[B],
+    docs: EndpointDocs = EndpointDocs()
+  ): Endpoint[A, B] =
     a => {
       val req: sttp.Request[String, Nothing] = request(a).response(sttp.asString)
       val result = backend.send(req)

--- a/xhr/client-faithful/src/main/scala/endpoints/xhr/faithful/Endpoints.scala
+++ b/xhr/client-faithful/src/main/scala/endpoints/xhr/faithful/Endpoints.scala
@@ -1,6 +1,5 @@
 package endpoints.xhr.faithful
 
-import endpoints.algebra.Documentation
 import endpoints.xhr
 import faithful.{Future, Promise}
 
@@ -17,9 +16,7 @@ trait Endpoints extends xhr.Endpoints {
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
-    summary: Documentation,
-    description: Documentation,
-    tags: List[String]
+    docs: EndpointDocs = EndpointDocs()
   ): Endpoint[A, B] =
     new Endpoint[A, B](request) {
       def apply(a: A) = {

--- a/xhr/client/src/main/scala/endpoints/xhr/future/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/future/Endpoints.scala
@@ -1,6 +1,5 @@
 package endpoints.xhr.future
 
-import endpoints.algebra.Documentation
 import endpoints.xhr
 
 import scala.concurrent.{Future, Promise}
@@ -25,9 +24,7 @@ trait EndpointsWithCustomErrors extends xhr.EndpointsWithCustomErrors {
   def endpoint[A, B](
     request: Request[A],
     response: Response[B],
-    summary: Documentation,
-    description: Documentation,
-    tags: List[String]
+    docs: EndpointDocs = EndpointDocs()
   ): Endpoint[A, B] =
     new Endpoint[A, B](request) {
       def apply(a: A) = {

--- a/xhr/client/src/main/scala/endpoints/xhr/thenable/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/thenable/Endpoints.scala
@@ -1,6 +1,5 @@
 package endpoints.xhr.thenable
 
-import endpoints.algebra.Documentation
 import endpoints.xhr
 
 import scala.scalajs.js
@@ -22,7 +21,11 @@ trait EndpointsWithCustomErrors extends xhr.EndpointsWithCustomErrors {
   /** Maps a `Result` to a `js.Thenable` */
   type Result[A] = js.Thenable[A]
 
-  def endpoint[A, B](request: Request[A], response: Response[B], summary: Documentation, description: Documentation, tags: List[String]): Endpoint[A, B] =
+  def endpoint[A, B](
+    request: Request[A],
+    response: Response[B],
+    docs: EndpointDocs = EndpointDocs()
+  ): Endpoint[A, B] =
     new Endpoint[A, B](request) {
       def apply(a: A) =
         new js.Promise[B]((resolve, error) => {


### PR DESCRIPTION
Also group together all documentation related parameters of the `endpoint` constructor in single case class `EndpointDocumentation`

Fixes #385