### PR TITLE
Add ujson interpreter to JsonSchemas

### DIFF
--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -8,7 +8,8 @@ lazy val openapi =
       publishSettings,
       `scala 2.12 to latest`, // We don’t support 2.11 because our tests have a dependency on circe
       name := "endpoints-openapi",
-      (Compile / boilerplateSource) := (Compile / baseDirectory).value / ".." / "src" / "main" / "boilerplate"
+      (Compile / boilerplateSource) := (Compile / baseDirectory).value / ".." / "src" / "main" / "boilerplate",
+      libraryDependencies += "com.lihaoyi" %%% "ujson" % "0.8.0"
     )
     .enablePlugins(spray.boilerplate.BoilerplatePlugin)
     .dependsOnLocalCrossProjects("json-schema-generic")

--- a/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
+++ b/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
@@ -1,0 +1,13 @@
+package endpoints.ujson
+
+import endpoints.algebra
+
+trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
+  [2..#
+  implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] =
+    new JsonSchema[([#T1#])] {
+      val codec = { case ([#t1#]) => ujson.Arr([#schema1.codec.encode(t1)#]) }
+    }#
+    ]
+
+}

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -1,0 +1,162 @@
+package endpoints.ujson
+
+import java.util.UUID
+
+import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
+import endpoints.algebra.Encoder
+
+import scala.collection.compat._
+import scala.collection.mutable
+
+trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
+
+  trait JsonSchema[A] {
+    def codec: Encoder[A, ujson.Value] // Eventually, will be a `Codec[A, Value]`
+  }
+  trait Record[A] extends JsonSchema[A] {
+    def codec: Encoder[A, ujson.Obj] // Result type refined to `Obj`
+  }
+  case class TagAndObj(discriminatorName: String, tag: String, obj: ujson.Obj)
+  class Tagged[A](val tagAndObj: A => TagAndObj) extends Record[A] {
+    val codec = value => {
+      val TagAndObj(name, tag, json) = tagAndObj(value)
+      json(name) = ujson.Str(tag)
+      json
+    }
+  }
+  type Enum[A] = JsonSchema[A]
+
+  implicit def jsonSchemaPartialInvFunctor: PartialInvariantFunctor[JsonSchema] =
+    new PartialInvariantFunctor[JsonSchema] {
+      def xmapPartial[A, B](fa: JsonSchema[A], f: A => Validated[B], g: B => A): JsonSchema[B] =
+        new JsonSchema[B] { val codec = b => fa.codec.encode(g(b)) }
+    }
+
+  implicit def recordPartialInvFunctor: PartialInvariantFunctor[Record] =
+    new PartialInvariantFunctor[Record] {
+      def xmapPartial[A, B](fa: Record[A], f: A => Validated[B], g: B => A): Record[B] =
+        new Record[B] { val codec = b => fa.codec.encode(g(b)) }
+    }
+
+  implicit def taggedPartialInvFunctor: PartialInvariantFunctor[Tagged] =
+    new PartialInvariantFunctor[Tagged] {
+      def xmapPartial[A, B](fa: Tagged[A], f: A => Validated[B], g: B => A): Tagged[B] =
+        new Tagged(fa.tagAndObj compose g)
+    }
+
+  def enumeration[A](values: Seq[A])(f: A => String)(implicit tpe: JsonSchema[String]): Enum[A] =
+    new JsonSchema[A] {
+      val codec = value => tpe.codec.encode(f(value))
+    }
+
+  def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
+
+  def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = schema
+
+  def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
+
+  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] = new JsonSchema[A] {
+    val codec = value => schema.codec.encode(value)
+  }
+
+  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] = new JsonSchema[A] {
+    val codec = value => schema.codec.encode(value)
+  }
+
+  lazy val emptyRecord: Record[Unit] = new Record[Unit] {
+    val codec = _ => ujson.Obj()
+  }
+
+  def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A] =
+    new Record[A] {
+      val codec = value => ujson.Obj(name -> tpe.codec.encode(value))
+    }
+
+
+  def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]] =
+    new Record[Option[A]] {
+      val codec = new Encoder[Option[A], ujson.Obj] {
+        def encode(maybeValue: Option[A]) = maybeValue match {
+          case None => ujson.Obj()
+          case Some(value) => ujson.Obj(name -> tpe.codec.encode(value))
+        }
+      }
+    }
+
+  def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A] =
+    new Tagged(value => TagAndObj(defaultDiscriminatorName, tag, recordA.codec.encode(value)))
+
+  def withDiscriminatorTagged[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
+    new Tagged(value => {
+      val TagAndObj(_, tag, obj) = tagged.tagAndObj(value)
+      TagAndObj(discriminatorName, tag, obj)
+    })
+
+  def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]] =
+    new Tagged({
+      case Left(value)  => taggedA.tagAndObj(value)
+      case Right(value) => taggedB.tagAndObj(value)
+    })
+
+  def zipRecords[A, B](recordA: Record[A], recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out] =
+    new Record[t.Out] {
+      val codec = new Encoder[t.Out, ujson.Obj] {
+        def encode(from: t.Out): ujson.Obj = {
+          val (a, b) = t.unapply(from)
+          new ujson.Obj(recordA.codec.encode(a).value ++ recordB.codec.encode(b).value)
+        }
+      }
+    }
+
+  implicit def uuidJsonSchema: JsonSchema[UUID] = new JsonSchema[UUID] {
+    val codec = uuid => ujson.Str(uuid.toString)
+  }
+
+  implicit def stringJsonSchema: JsonSchema[String] = new JsonSchema[String] {
+    val codec = ujson.Str(_)
+  }
+
+  implicit def intJsonSchema: JsonSchema[Int] = new JsonSchema[Int] {
+    val codec = n => ujson.Num(n.toDouble)
+  }
+
+  implicit def longJsonSchema: JsonSchema[Long] = new JsonSchema[Long] {
+    val codec = n => ujson.Num(n.toDouble)
+  }
+
+  implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal] = new JsonSchema[BigDecimal] {
+    val codec = x => ujson.Num(x.doubleValue)
+  }
+
+  implicit def floatJsonSchema: JsonSchema[Float] = new JsonSchema[Float] {
+    val codec = x => ujson.Num(x.toDouble)
+  }
+
+  implicit def doubleJsonSchema: JsonSchema[Double] = new JsonSchema[Double] {
+    val codec = ujson.Num(_)
+  }
+
+  implicit def booleanJsonSchema: JsonSchema[Boolean] = new JsonSchema[Boolean] {
+    val codec = ujson.Bool(_)
+  }
+
+  implicit def byteJsonSchema: JsonSchema[Byte] = new JsonSchema[Byte] {
+    val codec = b => ujson.Num(b.toDouble)
+  }
+
+  implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+    jsonSchema: JsonSchema[A],
+    factory: Factory[A, C[A]]
+  ): JsonSchema[C[A]] = new JsonSchema[C[A]] {
+    val codec = as => ujson.Arr(as.map(jsonSchema.codec.encode): _*)
+  }
+
+  implicit def mapJsonSchema[A](implicit jsonSchema: JsonSchema[A]): JsonSchema[Map[String, A]] =
+    new JsonSchema[Map[String, A]] {
+      val codec = map => {
+        new ujson.Obj(mutable.LinkedHashMap(map.map { case (k, v) => (k, jsonSchema.codec.encode(v)) }.toSeq: _*))
+      }
+    }
+}
+
+object JsonSchemas extends JsonSchemas

--- a/openapi/openapi/src/test/scala/endpoints/ujson/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/ujson/JsonSchemasTest.scala
@@ -1,0 +1,116 @@
+package endpoints.ujson
+
+import endpoints.algebra
+import org.scalatest.FreeSpec
+
+class JsonSchemasTest extends FreeSpec {
+
+  object JsonSchemasCodec extends algebra.JsonSchemasTest with endpoints.ujson.JsonSchemas
+  import JsonSchemasCodec._
+
+  "empty record" in {
+    assert(emptyRecord.codec.encode(()) == ujson.Obj())
+  }
+
+  "single record" in {
+    val schema = field[String]("field1")
+    assert(schema.codec.encode("string1") == ujson.Obj("field1" -> ujson.Str("string1")))
+  }
+
+  "optional field" in {
+    val schema = optField[Int]("x")
+    assert(schema.codec.encode(Some(42)) == ujson.Obj("x" -> ujson.Num(42)))
+    assert(schema.codec.encode(None) == ujson.Obj())
+  }
+
+  "nested optional field" in {
+    val schema = optField[Int]("level1")(field[Int]("level2"))
+    assert(schema.codec.encode(Some(123)) == ujson.Obj("level1" -> ujson.Obj("level2" -> ujson.Num(123))))
+    assert(schema.codec.encode(None) == ujson.Obj())
+  }
+
+  "two records" in {
+    val schema = field[Long]("foo") zip field[Boolean]("bar")
+    assert(schema.codec.encode((123L, true)) == ujson.Obj("foo" -> ujson.Num(123L), "bar" -> ujson.True))
+  }
+
+  "three records" in {
+    val schema =
+      field[BigDecimal]("foo") zip field[Boolean]("bar") zip field[Double]("pi")
+    val expected =
+      ujson.Obj(
+        "foo" -> ujson.Num(123.456),
+        "bar" -> ujson.True,
+        "pi"  -> ujson.Num(3.1416)
+      )
+    assert(schema.codec.encode((BigDecimal(123.456), true, 3.1416)) == expected)
+  }
+
+  "case class with one field" in {
+    case class IntClass(i: Int)
+    val schema = field[Int]("i").xmap[IntClass](i => IntClass(i))(_.i)
+    assert(schema.codec.encode(IntClass(1)) == ujson.Obj("i" -> ujson.Num(1)))
+  }
+
+  "case class with two fields" in {
+    case class TestClass(i: Int, s: String)
+    val schema = (field[Int]("i") zip field[String]("s"))
+      .xmap[TestClass](tuple => TestClass(tuple._1, tuple._2))(test => (test.i, test.s))
+
+    val expected = ujson.Obj("i" -> ujson.Num(1), "s" -> ujson.Str("one"))
+    assert(schema.codec.encode(TestClass(1, "one")) == expected)
+  }
+
+  "array" in {
+    val schema = field[List[String]]("names")
+    val expected = ujson.Obj("names" -> ujson.Arr(ujson.Str("Ernie"), ujson.Str("Bert")))
+    assert(schema.codec.encode(List("Ernie", "Bert")) == expected)
+  }
+
+  "tuple" in {
+    assert(boolIntString.codec.encode((true, 42, "foo")) == ujson.Arr(ujson.True, ujson.Num(42), ujson.Str("foo")))
+  }
+
+  "map with string key" in {
+    val schema = field[Map[String, Boolean]]("relevant")
+    val expected =
+      ujson.Obj("relevant" -> ujson.Obj("no" -> ujson.False, "yes" -> ujson.True))
+    assert(schema.codec.encode(Map("no" -> false, "yes" -> true)) == expected)
+  }
+
+  "two tagged choices" in {
+    val schema = field[Int]("i").tagged("I") orElse
+      field[String]("s").tagged("S")
+    assert(schema.codec.encode(Left(2)) == ujson.Obj("type" -> ujson.Str("I"), "i" -> ujson.Num(2)))
+    assert(schema.codec.encode(Right("string")) == ujson.Obj("type" -> ujson.Str("S"), "s" -> ujson.Str("string")))
+  }
+
+  "two tagged choices with a custom discriminator" in {
+    val schema =
+      field[Int]("i").tagged("I")
+        .orElse(field[String]("s").tagged("S"))
+        .withDiscriminator("kind")
+    assert(schema.codec.encode(Left(2)) == ujson.Obj("kind" -> ujson.Str("I"), "i" -> ujson.Num(2)))
+    assert(schema.codec.encode(Right("string")) == ujson.Obj("kind" -> ujson.Str("S"), "s" -> ujson.Str("string")))
+  }
+
+  "enum" in {
+    assert(Enum.colorSchema.codec.encode(Enum.Blue) == ujson.Str("Blue"))
+  }
+
+  "recursive type" in {
+    val expected =
+      ujson.Obj("next" -> ujson.Obj("next" -> ujson.Obj()))
+    assert(recursiveSchema.codec.encode(Recursive(Some(Recursive(Some(Recursive(None)))))) == expected)
+  }
+
+  "refined JsonSchema" in {
+    assert(evenNumberSchema.codec.encode(42) == ujson.Num(42))
+  }
+
+  "refined Tagged" in {
+    val expected = ujson.Obj("type" -> ujson.Str("Baz"), "i" -> ujson.Num(42))
+    assert(refinedTaggedSchema.codec.encode(RefinedTagged(42)) == expected)
+  }
+
+}


### PR DESCRIPTION
Addresses the first point of #399

Add an interpreter for `algebra.JsonSchemas` that produces an JSON encoder (based on [ujson](http://www.lihaoyi.com/upickle/#uJson)). I’ve used ujson because it is minimal, simple, mature, it supports Scala.js and has decent performance. The only drawback I can see is that its support of JSON numbers is incomplete: it only supports `Double` values (no `BigDecimal`). Hopefully this will be fixed in ujson itself, otherwise we can easily define our own AST instead of the default one.