### PR TITLE
Remove `namedGenericJsonSchema` and introduce `genericRecord` and `genericTagged`

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -89,9 +89,11 @@ trait JsonSchemas
     )
   }
 
-  def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
+  def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
+  def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = schema
+  def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
 
-  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] = {
+  private def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] = {
     // The schema won’t be evaluated until its `encoder` or `decoder` is effectively used
     lazy val evaluatedSchema = schema
     new JsonSchema[A] {
@@ -99,6 +101,9 @@ trait JsonSchemas
       def decoder: Decoder[A] = Decoder.instance(c => evaluatedSchema.decoder(c))
     }
   }
+
+  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] = lazySchema(schema, name)
+  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] = lazySchema(schema, name)
 
   def emptyRecord: Record[Unit] =
     Record(

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -44,9 +44,9 @@ class JsonSchemasTest extends FreeSpec {
 
   "recursive type" in {
     val json = Json.obj("next" -> Json.obj("next" -> Json.obj()))
-    val rec = JsonSchemasCodec.Rec(Some(JsonSchemasCodec.Rec(Some(JsonSchemasCodec.Rec(None)))))
-    assert(JsonSchemasCodec.recSchema.decoder.decodeJson(json).right.exists(_ == rec))
-    assert(JsonSchemasCodec.recSchema.encoder(rec) == json)
+    val rec = JsonSchemasCodec.Recursive(Some(JsonSchemasCodec.Recursive(Some(JsonSchemasCodec.Recursive(None)))))
+    assert(JsonSchemasCodec.recursiveSchema.decoder.decodeJson(json).right.exists(_ == rec))
+    assert(JsonSchemasCodec.recursiveSchema.encoder(rec) == json)
   }
 
 }

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -51,11 +51,12 @@ class JsonSchemasTest extends FreeSpec {
       def enumeration[A](values: Seq[A])(encode: A => String)(implicit tpe: String): String =
         s"$tpe"
 
-      def named[A, S[T] <: String](schema: S[A], name: String): S[A] =
-        s"'$name'!($schema)".asInstanceOf[S[A]]
+      def namedRecord[A](schema: Record[A], name: String): Record[A] = s"'$name'!($schema)"
+      def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = s"'$name'!($schema)"
+      def namedEnum[A](schema: Enum[A], name: String): Enum[A] = s"'$name'!($schema)"
 
-      def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] =
-        s"=>'$name'!($schema)"
+      def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] = s"=>'$name'!($schema)"
+      def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] = s"=>'$name'!($schema)"
 
       def emptyRecord: String =
         "%"
@@ -115,12 +116,12 @@ class JsonSchemasTest extends FreeSpec {
   val ns = "endpoints.generic.JsonSchemasTest.GenericSchemas"
 
   "case class" in {
-    val expectedSchema = s"'$ns.Foo'!('$ns.Foo'!(bar:string,baz:integer,qux:boolean?,%))"
+    val expectedSchema = s"'$ns.Foo'!(bar:string,baz:integer,qux:boolean?,%)"
     assert(FakeAlgebraJsonSchemas.Foo.schema == expectedSchema)
   }
 
   "sealed trait" in {
-    val expectedSchema = s"'$ns.Quux'!('$ns.Quux'!(${
+    val expectedSchema = s"'$ns.Quux'!(${
       List(
         s"'$ns.QuuxA'!(ss:[string],%)@QuuxA",
         s"'$ns.QuuxB'!(i:integer,%)@QuuxB",
@@ -128,18 +129,18 @@ class JsonSchemasTest extends FreeSpec {
         s"'$ns.QuuxD'!(%)@QuuxD",
         s"'$ns.QuuxE'!(%)@QuuxE"
       ).mkString("|")
-    }))"
+    })"
     assert(FakeAlgebraJsonSchemas.Quux.schema == expectedSchema)
   }
 
   "documentations" in {
-    val expectedSchema = s"'$ns.Doc'!('$ns.Doc'!(${
+    val expectedSchema = s"'$ns.Doc'!(${
       List(
         s"'$ns.DocA'!(i:integer{fieldDocI},%)@DocA",
         s"'$ns.DocB'!(a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%)@DocB",
         s"'$ns.DocC'!(%)@DocC"
       ).mkString("|")
-    }))"
+    })"
     assert(FakeAlgebraJsonSchemas.Doc.schema == expectedSchema)
   }
 

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -59,10 +59,11 @@ trait JsonSchemas
     )
   }
 
+  def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
+  def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = schema
+  def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
 
-  def named[A, S[T] <: JsonSchema[T]](schema: S[A], name: String): S[A] = schema
-
-  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] = {
+  private def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] = {
     // The schema won’t be evaluated until its `reads` or `writes` is effectively used
     lazy val evaluatedSchema = schema
     new JsonSchema[A] {
@@ -71,7 +72,10 @@ trait JsonSchemas
     }
   }
 
-  def emptyRecord: Record[Unit] =
+  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] = lazySchema(schema, name)
+  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] = lazySchema(schema, name)
+
+    def emptyRecord: Record[Unit] =
     Record(
       new Reads[Unit] {
         override def reads(json: JsValue): JsResult[Unit] = json match {

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -341,9 +341,9 @@ class JsonSchemasTest extends FreeSpec {
 
   "recursive type" in {
     testRoundtrip(
-      recSchema,
+      recursiveSchema,
       Json.obj("next" -> Json.obj("next" -> Json.obj())),
-      Rec(Some(Rec(Some(Rec(None)))))
+      Recursive(Some(Recursive(Some(Recursive(None)))))
     )
   }
 

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
@@ -61,11 +61,11 @@ trait JsonSchemasDocs extends JsonSchemas {
   }
 
   //#recursive
-  case class Rec(next: Option[Rec])
+  case class Recursive(next: Option[Recursive])
 
-  val recSchema: JsonSchema[Rec] = (
-    optField("next")(lazySchema(recSchema, "Rec"))
-  ).xmap(Rec)(_.next)
+  val recursiveSchema: Record[Recursive] = (
+    optField("next")(lazyRecord(recursiveSchema, "Rec"))
+  ).xmap(Recursive)(_.next)
   //#recursive
 
 }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -64,13 +64,13 @@ trait JsonSchemasTest extends JsonSchemas {
     case object Green extends Color
     case object Blue extends Color
 
-    val colorSchema: Enum[Color] = enumeration[Color](Seq(Red, Blue))(_.toString)
+    val colorSchema: Enum[Color] = enumeration[Color](Seq(Red, Blue))(_.toString).named("Color")
   }
 
-  case class Rec(next: Option[Rec])
-  val recSchema: JsonSchema[Rec] = (
-    optField("next")(lazySchema(recSchema, "Rec"))
-  ).xmap(Rec)(_.next)
+  case class Recursive(next: Option[Recursive])
+  val recursiveSchema: Record[Recursive] = (
+    optField("next")(lazyRecord(recursiveSchema, "Rec"))
+  ).xmap(Recursive)(_.next)
 
   val intDictionary: JsonSchema[Map[String, Int]] = mapJsonSchema[Int]
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -38,7 +38,10 @@ trait JsonSchemaEntities
         Schema.Primitive(name, format, None)
       case Array(elementType) =>
         Schema.Array(toSchema(elementType, coprodBase, referencedSchemas), None)
-      case DocumentedEnum(elementType, values) =>
+      case DocumentedEnum(elementType, values, Some(name)) =>
+        if (referencedSchemas(name)) Schema.Reference(name, None, None)
+        else Schema.Reference(name, Some(Schema.Enum(toSchema(elementType, coprodBase, referencedSchemas + name), values, None)), None)
+      case DocumentedEnum(elementType, values, None) =>
         Schema.Enum(toSchema(elementType, coprodBase, referencedSchemas), values, None)
       case lzy: LazySchema =>
         toSchema(lzy.value, coprodBase, referencedSchemas)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApiSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApiSchemas.scala
@@ -34,10 +34,10 @@ trait OpenApiSchemas extends JsonSchemas {
     ).xmap(Info.tupled)(info => (info.title, info.version))
 
   implicit lazy val pathItemSchema: JsonSchema[PathItem] =
-    lazySchema(mapJsonSchema[Operation], "endpoints.openapi.model.Operation")
+    mapJsonSchema[Operation](lazyRecord(operationSchema, "Operation"))
       .xmap(PathItem(_))(_.operations)
 
-  implicit lazy val operationSchema: JsonSchema[Operation] = (
+  implicit lazy val operationSchema: Record[Operation] = (
     optField [String]                            ("summary")     zip
     optField [String]                            ("description") zip
     optField [List[Parameter]]                   ("parameters")  zip
@@ -114,8 +114,8 @@ trait OpenApiSchemas extends JsonSchemas {
     components => (components.schemas, components.securitySchemes)
   }
 
-  private def schemaSchemaRef: JsonSchema[Schema] = lazySchema(schemaSchema, "Schema")
-  implicit lazy val schemaSchema: JsonSchema[Schema] = (
+  private def schemaSchemaRef: JsonSchema[Schema] = lazyRecord(schemaSchema, "Schema")
+  implicit lazy val schemaSchema: Record[Schema] = (
     optField [String]              ("type")          zip
     optField [String]              ("format")        zip
     optField [Schema]              ("items")(schemaSchemaRef) zip

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -54,7 +54,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
   "Enumerations" in {
     val expectedSchema =
-      Schema.Enum(Schema.Primitive("string", None, None), "Red" :: "Blue" :: Nil, None)
+      Schema.Reference("Color", Some(Schema.Enum(Schema.Primitive("string", None, None), "Red" :: "Blue" :: Nil, None)), None)
     Fixtures.toSchema(Fixtures.Enum.colorSchema) shouldBe expectedSchema
   }
 
@@ -75,7 +75,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
         additionalProperties = None,
         description = None
       )
-    Fixtures.toSchema(Fixtures.recSchema) shouldBe expectedSchema
+    Fixtures.toSchema(Fixtures.recursiveSchema) shouldBe expectedSchema
   }
 
   "Text response" should {

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -36,14 +36,14 @@ class JsonSchemasTest extends FreeSpec {
 
   "enum" in {
     val expectedSchema =
-      DocumentedEnum(DocumentedJsonSchemas.stringJsonSchema, "Red" :: "Blue" :: Nil)
+      DocumentedEnum(DocumentedJsonSchemas.stringJsonSchema, "Red" :: "Blue" :: Nil, Some("Color"))
     assert(DocumentedJsonSchemas.Enum.colorSchema == expectedSchema)
   }
 
   "recursive" in {
-    DocumentedJsonSchemas.recSchema match {
+    DocumentedJsonSchemas.recursiveSchema match {
       case DocumentedRecord(List(Field("next", tpe, true, None)), None, None) => assert(tpe.isInstanceOf[LazySchema])
-      case _ => fail(s"Unexpected type for 'recSchema': ${DocumentedJsonSchemas.recSchema}")
+      case _ => fail(s"Unexpected type for 'recSchema': ${DocumentedJsonSchemas.recursiveSchema}")
     }
   }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -24,10 +24,10 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
     )(Fixtures.listBooks, Fixtures.postBook)
   }
 
-  trait Fixtures extends algebra.Endpoints with algebra.JsonSchemaEntities with generic.JsonSchemas with algebra.BasicAuthentication {
+  trait Fixtures extends algebra.Endpoints with algebra.JsonSchemaEntities with generic.JsonSchemas with algebra.BasicAuthentication with algebra.JsonSchemasTest {
 
     implicit private val schemaStorage: JsonSchema[Storage] =
-      withDiscriminator(genericJsonSchema[Storage].asInstanceOf[Tagged[Storage]], "storageType")
+      withDiscriminator(genericTagged[Storage], "storageType")
 
     implicit val schemaAuthor: JsonSchema[Author] = (
       field[String]("name", documentation = Some("Author name")).xmap[Author](Author)(_.name)
@@ -39,7 +39,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
 
     val postBook =
       authenticatedEndpoint(
-        Post, path / "books", ok(emptyResponse), jsonRequest[Book], requestDocs = Some("Books list"), endpointDocs = EndpointDocs(tags = List("Books")))
+        Post, path / "books", ok(jsonResponse(Enum.colorSchema)), jsonRequest[Book], requestDocs = Some("Books list"), endpointDocs = EndpointDocs(tags = List("Books")))
   }
 
   "OpenApi" should {
@@ -126,7 +126,12 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |            }
         |          },
         |          "200" : {
-        |            "description" : ""
+        |            "description" : "",
+        |            "content": {
+        |              "application/json": {
+        |                "schema": { "$ref": "#/components/schemas/Color" }
+        |              }
+        |            }
         |          },
         |          "403" : {
         |            "description" : ""
@@ -146,6 +151,10 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |  },
         |  "components" : {
         |    "schemas" : {
+        |      "Color" : {
+        |        "type" : "string",
+        |        "enum" : ["Red", "Blue"]
+        |      },
         |      "endpoints.openapi.ReferencedSchemaTest.Storage.Online" : {
         |        "allOf" : [
         |          {

--- a/openapi/openapi/src/test/scala/endpoints/openapi/WebhooksTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/WebhooksTest.scala
@@ -11,7 +11,8 @@ class WebhooksTest extends WordSpec with Matchers {
   trait Webhooks extends algebra.Endpoints with algebra.JsonSchemaEntities {
 
     implicit lazy val messageSchema: JsonSchema[Message] =
-      named(field[String]("message"), "webhook.Message")
+      field[String]("message")
+        .named("webhook.Message")
         .xmap(Message(_))(_.value)
 
     val subscribe: Endpoint[String, Unit] = endpoint(


### PR DESCRIPTION
`genericRecord[Xxx].named("xxx")` is the new syntax for the previous `namedGenericJsonSchema[Xxx]("xxx")`

Also, make the `named` operation available only on `Record`, `Tagged`, and `Enum`.