### PR TITLE
 Implement decoders in `ujson.JsonSchemas` interpreter

### DIFF
--- a/algebras/algebra/src/main/scala/endpoints/algebra/Codec.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Codec.scala
@@ -12,11 +12,31 @@ trait Decoder[-From, +To] {
   def decode(from: From): Validated[To]
 }
 
+object Decoder {
+
+  /** Transform the decoded type of the given `decoder` with the function `f`. */
+  def mapDecoded[From, To1, To2](decoder: Decoder[From, To1])(f: To1 => To2): Decoder[From, To2] =
+    from => decoder.decode(from).map(f)
+
+  /** Transform the decoded type of the given `decoder` with the partial function `f`. */
+  def flatMapDecoded[From, To1, To2](decoder: Decoder[From, To1])(f: To1 => Validated[To2]): Decoder[From, To2] =
+    from => decoder.decode(from).flatMap(f)
+
+}
+
 /**
   * A way to encode a `From` value into a `To` value
   */
 trait Encoder[-From, +To] {
   def encode(from: From): To
+}
+
+object Encoder {
+
+  /** Transform the decoded type of the given `encoder` with the function `f`. */
+  def mapDecoded[From1, From2, To](encoder: Encoder[From1, To])(f: From2 => From1): Encoder[From2, To] =
+    from => encoder.encode(f(from))
+
 }
 
 /**

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -69,12 +69,12 @@ trait JsonSchemas
     def discriminator: String = defaultDiscriminatorName
     def taggedEncoded(a: A): (String, JsonObject)
     def taggedDecoder(tag: String): Option[Decoder[A]]
-    def encoder: Encoder.AsObject[A] =
+    final def encoder: Encoder.AsObject[A] =
       Encoder.AsObject.instance { a =>
         val (tag, json) = taggedEncoded(a)
         (discriminator -> Json.fromString(tag)) +: json
       }
-    def decoder: Decoder[A] =
+    final def decoder: Decoder[A] =
       Decoder.instance { cursor =>
         cursor.as[JsonObject].right.flatMap { jsonObject =>
           jsonObject(discriminator).flatMap(_.asString) match {

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -1,8 +1,6 @@
 package endpoints
 package circe
 
-import java.util.UUID
-
 import endpoints.algebra.circe.CirceCodec
 import io.circe._
 
@@ -193,8 +191,6 @@ trait JsonSchemas
   }
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
-
-  implicit def uuidJsonSchema: JsonSchema[UUID] = JsonSchema(implicitly, implicitly)
 
   implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)
 

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -108,8 +108,6 @@ class JsonSchemasTest extends FreeSpec {
           override def xmap[A, B](fa: String, f: A => B, g: B => A): String = fa
         }
 
-      lazy val uuidJsonSchema: String = "uuid"
-
       lazy val stringJsonSchema: String = "string"
 
       lazy val intJsonSchema: String = "integer"

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -1,7 +1,5 @@
 package endpoints.playjson
 
-import java.util.UUID
-
 import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -115,8 +113,6 @@ trait JsonSchemas
     )
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
-
-  implicit def uuidJsonSchema: JsonSchema[UUID] = JsonSchema(implicitly, implicitly)
 
   implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)
 

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasTest.scala
@@ -319,7 +319,7 @@ class JsonSchemasTest extends FreeSpec {
     assertError(
       colorSchema,
       JsString("yellow"),
-      "Invalid value yellow. Valid values are Red, Blue."
+      "Invalid value: yellow. Valid values are Red, Blue."
     )
   }
 
@@ -327,7 +327,7 @@ class JsonSchemasTest extends FreeSpec {
     assertError(
       colorSchema,
       JsString("Green"),
-      "Invalid value Green. Valid values are Red, Blue."
+      "Invalid value: Green. Valid values are Red, Blue."
     )
   }
 

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -146,7 +146,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     assert(encoded.size == decoded.size, "Enumeration values must have different string representation")
     enumeration(values)(
       tpe.xmapPartial { str =>
-        Validated.fromOption(decoded.get(str))(s"Invalid value ${str}. Valid values are ${values.map(encode).mkString(", ")}.")
+        Validated.fromOption(decoded.get(str))(s"Invalid value: ${str}. Valid values are ${values.map(encode).mkString(", ")}.")
       } (encode)
     )
   }

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import endpoints.{PartialInvariantFunctor, PartialInvariantFunctorSyntax, Tupler, Validated}
 
 import scala.collection.compat._
+import scala.util.control.Exception
 
 /**
   * An algebra interface for describing algebraic data types. Such descriptions
@@ -280,7 +281,13 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** A JSON schema for type `UUID`
     * @group operations
     */
-  implicit def uuidJsonSchema: JsonSchema[UUID]
+  implicit lazy val uuidJsonSchema: JsonSchema[UUID] =
+    stringJsonSchema.xmapPartial { str =>
+      Validated.fromEither(
+        Exception.nonFatalCatch.either(UUID.fromString(str))
+          .left.map(_ => s"Invalid UUID value: '$str'." :: Nil)
+      )
+    } (_.toString)
 
   /** A JSON schema for type `String`
     * @group operations

--- a/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
+++ b/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
@@ -1,12 +1,16 @@
 package endpoints.ujson
 
-import endpoints.algebra
+import endpoints.{ algebra, Invalid }
 
 trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
   [2..#
   implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] =
     new JsonSchema[([#T1#])] {
-      val codec = { case ([#t1#]) => ujson.Arr([#schema1.codec.encode(t1)#]) }
+      val decoder = {
+        case ujson.Arr(items) if items.length == 1 => [#schema1.decoder.decode(items(0))# zip ]
+        case json => Invalid(s"Invalid JSON array of 1 elements: $json.")
+      }
+      val encoder = { case ([#t1#]) => ujson.Arr([#schema1.encoder.encode(t1)#]) }
     }#
     ]
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -193,7 +193,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas { openapiJsonSc
     )
   }
 
-  lazy val uuidJsonSchema: JsonSchema[UUID] =
+  override lazy val uuidJsonSchema: JsonSchema[UUID] =
     new JsonSchema(
       ujsonSchemas.uuidJsonSchema,
       Primitive("string", format = Some("uuid"))

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -1,7 +1,5 @@
 package endpoints.ujson
 
-import java.util.UUID
-
 import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import endpoints.algebra.Encoder
 
@@ -109,10 +107,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     }
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
-
-  implicit def uuidJsonSchema: JsonSchema[UUID] = new JsonSchema[UUID] {
-    val codec = uuid => ujson.Str(uuid.toString)
-  }
 
   implicit def stringJsonSchema: JsonSchema[String] = new JsonSchema[String] {
     val codec = ujson.Str(_)

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -1,7 +1,7 @@
 package endpoints.ujson
 
-import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
-import endpoints.algebra.Encoder
+import endpoints.{Invalid, PartialInvariantFunctor, Tupler, Valid, Validated, algebra}
+import endpoints.algebra.{Codec, Decoder, Encoder}
 
 import scala.collection.compat._
 import scala.collection.mutable
@@ -9,42 +9,86 @@ import scala.collection.mutable
 trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {
-    def codec: Encoder[A, ujson.Value] // Eventually, will be a `Codec[A, Value]`
+
+    def encoder: Encoder[A, ujson.Value]
+
+    def decoder: Decoder[ujson.Value, A]
+
+    final def codec: Codec[ujson.Value, A] = new Codec[ujson.Value, A] {
+      def decode(from: ujson.Value): Validated[A] = decoder.decode(from)
+      def encode(from: A): ujson.Value = encoder.encode(from)
+    }
+
   }
+
   trait Record[A] extends JsonSchema[A] {
-    def codec: Encoder[A, ujson.Obj] // Result type refined to `Obj`
+
+    override def encoder: Encoder[A, ujson.Obj] // Result type refined to `Obj`
+
   }
-  case class TagAndObj(discriminatorName: String, tag: String, obj: ujson.Obj)
-  class Tagged[A](val tagAndObj: A => TagAndObj) extends Record[A] {
-    val codec = value => {
-      val TagAndObj(name, tag, json) = tagAndObj(value)
-      json(name) = ujson.Str(tag)
+
+  abstract class Tagged[A](val discriminator: String) extends Record[A] {
+    def findDecoder(tag: String): Option[Decoder[ujson.Value, A]]
+    def tagAndObj(a: A): (String, ujson.Obj)
+    final val decoder = {
+      case json @ ujson.Obj(fields) =>
+        fields.get(discriminator) match {
+          case Some(ujson.Str(tag)) =>
+            findDecoder(tag) match {
+              case Some(decoder) => decoder.decode(json)
+              case None          => Invalid(s"Invalid type discriminator: '$tag'.")
+            }
+          case _ => Invalid(s"Missing type discriminator property '$discriminator': $json.")
+        }
+      case json => Invalid(s"Invalid JSON object: $json.")
+    }
+    final val encoder = value => {
+      val (tag, json) = tagAndObj(value)
+      json(discriminator) = ujson.Str(tag)
       json
     }
   }
+
   type Enum[A] = JsonSchema[A]
 
   implicit def jsonSchemaPartialInvFunctor: PartialInvariantFunctor[JsonSchema] =
     new PartialInvariantFunctor[JsonSchema] {
       def xmapPartial[A, B](fa: JsonSchema[A], f: A => Validated[B], g: B => A): JsonSchema[B] =
-        new JsonSchema[B] { val codec = b => fa.codec.encode(g(b)) }
+        new JsonSchema[B] {
+          val decoder = Decoder.flatMapDecoded(fa.decoder)(f)
+          val encoder = Encoder.mapDecoded(fa.encoder)(g)
+        }
     }
 
   implicit def recordPartialInvFunctor: PartialInvariantFunctor[Record] =
     new PartialInvariantFunctor[Record] {
       def xmapPartial[A, B](fa: Record[A], f: A => Validated[B], g: B => A): Record[B] =
-        new Record[B] { val codec = b => fa.codec.encode(g(b)) }
+        new Record[B] {
+          val decoder = Decoder.flatMapDecoded(fa.decoder)(f)
+          val encoder = Encoder.mapDecoded(fa.encoder)(g)
+        }
     }
 
   implicit def taggedPartialInvFunctor: PartialInvariantFunctor[Tagged] =
     new PartialInvariantFunctor[Tagged] {
       def xmapPartial[A, B](fa: Tagged[A], f: A => Validated[B], g: B => A): Tagged[B] =
-        new Tagged(fa.tagAndObj compose g)
+        new Tagged[B](fa.discriminator) {
+          def findDecoder(tag: String): Option[Decoder[ujson.Value, B]] =
+            fa.findDecoder(tag).map(Decoder.flatMapDecoded(_)(f))
+          def tagAndObj(b: B): (String, ujson.Obj) = fa.tagAndObj(g(b))
+        }
     }
 
   def enumeration[A](values: Seq[A])(tpe: JsonSchema[A]): Enum[A] =
     new JsonSchema[A] {
-      val codec = value => tpe.codec.encode(value)
+      val decoder = Decoder.flatMapDecoded(tpe.decoder) { a =>
+        if (values.contains(a)) {
+          Valid(a)
+        } else {
+          Invalid(s"Invalid value: ${tpe.encoder.encode(a)}. Valid values are ${values.map(a => tpe.encoder.encode(a)).mkString(", ")}.")
+        }
+      }
+      val encoder = value => tpe.codec.encode(value)
     }
 
   def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
@@ -54,26 +98,48 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
 
   def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] = new JsonSchema[A] {
-    val codec = value => schema.codec.encode(value)
+    val decoder = json => schema.decoder.decode(json)
+    val encoder = value => schema.encoder.encode(value)
   }
 
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] = new JsonSchema[A] {
-    val codec = value => schema.codec.encode(value)
+    val decoder = json => schema.decoder.decode(json)
+    val encoder = value => schema.encoder.encode(value)
   }
 
   lazy val emptyRecord: Record[Unit] = new Record[Unit] {
-    val codec = _ => ujson.Obj()
+    val decoder = {
+      case _: ujson.Obj => Valid(())
+      case json         => Invalid(s"Invalid JSON object: $json.")
+    }
+    val encoder = _ => ujson.Obj()
   }
 
   def field[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[A] =
     new Record[A] {
-      val codec = value => ujson.Obj(name -> tpe.codec.encode(value))
+      val decoder = {
+        case obj @ ujson.Obj(fields) =>
+          fields.get(name) match {
+            case Some(json) => tpe.decoder.decode(json)
+            case None       => Invalid(s"Missing property '$name' in JSON object: $obj.")
+          }
+        case json => Invalid(s"Invalid JSON object: $json.")
+      }
+      val encoder = value => ujson.Obj(name -> tpe.encoder.encode(value))
     }
 
 
   def optField[A](name: String, documentation: Option[String] = None)(implicit tpe: JsonSchema[A]): Record[Option[A]] =
     new Record[Option[A]] {
-      val codec = new Encoder[Option[A], ujson.Obj] {
+      val decoder = {
+        case ujson.Obj(fields) =>
+          fields.get(name) match {
+            case Some(json) => tpe.decoder.decode(json).map(Some(_))
+            case None       => Valid(None)
+          }
+        case json => Invalid(s"Invalid JSON object: $json.")
+      }
+      val encoder = new Encoder[Option[A], ujson.Obj] {
         def encode(maybeValue: Option[A]) = maybeValue match {
           case None => ujson.Obj()
           case Some(value) => ujson.Obj(name -> tpe.codec.encode(value))
@@ -82,26 +148,37 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     }
 
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A] =
-    new Tagged(value => TagAndObj(defaultDiscriminatorName, tag, recordA.codec.encode(value)))
+    new Tagged[A](defaultDiscriminatorName) {
+      def findDecoder(tagName: String) = if (tagName == tag) Some(recordA.decoder) else None
+      def tagAndObj(value: A) = (tag, recordA.encoder.encode(value))
+    }
 
   def withDiscriminatorTagged[A](tagged: Tagged[A], discriminatorName: String): Tagged[A] =
-    new Tagged(value => {
-      val TagAndObj(_, tag, obj) = tagged.tagAndObj(value)
-      TagAndObj(discriminatorName, tag, obj)
-    })
+    new Tagged[A](discriminatorName) {
+      def findDecoder(tag: String): Option[Decoder[ujson.Value, A]] = tagged.findDecoder(tag)
+      def tagAndObj(value: A) = tagged.tagAndObj(value)
+    }
 
-  def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]] =
-    new Tagged({
-      case Left(value)  => taggedA.tagAndObj(value)
-      case Right(value) => taggedB.tagAndObj(value)
-    })
+  def choiceTagged[A, B](taggedA: Tagged[A], taggedB: Tagged[B]): Tagged[Either[A, B]] = {
+    assert(taggedA.discriminator == taggedB.discriminator)
+    new Tagged[Either[A, B]](taggedB.discriminator) {
+      def findDecoder(tag: String): Option[Decoder[ujson.Value, Either[A, B]]] =
+        taggedA.findDecoder(tag).map(Decoder.mapDecoded(_)(Left(_))) orElse
+        taggedB.findDecoder(tag).map(Decoder.mapDecoded(_)(Right(_)))
+      def tagAndObj(value: Either[A, B]) = value match {
+        case Left(a)  => taggedA.tagAndObj(a)
+        case Right(b) => taggedB.tagAndObj(b)
+      }
+    }
+  }
 
   def zipRecords[A, B](recordA: Record[A], recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out] =
     new Record[t.Out] {
-      val codec = new Encoder[t.Out, ujson.Obj] {
+      val decoder = (json: ujson.Value) => recordA.decoder.decode(json) zip recordB.decoder.decode(json)
+      val encoder = new Encoder[t.Out, ujson.Obj] {
         def encode(from: t.Out): ujson.Obj = {
           val (a, b) = t.unapply(from)
-          new ujson.Obj(recordA.codec.encode(a).value ++ recordB.codec.encode(b).value)
+          new ujson.Obj(recordA.encoder.encode(a).value ++ recordB.encoder.encode(b).value)
         }
       }
     }
@@ -109,47 +186,101 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
 
   implicit def stringJsonSchema: JsonSchema[String] = new JsonSchema[String] {
-    val codec = ujson.Str(_)
+    val decoder = {
+      case ujson.Str(str) => Valid(str)
+      case json           => Invalid(s"Invalid string value: $json.")
+    }
+    val encoder = ujson.Str(_)
   }
 
   implicit def intJsonSchema: JsonSchema[Int] = new JsonSchema[Int] {
-    val codec = n => ujson.Num(n.toDouble)
+    val decoder = {
+      case ujson.Num(x) if x.isValidInt => Valid(x.toInt)
+      case json                         => Invalid(s"Invalid integer value: $json.")
+    }
+    val encoder = n => ujson.Num(n.toDouble)
   }
 
   implicit def longJsonSchema: JsonSchema[Long] = new JsonSchema[Long] {
-    val codec = n => ujson.Num(n.toDouble)
+    val decoder = {
+      case json @ ujson.Num(x) =>
+        val y = BigDecimal(x) // no `isValidLong` operation on `Double`, so convert to `BigDecimal`
+        if (y.isValidLong) Valid(y.toLong) else Invalid(s"Invalid integer value: $json")
+      case json => Invalid(s"Invalid number value: $json.")
+    }
+    val encoder = n => ujson.Num(n.toDouble)
   }
 
   implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal] = new JsonSchema[BigDecimal] {
-    val codec = x => ujson.Num(x.doubleValue)
+    val decoder = {
+      case ujson.Num(x) => Valid(BigDecimal(x))
+      case json         => Invalid(s"Invalid number value: $json.")
+    }
+    val encoder = x => ujson.Num(x.doubleValue)
   }
 
   implicit def floatJsonSchema: JsonSchema[Float] = new JsonSchema[Float] {
-    val codec = x => ujson.Num(x.toDouble)
+    val decoder = {
+      case ujson.Num(x) => Valid(x.toFloat)
+      case json         => Invalid(s"Invalid number value: $json.")
+    }
+    val encoder = x => ujson.Num(x.toDouble)
   }
 
   implicit def doubleJsonSchema: JsonSchema[Double] = new JsonSchema[Double] {
-    val codec = ujson.Num(_)
+    val decoder = {
+      case ujson.Num(x) => Valid(x)
+      case json         => Invalid(s"Invalid number value: $json.")
+    }
+    val encoder = ujson.Num(_)
   }
 
   implicit def booleanJsonSchema: JsonSchema[Boolean] = new JsonSchema[Boolean] {
-    val codec = ujson.Bool(_)
+    val decoder = {
+      case ujson.Bool(b) => Valid(b)
+      case json          => Invalid(s"Invalid boolean value: $json.")
+    }
+    val encoder = ujson.Bool(_)
   }
 
   implicit def byteJsonSchema: JsonSchema[Byte] = new JsonSchema[Byte] {
-    val codec = b => ujson.Num(b.toDouble)
+    val decoder = {
+      case ujson.Num(x) if x.isValidByte => Valid(x.toByte)
+      case json                          => Invalid(s"Invalid byte value: $json.")
+    }
+    val encoder = b => ujson.Num(b.toDouble)
   }
 
   implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit
     jsonSchema: JsonSchema[A],
     factory: Factory[A, C[A]]
   ): JsonSchema[C[A]] = new JsonSchema[C[A]] {
-    val codec = as => ujson.Arr(as.map(jsonSchema.codec.encode): _*)
+    val decoder = {
+      case ujson.Arr(items) =>
+        val builder = factory.newBuilder
+        builder.sizeHint(items)
+        items.map(jsonSchema.decoder.decode)
+          .foldLeft[Validated[collection.mutable.Builder[A, C[A]]]](Valid(builder)) {
+            case (acc, value) => acc.zip(value).map { case (b, a) => b += a }
+          }.map(_.result())
+      case json => Invalid(s"Invalid JSON array: $json.")
+    }
+    val encoder = as => ujson.Arr(as.map(jsonSchema.codec.encode): _*)
   }
 
   implicit def mapJsonSchema[A](implicit jsonSchema: JsonSchema[A]): JsonSchema[Map[String, A]] =
     new JsonSchema[Map[String, A]] {
-      val codec = map => {
+      val decoder = {
+        case ujson.Obj(items) =>
+          val builder = Map.newBuilder[String, A]
+          builder.sizeHint(items)
+          items.map { case (name, value) => jsonSchema.decoder.decode(value).map((name, _)) }
+            .foldLeft[Validated[collection.mutable.Builder[(String, A), Map[String, A]]]](Valid(builder)) {
+              case (acc, value) => acc.zip(value).map { case (b, name, value) => b += name -> value }
+            }.map(_.result())
+        case json => Invalid(s"Invalid JSON object: $json.")
+      }
+      val encoder = map => {
         new ujson.Obj(mutable.LinkedHashMap(map.map { case (k, v) => (k, jsonSchema.codec.encode(v)) }.toSeq: _*))
       }
     }


### PR DESCRIPTION
This addresses the fifth point of #399