### PR TITLE
Provide JSON schemas for tuples

### DIFF
--- a/documentation/manual/src/doc/algebras/json-schemas.md
+++ b/documentation/manual/src/doc/algebras/json-schemas.md
@@ -19,7 +19,7 @@ The algebra introduces the concept of `JsonSchema[A]`: a JSON schema for a type 
 
 ### Basic types and record types
 
-The trait provides some predefined JSON schemas (for `String`, `Int`, `Boolean`, etc.)
+The trait provides some predefined JSON schemas (for `String`, `Int`, `Boolean`, `Seq`, etc.)
 and ways to combine them together to build more complex schemas.
 
 For instance, given the following `Rectangle` data type:
@@ -104,6 +104,18 @@ our case objects.
 It will work similarly for other representations of enumerated values.
 Most of them provide `values` which can conveniently be passed into `enumeration`.
 However, it is still possible to explicitly pass a certain subset of allowed values.
+
+### Tuples
+
+JSON schemas for tuples from 2 to 22 elements are provided out of the box. For instance, if
+there are implicit `JsonSchema` instances for types `A`, `B`, and `C`, then you can summon
+a `JsonSchema[(A, B, C)]`. Tuples are modeled in JSON with arrays, as recommended in the
+[JSON Schema documentation](https://json-schema.org/understanding-json-schema/reference/array.html#tuple-validation).
+
+Here is an example of JSON schema for a GeoJSON `Point`, where GPS coordinates are modeled with a pair (longitude, latitude):
+
+~~~ scala src=../../../../../json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala#tuple
+~~~
 
 ### Recursive types
 

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -9,8 +9,10 @@ val `json-schema` =
       `scala 2.11 to latest`,
       name := "endpoints-algebra-json-schema",
       addScalaTestCrossDependency,
-      libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.2"
+      libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.2",
+      (Compile / boilerplateSource) := baseDirectory.value / ".." / "src" / "main" / "boilerplate"
     )
+    .enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
 val `json-schema-js` = `json-schema`.js
 val `json-schema-jvm` = `json-schema`.jvm
@@ -22,8 +24,10 @@ lazy val `json-schema-generic` =
       `scala 2.11 to latest`,
       name := "endpoints-json-schema-generic",
       libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.3",
-      addScalaTestCrossDependency
+      addScalaTestCrossDependency,
+      (Test / boilerplateSource) := baseDirectory.value / ".." / "src" / "test" / "boilerplate"
     )
+    .enablePlugins(spray.boilerplate.BoilerplatePlugin)
     .dependsOnLocalCrossProjects("json-schema")
 
 lazy val `json-schema-generic-js` = `json-schema-generic`.js
@@ -35,8 +39,10 @@ lazy val `json-schema-circe` =
       publishSettings,
       `scala 2.12 to latest`,
       name := "endpoints-json-schema-circe",
-      libraryDependencies += "io.circe" %%% "circe-core" % circeVersion
+      libraryDependencies += "io.circe" %%% "circe-core" % circeVersion,
+      (Compile / boilerplateSource) := baseDirectory.value / ".." / "src" / "main" / "boilerplate"
     )
+    .enablePlugins(spray.boilerplate.BoilerplatePlugin)
     .dependsOnLocalCrossProjects("algebra-circe") // Needed only because of CirceCodec, but that class doesn’t depend on the algebra
     .dependsOnLocalCrossProjectsWithScope("json-schema" -> "test->test;compile->compile")
 
@@ -49,8 +55,10 @@ lazy val `json-schema-playjson` =
       publishSettings,
       `scala 2.11 to latest`,
       name := "endpoints-json-schema-playjson",
-      libraryDependencies += "com.typesafe.play" %%% "play-json" % playjsonVersion
+      libraryDependencies += "com.typesafe.play" %%% "play-json" % playjsonVersion,
+      (Compile / boilerplateSource) := baseDirectory.value / ".." / "src" / "main" / "boilerplate"
     )
+    .enablePlugins(spray.boilerplate.BoilerplatePlugin)
     .dependsOnLocalCrossProjectsWithScope("json-schema" -> "test->test;compile->compile")
 
 lazy val `json-schema-playjson-js` = `json-schema-playjson`.js

--- a/json-schema/json-schema-circe/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/json-schema/json-schema-circe/src/main/boilerplate/TuplesSchemas.scala.template
@@ -1,0 +1,16 @@
+package endpoints.circe
+
+import endpoints.algebra
+import io.circe.{Encoder, Decoder}
+
+trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
+  [2..#
+  implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] = {
+    [#implicit val schema1Encoder: Encoder[T1] = schema1.encoder
+    implicit val schema1Decoder: Decoder[T1] = schema1.decoder#
+    ]
+    JsonSchema(implicitly, implicitly)
+  }#
+]
+
+}

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -13,7 +13,7 @@ import scala.language.higherKinds
   * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces a circe codec.
   */
 trait JsonSchemas
-  extends algebra.JsonSchemas {
+  extends algebra.JsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {
     def encoder: Encoder[A]

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -49,4 +49,11 @@ class JsonSchemasTest extends FreeSpec {
     assert(JsonSchemasCodec.recursiveSchema.encoder(rec) == json)
   }
 
+  "tuple" in {
+    val json = Json.arr(Json.True, Json.fromInt(42), Json.fromString("foo"))
+    val value = (true, 42, "foo")
+    assert(JsonSchemasCodec.boolIntString.decoder.decodeJson(json).right.exists(_ == value))
+    assert(JsonSchemasCodec.boolIntString.encoder(value) == json)
+  }
+
 }

--- a/json-schema/json-schema-generic/src/test/boilerplate/FakeTuplesSchemas.scala.template
+++ b/json-schema/json-schema-generic/src/test/boilerplate/FakeTuplesSchemas.scala.template
@@ -1,0 +1,14 @@
+package endpoints.generic
+
+import endpoints.algebra
+
+trait FakeTuplesSchemas extends algebra.TuplesSchemas { this: algebra.JsonSchemas =>
+
+  type JsonSchema[+A] = String
+
+  [2..#
+  implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] =
+    s"[[#$schema1#]]"#
+  ]
+
+}

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -18,7 +18,7 @@ class JsonSchemasTest extends FreeSpec {
 
     sealed trait Quux
     case class QuuxA(ss: List[String]) extends Quux
-    case class QuuxB(i: Int) extends Quux
+    case class QuuxB(id: (Int, Double)) extends Quux
     case class QuuxC(b: Boolean) extends Quux
     case class QuuxD() extends Quux
     case object QuuxE extends Quux
@@ -41,9 +41,8 @@ class JsonSchemasTest extends FreeSpec {
     }
   }
 
-  object FakeAlgebraJsonSchemas extends GenericSchemas with endpoints.algebra.JsonSchemas {
+  object FakeAlgebraJsonSchemas extends GenericSchemas with endpoints.algebra.JsonSchemas with FakeTuplesSchemas {
 
-      type JsonSchema[+A] = String
       type Record[+A] = String
       type Tagged[+A] = String
       type Enum[+A] = String
@@ -124,7 +123,7 @@ class JsonSchemasTest extends FreeSpec {
     val expectedSchema = s"'$ns.Quux'!(${
       List(
         s"'$ns.QuuxA'!(ss:[string],%)@QuuxA",
-        s"'$ns.QuuxB'!(i:integer,%)@QuuxB",
+        s"'$ns.QuuxB'!(id:[integer, number],%)@QuuxB",
         s"'$ns.QuuxC'!(b:boolean,%)@QuuxC",
         s"'$ns.QuuxD'!(%)@QuuxD",
         s"'$ns.QuuxE'!(%)@QuuxE"

--- a/json-schema/json-schema-playjson/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/json-schema/json-schema-playjson/src/main/boilerplate/TuplesSchemas.scala.template
@@ -1,0 +1,16 @@
+package endpoints.playjson
+
+import endpoints.algebra
+import play.api.libs.json.{Reads, Writes}
+
+trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
+  [2..#
+  implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] = {
+    [#implicit val schema1Writes: Writes[T1] = schema1.writes
+    implicit val schema1Reads: Reads[T1] = schema1.reads#
+    ]
+    JsonSchema(implicitly, implicitly)
+  }#
+  ]
+
+}

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -14,7 +14,7 @@ import scala.language.higherKinds
   * and `play.api.libs.json.Writes`.
   */
 trait JsonSchemas
-  extends algebra.JsonSchemas {
+  extends algebra.JsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {
     def reads: Reads[A]

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -347,6 +347,14 @@ class JsonSchemasTest extends FreeSpec {
     )
   }
 
+  "tuple" in {
+    testRoundtrip(
+      boolIntString,
+      Json.arr(true, 42, "foo"),
+      (true, 42, "foo")
+    )
+  }
+
   private def testRoundtrip[A](jsonSchema: JsonSchema[A], json: JsValue, expected: A) = {
     val result = jsonSchema.reads.reads(json)
     assert(result.isSuccess, result)

--- a/json-schema/json-schema/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/json-schema/json-schema/src/main/boilerplate/TuplesSchemas.scala.template
@@ -1,0 +1,13 @@
+package endpoints.algebra
+
+trait TuplesSchemas { this: JsonSchemas =>
+  [2..#
+  /**
+    * A JSON schema for a tuple of 1 elements.
+    *
+    * Tuples are modeled with JSON arrays, as documented in [[https://json-schema.org/understanding-json-schema/reference/array.html\#tuple-validation]].
+    */
+  implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])]#
+]
+
+}

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -61,7 +61,7 @@ import scala.language.higherKinds
   *
   * @group algebras
   */
-trait JsonSchemas {
+trait JsonSchemas extends TuplesSchemas {
 
   /** The JSON schema of a type `A` */
   type JsonSchema[A]

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasDocs.scala
@@ -68,4 +68,13 @@ trait JsonSchemasDocs extends JsonSchemas {
   ).xmap(Recursive)(_.next)
   //#recursive
 
+  //#tuple
+  type Coordinates = (Double, Double) // (Longitude, Latitude)
+  case class Point(coordinates: Coordinates)
+
+  implicit val pointSchema: JsonSchema[Point] =
+    field[Coordinates]("coordinates")
+      .tagged("Point")
+      .xmap(Point(_))(_.coordinates)
+  //#tuple
 }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -74,4 +74,6 @@ trait JsonSchemasTest extends JsonSchemas {
 
   val intDictionary: JsonSchema[Map[String, Int]] = mapJsonSchema[Int]
 
+  implicit val boolIntString: JsonSchema[(Boolean, Int, String)] = tuple3JsonSchema
+
 }

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -7,8 +7,10 @@ lazy val openapi =
     .settings(
       publishSettings,
       `scala 2.12 to latest`, // We don’t support 2.11 because our tests have a dependency on circe
-      name := "endpoints-openapi"
+      name := "endpoints-openapi",
+      (Compile / boilerplateSource) := (Compile / baseDirectory).value / ".." / "src" / "main" / "boilerplate"
     )
+    .enablePlugins(spray.boilerplate.BoilerplatePlugin)
     .dependsOnLocalCrossProjects("json-schema-generic")
     .dependsOnLocalCrossProjectsWithScope(
       "algebra" -> "test->test;compile->compile",

--- a/openapi/openapi/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/openapi/openapi/src/main/boilerplate/TuplesSchemas.scala.template
@@ -1,0 +1,11 @@
+package endpoints.openapi
+
+import endpoints.algebra
+
+trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
+  [2..#
+  implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] =
+    DocumentedJsonSchema.Array(Right([#schema1# :: ] :: Nil))#
+  ]
+
+}

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
@@ -6,7 +6,7 @@ import endpoints.openapi.model.{MediaType, Schema}
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   private lazy val invalidJsonEntity =
-    Map("application/json" -> MediaType(Some(Schema.Reference("endpoints.Errors", Some(Schema.Array(Schema.simpleString, None)), None))))
+    Map("application/json" -> MediaType(Some(Schema.Reference("endpoints.Errors", Some(Schema.Array(Left(Schema.simpleString), None)), None))))
 
   lazy val clientErrorsResponseEntity: ResponseEntity[Invalid] = invalidJsonEntity
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -155,8 +155,10 @@ trait EndpointsWithCustomErrors
       case Schema.Object(properties, additionalProperties, _) =>
         properties.map(_.schema).flatMap(captureReferencedSchemasRec) ++
           additionalProperties.toList.flatMap(captureReferencedSchemasRec)
-      case Schema.Array(elementType, _) =>
+      case Schema.Array(Left(elementType), _) =>
         captureReferencedSchemasRec(elementType)
+      case Schema.Array(Right(elementTypes), _) =>
+        elementTypes.flatMap(captureReferencedSchemasRec)
       case Schema.Enum(elementType, _, _) =>
         captureReferencedSchemasRec(elementType)
       case Schema.Primitive(_, _, _) =>

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemaEntities.scala
@@ -36,8 +36,10 @@ trait JsonSchemaEntities
         expandCoproductSchema(coprod, referencedSchemas)
       case Primitive(name, format) =>
         Schema.Primitive(name, format, None)
-      case Array(elementType) =>
-        Schema.Array(toSchema(elementType, coprodBase, referencedSchemas), None)
+      case Array(Left(elementType)) =>
+        Schema.Array(Left(toSchema(elementType, coprodBase, referencedSchemas)), None)
+      case Array(Right(elementTypes)) =>
+        Schema.Array(Right(elementTypes.map(elementType => toSchema(elementType, coprodBase, referencedSchemas))), None)
       case DocumentedEnum(elementType, values, Some(name)) =>
         if (referencedSchemas(name)) Schema.Reference(name, None, None)
         else Schema.Reference(name, Some(Schema.Enum(toSchema(elementType, coprodBase, referencedSchemas + name), values, None)), None)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -12,7 +12,7 @@ import scala.language.higherKinds
   *
   * @group interpreters
   */
-trait JsonSchemas extends endpoints.algebra.JsonSchemas {
+trait JsonSchemas extends endpoints.algebra.JsonSchemas with TuplesSchemas {
 
   import DocumentedJsonSchema._
 
@@ -34,7 +34,10 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
 
     case class Primitive(name: String, format: Option[String] = None) extends DocumentedJsonSchema
 
-    case class Array(elementType: DocumentedJsonSchema) extends DocumentedJsonSchema
+    /**
+      * @param schema `Left(itemSchema)` for a homogeneous array, or `Right(itemSchemas)` for a heterogeneous array (ie, a tuple)
+      */
+    case class Array(schema: Either[DocumentedJsonSchema, List[DocumentedJsonSchema]]) extends DocumentedJsonSchema
 
     case class DocumentedEnum(elementType: DocumentedJsonSchema, values: List[String], name: Option[String]) extends DocumentedJsonSchema
 
@@ -113,7 +116,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas {
   def arrayJsonSchema[C[X] <: Seq[X], A](implicit
     jsonSchema: JsonSchema[A],
     factory: Factory[A, C[A]]
-  ): JsonSchema[C[A]] = Array(jsonSchema)
+  ): JsonSchema[C[A]] = Array(Left(jsonSchema))
 
   def mapJsonSchema[A](implicit jsonSchema: DocumentedJsonSchema): DocumentedJsonSchema =
     DocumentedRecord(fields = Nil, additionalProperties = Some(jsonSchema))

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
@@ -42,7 +42,7 @@ trait Urls extends algebra.Urls {
     param.copy(isRequired = false)
 
   implicit def repeatedQueryStringParam[A, CC[X] <: Iterable[X]](implicit param: QueryStringParam[A], factory: Factory[A, CC[A]]): QueryStringParam[CC[A]] =
-    DocumentedQueryStringParam(Schema.Array(param.schema, description = None), isRequired = false)
+    DocumentedQueryStringParam(Schema.Array(Left(param.schema), description = None), isRequired = false)
   
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
     def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] = fa

--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
@@ -93,7 +93,7 @@ object Schema {
 
   case class Object(properties: List[Property], additionalProperties: Option[Schema], description: Option[String]) extends Schema
 
-  case class Array(elementType: Schema, description: Option[String]) extends Schema
+  case class Array(elementType: Either[Schema, List[Schema]], description: Option[String]) extends Schema
 
   case class Enum(elementType: Schema, values: List[String], description: Option[String]) extends Schema
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ArraysTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ArraysTest.scala
@@ -1,0 +1,131 @@
+package endpoints.openapi
+
+import endpoints.openapi.model.{Info, OpenApi}
+import endpoints.{algebra, openapi}
+import org.scalatest.{Matchers, WordSpec}
+
+class ArraysTest extends WordSpec with Matchers {
+
+  trait Arrays extends algebra.Endpoints with algebra.JsonSchemaEntities {
+
+    val arrays: Endpoint[List[String], (Boolean, Int, String)] = endpoint(
+      post(path / "foo", jsonRequest[List[String]]),
+      ok(jsonResponse)
+    )
+
+  }
+
+  object ArraysDocumentation extends Arrays with openapi.Endpoints with openapi.JsonSchemaEntities {
+
+    val api: OpenApi = openApi(
+      Info(title = "Example of API using homogeneous and heterogeneous arrays", version = "0.0.0")
+    )(arrays)
+
+  }
+
+  "Arrays" should {
+
+    val expectedSchema =
+      """{
+        |  "openapi" : "3.0.0",
+        |  "info" : {
+        |    "title" : "Example of API using homogeneous and heterogeneous arrays",
+        |    "version" : "0.0.0"
+        |  },
+        |  "paths" : {
+        |    "/foo" : {
+        |      "post" : {
+        |        "requestBody" : {
+        |          "content" : {
+        |            "application/json" : {
+        |              "schema" : {
+        |                "type" : "array",
+        |                "items" : {
+        |                  "type" : "string"
+        |                }
+        |              }
+        |            }
+        |          }
+        |        },
+        |        "responses" : {
+        |          "400" : {
+        |            "description" : "Client error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
+        |          "500" : {
+        |            "description" : "Server error",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "$ref" : "#/components/schemas/endpoints.Errors"
+        |                }
+        |              }
+        |            }
+        |          },
+        |          "200" : {
+        |            "description" : "",
+        |            "content" : {
+        |              "application/json" : {
+        |                "schema" : {
+        |                  "type" : "array",
+        |                  "items" : [
+        |                    {
+        |                      "type" : "boolean"
+        |                    },
+        |                    {
+        |                      "type" : "integer",
+        |                      "format" : "int32"
+        |                    },
+        |                    {
+        |                      "type" : "string"
+        |                    }
+        |                  ]
+        |                }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  },
+        |  "components" : {
+        |    "schemas" : {
+        |      "endpoints.Errors" : {
+        |        "type" : "array",
+        |        "items" : {
+        |          "type" : "string"
+        |        }
+        |      }
+        |    },
+        |    "securitySchemes" : {
+        |
+        |    }
+        |  }
+        |}""".stripMargin
+
+    "be documented with circe" in {
+      object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.circe.JsonSchemas
+      import OpenApiEncoder.JsonSchema._
+      import io.circe.syntax._
+      import io.circe.parser.parse
+
+      ArraysDocumentation.api.asJson shouldBe parse(expectedSchema).right.get
+    }
+
+    "be documented with playjson" in {
+      object OpenApiEncoder extends openapi.model.OpenApiSchemas with endpoints.playjson.JsonSchemas
+      import OpenApiEncoder.JsonSchema._
+      import play.api.libs.json.Json
+
+      Json.toJson(ArraysDocumentation.api) shouldBe Json.parse(expectedSchema)
+    }
+
+  }
+
+}

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -19,7 +19,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
       val expectedParameters =
         Parameter("n", In.Query, required = true, description = None, schema = Schema.simpleNumber) ::
         Parameter("lang", In.Query, required = false, description = None, schema = Schema.simpleString) ::
-        Parameter("ids", In.Query, required = false, description = None, schema = Schema.Array(Schema.simpleInteger, None)) ::
+        Parameter("ids", In.Query, required = false, description = None, schema = Schema.Array(Left(Schema.simpleInteger), None)) ::
         Nil
       Fixtures.quux.item.operations("get").parameters shouldBe expectedParameters
     }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -52,4 +52,9 @@ class JsonSchemasTest extends FreeSpec {
     assert(DocumentedJsonSchemas.intDictionary == expected)
   }
 
+  "tuple" in {
+    val expected = Array(Right(DocumentedJsonSchemas.booleanJsonSchema :: DocumentedJsonSchemas.intJsonSchema :: DocumentedJsonSchemas.stringJsonSchema :: Nil))
+    assert(DocumentedJsonSchemas.boolIntString == expected)
+  }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,6 +22,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
+addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 
 lazy val `sbt-assets` = RootProject(file("../sbt-assets"))
 


### PR DESCRIPTION
Fixes #387

- Extend our JSON schema array model to support both homogeneous arrays
  and tuples,
- Provide implicit JSON schemas for tuples from 2 to 22 elements.