### PR TITLE
Add `as` operation to `JsonSchema`

### DIFF
--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
@@ -85,7 +85,7 @@ trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErro
 
   def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] = { (segments: List[String], query: Map[String, List[String]]) =>
     path.validate(segments).flatMap {
-      case (validA, Nil) => Some(validA.tuple(qs.validate(query)))
+      case (validA, Nil) => Some(validA.zip(qs.validate(query)))
       case (_, _)        => None
     }
   }
@@ -128,7 +128,7 @@ trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErro
       }
 
   def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] = { (params: Map[String, List[String]]) =>
-    first.validate(params).tuple(second.validate(params))
+    first.validate(params).zip(second.validate(params))
   }
 
   implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] = new PartialInvariantFunctor[Url] {
@@ -174,7 +174,7 @@ trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErro
     (p1: List[String]) => {
       first.validate(p1).flatMap { case (validA, p2) =>
         second.validate(p2).map { case (validB, p3) =>
-          (validA.tuple(validB), p3)
+          (validA.zip(validB), p3)
         }
       }
     }

--- a/documentation/manual/src/doc/algebras/json-schemas.md
+++ b/documentation/manual/src/doc/algebras/json-schemas.md
@@ -194,9 +194,8 @@ and `genericTagged` returns a `Tagged`.
 
 ### JSON schemas transformation
 
-The module also takes advantage shapeless to define more convenient
-operations for combining JSON schema definitions: the `zip` operation
-is replaced by a `:*:` operator, and `xmap` is replaced by `as`:
+The module also takes advantage shapeless to provide a more convenient `as` operation for
+transforming JSON schema definitions, instead of `xmap`:
 
 ~~~ scala src=../../../../../json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala#explicit-schema
 ~~~

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
@@ -13,7 +13,7 @@ trait JsonSchemasDocs extends JsonSchemas {
   locally {
     //#explicit-schema
     implicit val rectangleSchema: JsonSchema[Rectangle] = (
-      field[Double]("width") :*:
+      field[Double]("width") zip
       field[Double]("height")
     ).as[Rectangle]
     //#explicit-schema

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -42,6 +42,15 @@ class JsonSchemasTest extends FreeSpec {
     object Doc {
       val schema: JsonSchema[Doc] = genericJsonSchema[Doc]
     }
+
+    val tupledSchema = field[Int]("x") zip field[Int]("y")
+    val tupledSchema2: JsonSchema[(Int, Int)] = tupledSchema
+
+    case class Point2(x: Int, y: Int)
+    val schema3: JsonSchema[Point2] = tupledSchema2.as[Point2]
+
+    case class Point3(x: Int, y: Int, z: Int)
+    val schemaPoint3 = (field[Int]("x") zip field[Int]("y") zip field[Int]("z")).as[Point3]
   }
 
   object FakeAlgebraJsonSchemas extends GenericSchemas with endpoints.algebra.JsonSchemas with FakeTuplesSchemas {
@@ -78,7 +87,7 @@ class JsonSchemasTest extends FreeSpec {
       def choiceTagged[A, B](taggedA: String, taggedB: String): String =
         s"$taggedA|$taggedB"
 
-      def zipRecords[A, B](recordA: String, recordB: String): String =
+      def zipRecords[A, B](recordA: String, recordB: String)(implicit t: Tupler[A, B]): String =
         s"$recordA,$recordB"
 
       def jsonSchemaPartialInvFunctor: PartialInvariantFunctor[JsonSchema] =

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -115,7 +115,7 @@ class JsonSchemasTest extends FreeSpec {
     testRoundtrip(
       field[BigDecimal]("foo") zip field[Boolean]("bar") zip field[Double]("pi"),
       Json.obj("foo" -> JsNumber(BigDecimal(123.456)), "bar" -> JsBoolean(true), "pi" -> JsNumber(3.1416)),
-      ((BigDecimal(123.456), true), 3.1416)
+      (BigDecimal(123.456), true, 3.1416)
     )
   }
 

--- a/json-schema/json-schema/src/main/boilerplate/TuplerAppend.scala.template
+++ b/json-schema/json-schema/src/main/boilerplate/TuplerAppend.scala.template
@@ -1,0 +1,22 @@
+package endpoints
+
+/**
+  * Generated trait that provides [[Tupler]] instances for appending to
+  * tuples from 3 to 21 elements
+  */
+trait TuplerAppend extends Tupler2 {
+  [3..21#
+  /**
+    * A [[Tupler]] that appends an element to an existing tuple of size 1.
+    */
+  implicit def tupler1Append[[#T1#], T2]: Tupler[([#T1#]), T2] { type Out = ([#T1#], T2) } =
+    new Tupler[([#T1#]), T2] {
+    type Out = ([#T1#], T2)
+    def apply(t: ([#T1#]), t2: T2): ([#T1#], T2) = ([#t._1#], t2)
+    def unapply(out: ([#T1#], T2)): (([#T1#]), T2) = {
+      val ([#t1#], t2) = out
+      (([#t1#]), t2)
+    }
+  }#
+]
+}

--- a/json-schema/json-schema/src/main/scala/endpoints/Tupler.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/Tupler.scala
@@ -108,37 +108,6 @@ trait Tupler3 extends Tupler2 {
       }
     }
 
-  implicit def tupler3And1[A, B, C, D]: Tupler[(A, B, C), D] { type Out = (A, B, C, D) } =
-    new Tupler[(A, B, C), D] {
-      type Out = (A, B, C, D)
-      def apply(abc: (A, B, C), d: D): (A, B, C, D) = (abc._1, abc._2, abc._3, d)
-      def unapply(out: (A, B, C, D)): ((A, B, C), D) = {
-        val (a, b, c, d) = out
-        ((a, b, c), d)
-      }
-    }
-
-  implicit def tupler4And1[A, B, C, D, E]: Tupler[(A, B, C, D), E] { type Out = (A, B, C, D, E) } =
-    new Tupler[(A, B, C, D), E] {
-      type Out = (A, B, C, D, E)
-      def apply(abcd: (A, B, C, D), e: E): (A, B, C, D, E) = (abcd._1, abcd._2, abcd._3, abcd._4, e)
-      def unapply(out: (A, B, C, D, E)): ((A, B, C, D), E) = {
-        val (a, b, c, d, e) = out
-        ((a, b, c, d), e)
-      }
-    }
-
-  implicit def tupler5And1[A, B, C, D, E, F]: Tupler[(A, B, C, D, E), F] { type Out = (A, B, C, D, E, F) } =
-    new Tupler[(A, B, C, D, E), F] {
-      type Out = (A, B, C, D, E, F)
-      def apply(abcde: (A, B, C, D, E), f: F): (A, B, C, D, E, F) =
-        (abcde._1, abcde._2, abcde._3, abcde._4, abcde._5, f)
-      def unapply(out: (A, B, C, D, E, F)): ((A, B, C, D, E), F) = {
-        val (a, b, c, d, e, f) = out
-        ((a, b, c, d, e), f)
-      }
-    }
-
   implicit def leftUnit[A]: Aux[Unit, A, A] = new Tupler[Unit, A] {
     type Out = A
     def apply(a: Unit, b: A): A = b
@@ -147,7 +116,7 @@ trait Tupler3 extends Tupler2 {
 
 }
 
-trait Tupler4 extends Tupler3 {
+trait Tupler4 extends Tupler3 with TuplerAppend {
 
   implicit def rightUnit[A]: Aux[A, Unit, A] = new Tupler[A, Unit] {
     type Out = A

--- a/json-schema/json-schema/src/main/scala/endpoints/Validated.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/Validated.scala
@@ -42,13 +42,6 @@ sealed trait Validated[+A] {
   }
 
   /**
-    * Tuples together two validated values
-    *
-    * @see [[tuple]]
-    */
-  def zip[B](that: Validated[B]): Validated[(A, B)] = this.tuple(that)
-
-  /**
     * Tuples together two validated values and tries to return a flat tuple instead of nested tuples. Also strips
     * out `Unit` values in the tuples.
     *
@@ -57,7 +50,7 @@ sealed trait Validated[+A] {
     *
     * @see [[Tupler]]
     */
-  def tuple[A0 >: A, B](that: Validated[B])(implicit tupler: Tupler[A0, B]): Validated[tupler.Out] = (this, that) match {
+  def zip[A0 >: A, B](that: Validated[B])(implicit tupler: Tupler[A0, B]): Validated[tupler.Out] = (this, that) match {
     case (Valid(a), Valid(b))             => Valid(tupler(a, b))
     case (_: Valid[A], invalid: Invalid)  => invalid
     case (invalid: Invalid, _: Valid[B])  => invalid

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -2,7 +2,7 @@ package endpoints.algebra
 
 import java.util.UUID
 
-import endpoints.{PartialInvariantFunctor, PartialInvariantFunctorSyntax}
+import endpoints.{PartialInvariantFunctor, PartialInvariantFunctorSyntax, Tupler}
 
 import scala.collection.compat._
 import scala.language.higherKinds
@@ -210,13 +210,13 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]]
 
   /** The JSON schema of a record merging the fields of the two given records */
-  def zipRecords[A, B](recordA: Record[A], recordB: Record[B]): Record[(A, B)]
+  def zipRecords[A, B](recordA: Record[A], recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out]
 
   /** Implicit methods for values of type [[Record]]
     * @group operations
     */
   final implicit class RecordOps[A](recordA: Record[A]) {
-    def zip[B](recordB: Record[B]): Record[(A, B)] = zipRecords(recordA, recordB)
+    def zip[B](recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out] = zipRecords(recordA, recordB)
     def tagged(tag: String): Tagged[A] = taggedRecord(recordA, tag)
     def named(name: String): Record[A] = namedRecord(recordA, name)
   }

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala
@@ -23,9 +23,7 @@ trait JsonSchemasTest extends JsonSchemas {
       emptyRecord zip
       field[String]("name", Some("Name of the user")) zip
       field[Int]("age")
-    )
-      .xmap[(String, Int)](p => (p._1._2, p._2))(p => (((), p._1), p._2))
-      .xmap((User.apply _).tupled)(Function.unlift(User.unapply))
+    ).xmap((User.apply _).tupled)(Function.unlift(User.unapply))
   }
 
   sealed trait Foo

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -102,7 +102,7 @@ trait JsonSchemas extends endpoints.algebra.JsonSchemas with TuplesSchemas {
   def choiceTagged[A, B](taggedA: DocumentedCoProd, taggedB: DocumentedCoProd): DocumentedCoProd =
     DocumentedCoProd(taggedA.alternatives ++ taggedB.alternatives)
 
-  def zipRecords[A, B](recordA: DocumentedRecord, recordB: DocumentedRecord): DocumentedRecord =
+  def zipRecords[A, B](recordA: DocumentedRecord, recordB: DocumentedRecord)(implicit t: Tupler[A, B]): DocumentedRecord =
     DocumentedRecord(recordA.fields ++ recordB.fields)
 
   lazy val uuidJsonSchema: DocumentedJsonSchema = Primitive("string", format = Some("uuid"))

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -84,7 +84,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
 
   implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] = new Semigroupal[RequestHeaders] {
     def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(implicit tupler: Tupler[A, B]): RequestHeaders[tupler.Out] =
-      headers => fa(headers).tuple(fb(headers))
+      headers => fa(headers).zip(fb(headers))
   }
 
   /**

--- a/play/server/src/main/scala/endpoints/play/server/Urls.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Urls.scala
@@ -112,7 +112,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
   def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
     new QueryString[tupler.Out] {
       def decode(qs: Map[String, Seq[String]]) =
-        first.decode(qs).tuple(second.decode(qs))
+        first.decode(qs).zip(second.decode(qs))
       def encode(ab: tupler.Out) = {
         val (a, b) = tupler.unapply(ab)
         first.encode(a) ++ second.encode(b)
@@ -256,7 +256,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
       def decode(segments: List[String]) =
         first.decode(segments).flatMap { case (validA, segments2) =>
           second.decode(segments2).map { case (validB, segments3) =>
-            (validA.tuple(validB), segments3)
+            (validA.zip(validB), segments3)
           }
         }
       def encode(ab: tupler.Out) = {
@@ -290,7 +290,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
     new Url[tupler.Out] {
 
       def decodeUrl(req: RequestHeader): Option[Validated[tupler.Out]] =
-        pathExtractor(path, req).map(_.tuple(qs.decode(req.queryString)))
+        pathExtractor(path, req).map(_.zip(qs.decode(req.queryString)))
 
       def encodeUrl(ab: tupler.Out) = {
         val (a, b) = tupler.unapply(ab)


### PR DESCRIPTION
Fixes #379

- Make `Record#zip` return a flat tuple (by using `Tupler`) instead
  of nested pairs,
- Rename `Validated#tuple` to `Validated#zip`, to be consistent with
  `Record#zip`,
- Remove `:*:` operation from `Record`: we can just use `zip`,
- Remove `tupled` operation from `Record`: it is not needed anymore
  since `zip` returns a flat tuple,
- Add `as[B]` operation to `Record[A]` and `JsonSchema[A]`. This
  operation takes an implicit `Generic.Aux[A, B]`, which is summoned
  by shapeless (although, to make it work we had to introduce a rule
  that checks that the generic representation of `A` is the same as
  the generic representation of `B`),
- Add implicit `Tupler` instances appending an element to a tuple
  from 3 to 21 elements.