### PR TITLE
Document the singleton value of a tagged alternative discriminator field

### DIFF
--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -164,7 +164,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |            "type" : "object",
         |            "properties" : {
         |              "storageType" : {
-        |                "type" : "string"
+        |                "type" : "string",
+        |                "enum" : ["Online"]
         |              },
         |              "link" : {
         |                "type" : "string"
@@ -249,7 +250,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |            "type" : "object",
         |            "properties" : {
         |              "storageType" : {
-        |                "type" : "string"
+        |                "type" : "string",
+        |                "enum" : ["Library"]
         |              },
         |              "room" : {
         |                "type" : "string"


### PR DESCRIPTION
![Screenshot from 2019-10-31 13-11-52](https://user-images.githubusercontent.com/332812/67945777-09f7ed80-fbe0-11e9-997a-c1b54e2364ca.png)

@krzemin I’ve tried to use several code generators (to check that I wasn’t introducing a change incompatible with what code generators expect) but none of them accepted our swagger document (even before this PR). Do you know a code generator that works with our swagger documents?