### PR TITLE
Increase configurability of generic schema derivation process

### DIFF
--- a/documentation/manual/src/doc/algebras/json-schemas.md
+++ b/documentation/manual/src/doc/algebras/json-schemas.md
@@ -150,10 +150,16 @@ type. The rules for deriving the schema are the following:
   the same name and type (for instance, the generic schema for the `Rectangle`
   type has a `width` required property of type `integer`),
 - each case class field of type `Option[A]` for some type `A` has a corresponding
-  optional JSON object property of the same name and type.
+  optional JSON object property of the same name and type,
+- documentation specific to case class fields can be defined by annotating the fields
+  with the `@docs` annotation,
+- for sealed traits, the discriminator field name can be defined by the `@discriminator`
+  annotation, otherwise the `defaultDiscriminatorName` value is used,
+- the schema is named by the `@name` annotation, if present, or by invoking the
+  `classTagToSchemaName` operation with the `ClassTag` of the type for which the schema
+  is derived.
 
-Documentation specific to case class fields can be defined by annotating the fields
-with the `@docs` annotation:
+Here is an example that illustrates how to configure the generic schema derivation process:
 
 ~~~ scala src=../../../../../json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala#documented-generic-schema
 ~~~

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -130,7 +130,7 @@ trait JsonSchemas
       def taggedDecoder(tagName: String) = if (tag == tagName) Some(recordA.decoder) else None
     }
 
-  def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
+  def withDiscriminatorTagged[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
     new Tagged[A] {
       override def discriminator: String = discriminatorName
       def taggedEncoded(a: A): (String, JsonObject) = tagged.taggedEncoded(a)

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -1,0 +1,31 @@
+package endpoints.generic
+
+/**
+  * Documents a case class field.
+  *
+  * Annotate a case class field with this annotation to define its
+  * documentation.
+  *
+  * @param text Description of the annotated field
+  */
+case class docs(text: String) extends scala.annotation.Annotation
+
+/**
+  * Defines the name of a generic schema.
+  *
+  * Annotate a sealed trait or case class definition with this annotation
+  * to define its schema name.
+  *
+  * @param value Name of the schema
+  */
+case class name(value: String) extends scala.annotation.Annotation
+
+/**
+  * Defines the name of the discriminator field of a generic tagged schema.
+  *
+  * Annotate a sealed trait definition with this annotation to define
+  * the name of its discriminator field.
+  *
+  * @param name Name of the tagged discriminator field
+  */
+case class discriminator(name: String) extends scala.annotation.Annotation

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/docs.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/docs.scala
@@ -1,8 +1,0 @@
-package endpoints.generic
-
-/**
-  * Documents a case class field.
-  *
-  * @param text Description of the annotated field
-  */
-case class docs(text: String) extends scala.annotation.Annotation

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
@@ -21,6 +21,14 @@ trait JsonSchemasDocs extends JsonSchemas {
 
   locally {
     //#documented-generic-schema
+    @discriminator("kind")
+    @name("ShapeSchema")
+    sealed trait Shape
+
+    @name("CircleSchema")
+    case class Circle(radius: Double) extends Shape
+
+    @name("RectangleSchema")
     case class Rectangle(
       @docs("Rectangle width") width: Double,
       height: Double

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -27,6 +27,8 @@ class JsonSchemasTest extends FreeSpec {
       implicit val schema: JsonSchema[Quux] = genericJsonSchema[Quux]
     }
 
+    @discriminator("$type")
+    @name("DocResource")
     sealed trait Doc
     case class DocA(@docs("fieldDocI") i: Int) extends Doc
     case class DocB(
@@ -34,6 +36,7 @@ class JsonSchemasTest extends FreeSpec {
       @docs("fieldDocB") b: Boolean,
       @docs("fieldDocSS") ss: List[String]
     ) extends Doc
+    @name("DocC")
     case object DocC extends Doc
 
     object Doc {
@@ -70,7 +73,7 @@ class JsonSchemasTest extends FreeSpec {
       def taggedRecord[A](recordA: String, tag: String): String =
         s"$recordA@$tag"
 
-      def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
+      def withDiscriminatorTagged[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
         s"$tagged#$discriminatorName"
 
       def choiceTagged[A, B](taggedA: String, taggedB: String): String =
@@ -129,18 +132,18 @@ class JsonSchemasTest extends FreeSpec {
         s"'$ns.QuuxD'!(%)@QuuxD",
         s"'$ns.QuuxE'!(%)@QuuxE"
       ).mkString("|")
-    })"
+    })#type"
     assert(FakeAlgebraJsonSchemas.Quux.schema == expectedSchema)
   }
 
   "documentations" in {
-    val expectedSchema = s"'$ns.Doc'!(${
+    val expectedSchema = s"'DocResource'!(${
       List(
         s"'$ns.DocA'!(i:integer{fieldDocI},%)@DocA",
         s"'$ns.DocB'!(a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%)@DocB",
-        s"'$ns.DocC'!(%)@DocC"
+        s"'DocC'!(%)@DocC"
       ).mkString("|")
-    })"
+    })#$$type"
     assert(FakeAlgebraJsonSchemas.Doc.schema == expectedSchema)
   }
 

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -190,7 +190,7 @@ trait JsonSchemas
     def findReads(tagName: String): Option[Reads[A]] = if (tag == tagName) Some(recordA.reads) else None
   }
 
-  def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
+  def withDiscriminatorTagged[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
     new Tagged[A] {
       override def discriminator: String = discriminatorName
       def tagAndJson(a: A): (String, JsObject) = tagged.tagAndJson(a)

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -142,7 +142,7 @@ trait JsonSchemas {
   def defaultDiscriminatorName: String = "type"
 
   /** Allows to specify name of discriminator field for sum type */
-  def withDiscriminator[A](tagged: Tagged[A], discriminatorName: String): Tagged[A]
+  def withDiscriminatorTagged[A](tagged: Tagged[A], discriminatorName: String): Tagged[A]
 
   /** The JSON schema of a coproduct made of the given alternative tagged records */
   def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]]
@@ -176,6 +176,7 @@ trait JsonSchemas {
     def orElse[B](taggedB: Tagged[B]): Tagged[Either[A, B]] = choiceTagged(taggedA, taggedB)
     def xmap[B](f: A => B)(g: B => A): Tagged[B] = xmapTagged(taggedA, f, g)
     def named(name: String): Tagged[A] = namedTagged(taggedA, name)
+    def withDiscriminator(name: String): Tagged[A] = withDiscriminatorTagged(taggedA, name)
   }
 
   final implicit class EnumOps[A](enumA: Enum[A]) {

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -77,7 +77,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
   def taggedRecord[A](recordA: DocumentedRecord, tag: String): DocumentedCoProd =
     DocumentedCoProd(List(tag -> recordA))
 
-  def withDiscriminator[A](tagged: DocumentedCoProd, discriminatorName: String): DocumentedCoProd =
+  def withDiscriminatorTagged[A](tagged: DocumentedCoProd, discriminatorName: String): DocumentedCoProd =
     tagged.copy(discriminatorName = discriminatorName)
 
   def choiceTagged[A, B](taggedA: DocumentedCoProd, taggedB: DocumentedCoProd): DocumentedCoProd =

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -1,11 +1,13 @@
 package endpoints.openapi
 
+import endpoints.generic.discriminator
 import endpoints.openapi.model._
 import endpoints.{algebra, generic, openapi}
 import org.scalatest.{Matchers, WordSpec}
 
 class ReferencedSchemaTest extends WordSpec with Matchers {
 
+  @discriminator("storageType")
   sealed trait Storage
 
   object Storage {
@@ -27,7 +29,7 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
   trait Fixtures extends algebra.Endpoints with algebra.JsonSchemaEntities with generic.JsonSchemas with algebra.BasicAuthentication with algebra.JsonSchemasTest {
 
     implicit private val schemaStorage: JsonSchema[Storage] =
-      withDiscriminator(genericTagged[Storage], "storageType")
+      genericTagged[Storage]
 
     implicit val schemaAuthor: JsonSchema[Author] = (
       field[String]("name", documentation = Some("Author name")).xmap[Author](Author)(_.name)


### PR DESCRIPTION
Fixes #137

- Adds a `@discriminator` annotation allowing users to define the
  discriminator field name of a sealed trait schema (if absent,
  fallback to `defaultDiscriminatorName`)
- Adds a `@name` annotation allowing users to define the schema name
  of a sealed trait schema or a case class schema (if absent, fallback
  to `classTagToSchemaName`)
- Make `withDiscriminator` an operation available on `Tagged` schemas