### PR TITLE
Support examples in the documentation

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -192,6 +192,8 @@ trait JsonSchemas
     Record(encoder, decoder)
   }
 
+  def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
+
   implicit def uuidJsonSchema: JsonSchema[UUID] = JsonSchema(implicitly, implicitly)
 
   implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -89,6 +89,9 @@ class JsonSchemasTest extends FreeSpec {
       def zipRecords[A, B](recordA: String, recordB: String)(implicit t: Tupler[A, B]): String =
         s"$recordA,$recordB"
 
+    def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] =
+      schema
+
       def jsonSchemaPartialInvFunctor: PartialInvariantFunctor[JsonSchema] =
         new PartialInvariantFunctor[JsonSchema] {
           def xmapPartial[A, B](fa: String, f: A => Validated[B], g: B => A): String = fa

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -114,6 +114,8 @@ trait JsonSchemas
       (__ \ name).writeNullable(tpe.writes)
     )
 
+  def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
+
   implicit def uuidJsonSchema: JsonSchema[UUID] = JsonSchema(implicitly, implicitly)
 
   implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -73,8 +73,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /**
     * The JSON schema of a type `A`
     *
-    * @note This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]] and
-    *       [[InvariantFunctorSyntax]] classes.
+    * @note This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]],
+    *       [[InvariantFunctorSyntax]], and [[JsonSchemaOps]] classes.
     * @group types
     */
   type JsonSchema[A]
@@ -249,6 +249,12 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
 
   /** The JSON schema of a record merging the fields of the two given records */
   def zipRecords[A, B](recordA: Record[A], recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out]
+
+  def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A]
+
+  final implicit class JsonSchemaOps[A](schemaA: JsonSchema[A]) {
+    def withExample(example: A): JsonSchema[A] = withExampleJsonSchema(schemaA, example)
+  }
 
   /** Implicit methods for values of type [[Record]]
     * @group operations

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
@@ -6,7 +6,11 @@ import endpoints.openapi.model.{MediaType, Schema}
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   private lazy val invalidJsonEntity =
-    Map("application/json" -> MediaType(Some(Schema.Reference("endpoints.Errors", Some(Schema.Array(Left(Schema.simpleString), None)), None))))
+    Map(
+      "application/json" -> MediaType(
+        Some(Schema.Reference("endpoints.Errors", Some(Schema.Array(Left(Schema.simpleString), None, None)), None))
+      )
+    )
 
   lazy val clientErrorsResponseEntity: ResponseEntity[Invalid] = invalidJsonEntity
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -148,26 +148,26 @@ trait EndpointsWithCustomErrors
     } yield recSchema
 
     allReferencedSchemas
-      .collect { case Schema.Reference(name, Some(original), _) => name -> original }
+      .collect { case Schema.Reference(name, Some(original), _, _) => name -> original }
       .toMap
   }
 
   private def captureReferencedSchemasRec(schema: Schema): Seq[Schema.Reference] =
     schema match {
-      case Schema.Object(properties, additionalProperties, _) =>
+      case Schema.Object(properties, additionalProperties, _, _) =>
         properties.map(_.schema).flatMap(captureReferencedSchemasRec) ++
           additionalProperties.toList.flatMap(captureReferencedSchemasRec)
-      case Schema.Array(Left(elementType), _) =>
+      case Schema.Array(Left(elementType), _, _) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Array(Right(elementTypes), _) =>
+      case Schema.Array(Right(elementTypes), _, _) =>
         elementTypes.flatMap(captureReferencedSchemasRec)
-      case Schema.Enum(elementType, _, _) =>
+      case Schema.Enum(elementType, _, _, _) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Primitive(_, _, _) =>
+      case Schema.Primitive(_, _, _, _) =>
         Nil
-      case Schema.OneOf(_, alternatives, _) =>
+      case Schema.OneOf(_, alternatives, _, _) =>
         alternatives.map(_._2).flatMap(captureReferencedSchemasRec)
-      case Schema.AllOf(schemas, _) =>
+      case Schema.AllOf(schemas, _, _) =>
         schemas.flatMap {
           case _: Schema.Reference => Nil
           case s => captureReferencedSchemasRec(s)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -27,25 +27,47 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   class Tagged[A](override val ujsonSchema: ujsonSchemas.Tagged[A], override val docs: DocumentedCoProd) extends JsonSchema[A](ujsonSchema, docs)
   class Enum[A](override val ujsonSchema: ujsonSchemas.Enum[A], override val docs: DocumentedEnum) extends JsonSchema[A](ujsonSchema, docs)
 
-  sealed trait DocumentedJsonSchema
+  sealed trait DocumentedJsonSchema {
+    def example: Option[ujson.Value]
+  }
 
   object DocumentedJsonSchema {
 
-    case class DocumentedRecord(fields: List[Field], additionalProperties: Option[DocumentedJsonSchema] = None, name: Option[String] = None) extends DocumentedJsonSchema
+    case class DocumentedRecord(
+      fields: List[Field],
+      additionalProperties: Option[DocumentedJsonSchema] = None,
+      name: Option[String] = None,
+      example: Option[ujson.Value] = None
+    ) extends DocumentedJsonSchema
     case class Field(name: String, tpe: DocumentedJsonSchema, isOptional: Boolean, documentation: Option[String])
 
-    case class DocumentedCoProd(alternatives: List[(String, DocumentedRecord)],
-                                name: Option[String] = None,
-                                discriminatorName: String = defaultDiscriminatorName) extends DocumentedJsonSchema
+    case class DocumentedCoProd(
+      alternatives: List[(String, DocumentedRecord)],
+      name: Option[String] = None,
+      discriminatorName: String = defaultDiscriminatorName,
+      example: Option[ujson.Value] = None
+    ) extends DocumentedJsonSchema
 
-    case class Primitive(name: String, format: Option[String] = None) extends DocumentedJsonSchema
+    case class Primitive(
+      name: String,
+      format: Option[String] = None,
+      example: Option[ujson.Value] = None
+    ) extends DocumentedJsonSchema
 
     /**
       * @param schema `Left(itemSchema)` for a homogeneous array, or `Right(itemSchemas)` for a heterogeneous array (ie, a tuple)
       */
-    case class Array(schema: Either[DocumentedJsonSchema, List[DocumentedJsonSchema]]) extends DocumentedJsonSchema
+    case class Array(
+      schema: Either[DocumentedJsonSchema, List[DocumentedJsonSchema]],
+      example: Option[ujson.Value] = None
+    ) extends DocumentedJsonSchema
 
-    case class DocumentedEnum(elementType: DocumentedJsonSchema, values: List[ujson.Value], name: Option[String]) extends DocumentedJsonSchema
+    case class DocumentedEnum(
+      elementType: DocumentedJsonSchema,
+      values: List[ujson.Value],
+      name: Option[String],
+      example: Option[ujson.Value] = None
+    ) extends DocumentedJsonSchema
 
     // A documented JSON schema that is unevaluated unless its `value` is accessed
     sealed trait LazySchema extends DocumentedJsonSchema {
@@ -55,6 +77,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       def apply(s: => DocumentedJsonSchema): LazySchema =
         new LazySchema {
           lazy val value: DocumentedJsonSchema = s
+          def example: Option[ujson.Value] = value.example
         }
     }
   }
@@ -147,6 +170,23 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       ujsonSchemas.zipRecords(recordA.ujsonSchema, recordB.ujsonSchema),
       DocumentedRecord(recordA.docs.fields ++ recordB.docs.fields)
     )
+
+  def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = {
+    val exampleJson = schema.ujsonSchema.codec.encode(example)
+    def updatedDocs(djs: DocumentedJsonSchema): DocumentedJsonSchema =
+      djs match {
+        case s: DocumentedRecord => s.copy(example = Some(exampleJson))
+        case s: DocumentedCoProd => s.copy(example = Some(exampleJson))
+        case s: Primitive        => s.copy(example = Some(exampleJson))
+        case s: Array            => s.copy(example = Some(exampleJson))
+        case s: DocumentedEnum   => s.copy(example = Some(exampleJson))
+        case s: LazySchema       => LazySchema(updatedDocs(s.value))
+      }
+    new JsonSchema(
+      schema.ujsonSchema,
+      updatedDocs(schema.docs)
+    )
+  }
 
   lazy val uuidJsonSchema: JsonSchema[UUID] =
     new JsonSchema(

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -13,9 +13,14 @@ import scala.collection.compat._
   *
   * @group interpreters
   */
-trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
+trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas { openapiJsonSchemas =>
 
-  lazy val ujsonSchemas: endpoints.ujson.JsonSchemas = endpoints.ujson.JsonSchemas
+  /**
+    * The JSON codecs used to produce some parts of the documentation.
+    */
+  lazy val ujsonSchemas: endpoints.ujson.JsonSchemas = new endpoints.ujson.JsonSchemas {
+    override def defaultDiscriminatorName: String = openapiJsonSchemas.defaultDiscriminatorName
+  }
 
   import DocumentedJsonSchema._
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
@@ -40,7 +40,7 @@ trait Urls extends algebra.Urls {
     param.copy(isRequired = false)
 
   implicit def repeatedQueryStringParam[A, CC[X] <: Iterable[X]](implicit param: QueryStringParam[A], factory: Factory[A, CC[A]]): QueryStringParam[CC[A]] =
-    DocumentedQueryStringParam(Schema.Array(Left(param.schema), description = None), isRequired = false)
+    DocumentedQueryStringParam(Schema.Array(Left(param.schema), description = None, example = None), isRequired = false)
   
   implicit lazy val queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString] = new PartialInvariantFunctor[QueryString] {
     def xmapPartial[A, B](fa: QueryString[A], f: A => Validated[B], g: B => A): QueryString[B] = fa

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -160,5 +160,3 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       }
     }
 }
-
-object JsonSchemas extends JsonSchemas

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -108,6 +108,8 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       }
     }
 
+  def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
+
   implicit def uuidJsonSchema: JsonSchema[UUID] = new JsonSchema[UUID] {
     val codec = uuid => ujson.Str(uuid.toString)
   }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -19,7 +19,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
       val expectedParameters =
         Parameter("n", In.Query, required = true, description = None, schema = Schema.simpleNumber) ::
         Parameter("lang", In.Query, required = false, description = None, schema = Schema.simpleString) ::
-        Parameter("ids", In.Query, required = false, description = None, schema = Schema.Array(Left(Schema.simpleInteger), None)) ::
+        Parameter("ids", In.Query, required = false, description = None, schema = Schema.Array(Left(Schema.simpleInteger), None, None)) ::
         Nil
       Fixtures.quux.item.operations("get").parameters shouldBe expectedParameters
     }
@@ -42,9 +42,10 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
     "be exposed in JSON schema" in {
       val expectedSchema =
         Schema.Object(
-          Schema.Property("name", Schema.Primitive("string", None, None), isRequired = true, description = Some("Name of the user")) ::
-          Schema.Property("age", Schema.Primitive("integer", Some("int32"), None), isRequired = true, description = None) ::
+          Schema.Property("name", Schema.Primitive("string", None, None, None), isRequired = true, description = Some("Name of the user")) ::
+          Schema.Property("age", Schema.Primitive("integer", Some("int32"), None, None), isRequired = true, description = None) ::
           Nil,
+          None,
           None,
           None
         )
@@ -54,7 +55,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
   "Enumerations" in {
     val expectedSchema =
-      Schema.Reference("Color", Some(Schema.Enum(Schema.Primitive("string", None, None), ujson.Str("Red") :: ujson.Str("Blue") :: Nil, None)), None)
+      Schema.Reference("Color", Some(Schema.Enum(Schema.Primitive("string", None, None, None), ujson.Str("Red") :: ujson.Str("Blue") :: Nil, None, None)), None)
     Fixtures.toSchema(Fixtures.Enum.colorSchema.docs) shouldBe expectedSchema
   }
 
@@ -65,7 +66,8 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
         Some(Schema.Object(
           Schema.Property("next", Schema.Reference("Rec", None, None), isRequired = false, description = None) :: Nil,
           additionalProperties = None,
-          description = None
+          description = None,
+          example = None
         )),
         None
       )
@@ -73,7 +75,8 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
       Schema.Object(
         Schema.Property("next", recSchema, isRequired = false, description = None) :: Nil,
         additionalProperties = None,
-        description = None
+        description = None,
+        example = None
       )
     Fixtures.toSchema(Fixtures.recursiveSchema.docs) shouldBe expectedSchema
   }
@@ -95,7 +98,7 @@ class EndpointsTest extends WordSpec with Matchers with OptionValues {
 
       reqBody shouldBe defined
       reqBody.value.description.value shouldEqual "Text Req"
-      reqBody.value.content("text/plain").schema.value shouldEqual Schema.Primitive("string", None, None)
+      reqBody.value.content("text/plain").schema.value shouldEqual Schema.Primitive("string", None, None, None)
     }
   }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ExamplesTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ExamplesTest.scala
@@ -10,7 +10,7 @@ class ExamplesTest extends WordSpec with Matchers {
 
     "Include examples in documentation" in new Fixtures {
       checkExample(recordSchema)(ujson.Obj("foo" -> ujson.Str("Quux"), "bar" -> ujson.Num(42)))
-      checkExample(coprodSchema)(ujson.Obj("type" -> ujson.Str("R"), "bar" -> ujson.Num(42)))
+      checkExample(coprodSchema)(ujson.Obj("kind" -> ujson.Str("R"), "bar" -> ujson.Num(42)))
       checkExample(enumSchema)(ujson.Str("foo"))
       checkExample(arraySchema)(ujson.Arr(ujson.Num(1), ujson.Num(2)))
       checkExample(mapSchema)(ujson.Obj("foo" -> ujson.Num(1), "bar" -> ujson.Num(2)))
@@ -20,6 +20,8 @@ class ExamplesTest extends WordSpec with Matchers {
   }
 
   trait FixturesAlg extends algebra.JsonSchemas {
+
+    override def defaultDiscriminatorName: String = "kind"
 
     val recordSchema = (
       field[String]("foo") zip

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -54,7 +54,7 @@ class JsonSchemasTest extends FreeSpec {
 
   "recursive" in {
     DocumentedJsonSchemas.recursiveSchema.docs match {
-      case DocumentedRecord(List(Field("next", tpe, true, None)), None, None) => assert(tpe.isInstanceOf[LazySchema])
+      case DocumentedRecord(List(Field("next", tpe, true, None)), None, None, None) => assert(tpe.isInstanceOf[LazySchema])
       case _ => fail(s"Unexpected type for 'recSchema': ${DocumentedJsonSchemas.recursiveSchema.docs}")
     }
   }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -167,7 +167,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |            "properties" : {
         |              "storageType" : {
         |                "type" : "string",
-        |                "enum" : ["Online"]
+        |                "enum" : ["Online"],
+        |                "example" : "Online"
         |              },
         |              "link" : {
         |                "type" : "string"
@@ -253,7 +254,8 @@ class ReferencedSchemaTest extends WordSpec with Matchers {
         |            "properties" : {
         |              "storageType" : {
         |                "type" : "string",
-        |                "enum" : ["Library"]
+        |                "enum" : ["Library"],
+        |                "example" : "Library"
         |              },
         |              "room" : {
         |                "type" : "string"


### PR DESCRIPTION
Fixes #121

Only examples in JSON entities are supported (query parameter examples
are not supported).