### PR TITLE
Add a `format` parameter to the `JsonSchema[String]` constructor

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -192,7 +192,7 @@ trait JsonSchemas
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
 
-  implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)
+  def stringJsonSchema(format: Option[String]): JsonSchema[String] = JsonSchema(implicitly, implicitly)
 
   implicit def intJsonSchema: JsonSchema[Int] = JsonSchema(implicitly, implicitly)
 

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -108,7 +108,7 @@ class JsonSchemasTest extends AnyFreeSpec {
           override def xmap[A, B](fa: String, f: A => B, g: B => A): String = fa
         }
 
-      lazy val stringJsonSchema: String = "string"
+      def stringJsonSchema(format: Option[String]): String = "string"
 
       lazy val intJsonSchema: String = "integer"
 

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -114,7 +114,7 @@ trait JsonSchemas
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
 
-  implicit def stringJsonSchema: JsonSchema[String] = JsonSchema(implicitly, implicitly)
+  def stringJsonSchema(format: Option[String]): JsonSchema[String] = JsonSchema(implicitly, implicitly)
 
   implicit def intJsonSchema: JsonSchema[Int] = JsonSchema(implicitly, implicitly)
 

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -281,18 +281,27 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** A JSON schema for type `UUID`
     * @group operations
     */
-  implicit lazy val uuidJsonSchema: JsonSchema[UUID] =
-    stringJsonSchema.xmapPartial { str =>
+  final implicit lazy val uuidJsonSchema: JsonSchema[UUID] =
+    stringJsonSchema(format = Some("uuid")).xmapPartial { str =>
       Validated.fromEither(
         Exception.nonFatalCatch.either(UUID.fromString(str))
           .left.map(_ => s"Invalid UUID value: '$str'." :: Nil)
       )
     } (_.toString)
 
+  /**
+    * A JSON schema for type `String`.
+    *
+    * @param format An additional semantic information about the underlying format of the string
+    * @see [[https://json-schema.org/understanding-json-schema/reference/string.html#format]]
+    * @group operations
+    */
+  def stringJsonSchema(format: Option[String]): JsonSchema[String]
+
   /** A JSON schema for type `String`
     * @group operations
     */
-  implicit def stringJsonSchema: JsonSchema[String]
+  final implicit def defaultStringJsonSchema: JsonSchema[String] = stringJsonSchema(format = None)
 
   /** A JSON schema for type `Int`
     * @group operations

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -1,7 +1,5 @@
 package endpoints.openapi
 
-import java.util.UUID
-
 import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import endpoints.algebra.{Documentation, Encoder}
 import endpoints.openapi.model.Schema
@@ -193,14 +191,8 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas { openapiJsonSc
     )
   }
 
-  override lazy val uuidJsonSchema: JsonSchema[UUID] =
-    new JsonSchema(
-      ujsonSchemas.uuidJsonSchema,
-      Primitive("string", format = Some("uuid"))
-    )
-
-  lazy val stringJsonSchema: JsonSchema[String] =
-    new JsonSchema(ujsonSchemas.stringJsonSchema, Primitive("string"))
+  def stringJsonSchema(format: Option[String]): JsonSchema[String] =
+    new JsonSchema(ujsonSchemas.stringJsonSchema(format), Primitive("string", format))
 
   lazy val intJsonSchema: JsonSchema[Int] =
     new JsonSchema(ujsonSchemas.intJsonSchema, Primitive("integer", format = Some("int32")))

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -184,7 +184,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A] = schema
 
-  implicit def stringJsonSchema: JsonSchema[String] = new JsonSchema[String] {
+  def stringJsonSchema(format: Option[String]): JsonSchema[String] = new JsonSchema[String] {
     val decoder = {
       case ujson.Str(str) => Valid(str)
       case json           => Invalid(s"Invalid string value: $json.")

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -14,7 +14,7 @@ class JsonSchemasTest extends AnyFreeSpec {
   "case class" in {
     val expectedSchema =
       DocumentedRecord(
-        Field("name", DocumentedJsonSchemas.stringJsonSchema.docs, isOptional = false, documentation = Some("Name of the user")) ::
+        Field("name", DocumentedJsonSchemas.defaultStringJsonSchema.docs, isOptional = false, documentation = Some("Name of the user")) ::
         Field("age", DocumentedJsonSchemas.intJsonSchema.docs, isOptional = false, documentation = None) ::
         Nil
       )
@@ -24,7 +24,7 @@ class JsonSchemasTest extends AnyFreeSpec {
   "sealed trait" in {
     val expectedSchema =
       DocumentedCoProd(
-        ("Bar", DocumentedRecord(Field("s", DocumentedJsonSchemas.stringJsonSchema.docs, isOptional = false, documentation = None) :: Nil)) ::
+        ("Bar", DocumentedRecord(Field("s", DocumentedJsonSchemas.defaultStringJsonSchema.docs, isOptional = false, documentation = None) :: Nil)) ::
         ("Baz", DocumentedRecord(Field("i", DocumentedJsonSchemas.intJsonSchema.docs, isOptional = false, documentation = None) :: Nil)) ::
         ("Bax", DocumentedRecord(Nil)) ::
         ("Qux", DocumentedRecord(Nil)) ::
@@ -36,7 +36,7 @@ class JsonSchemasTest extends AnyFreeSpec {
 
   "enum" in {
     val expectedSchema =
-      DocumentedEnum(DocumentedJsonSchemas.stringJsonSchema.docs, ujson.Str("Red") :: ujson.Str("Blue") :: Nil, Some("Color"))
+      DocumentedEnum(DocumentedJsonSchemas.defaultStringJsonSchema.docs, ujson.Str("Red") :: ujson.Str("Blue") :: Nil, Some("Color"))
     assert(DocumentedJsonSchemas.Enum.colorSchema.docs == expectedSchema)
   }
 
@@ -44,7 +44,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     val expectedSchema =
       DocumentedEnum(
         DocumentedRecord(
-          Field("quux", DocumentedJsonSchemas.stringJsonSchema.docs, isOptional = false, documentation = None) :: Nil
+          Field("quux", DocumentedJsonSchemas.defaultStringJsonSchema.docs, isOptional = false, documentation = None) :: Nil
         ),
         ujson.Obj("quux" -> ujson.Str("bar")) :: ujson.Obj("quux" -> ujson.Str("baz")) :: Nil,
         None
@@ -65,7 +65,7 @@ class JsonSchemasTest extends AnyFreeSpec {
   }
 
   "tuple" in {
-    val expected = Array(Right(DocumentedJsonSchemas.booleanJsonSchema.docs :: DocumentedJsonSchemas.intJsonSchema.docs :: DocumentedJsonSchemas.stringJsonSchema.docs :: Nil))
+    val expected = Array(Right(DocumentedJsonSchemas.booleanJsonSchema.docs :: DocumentedJsonSchemas.intJsonSchema.docs :: DocumentedJsonSchemas.defaultStringJsonSchema.docs :: Nil))
     assert(DocumentedJsonSchemas.boolIntString.docs == expected)
   }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -1,5 +1,7 @@
 package endpoints.openapi
 
+import java.util.UUID
+
 import endpoints.generic.discriminator
 import endpoints.openapi.model._
 import endpoints.{algebra, generic, openapi}
@@ -18,7 +20,7 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
 
   case class Author(name: String)
 
-  case class Book(id: Int, title: String, author: Author, isbnCodes: List[String], storage: Storage)
+  case class Book(id: UUID, title: String, author: Author, isbnCodes: List[String], storage: Storage)
 
   object Fixtures extends Fixtures with openapi.Endpoints with openapi.JsonEntitiesFromSchemas with openapi.BasicAuthentication {
 
@@ -204,8 +206,8 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |            ]
         |          },
         |          "id" : {
-        |            "type" : "integer",
-        |            "format" : "int32"
+        |            "type" : "string",
+        |            "format" : "uuid"
         |          },
         |          "storage" : {
         |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"


### PR DESCRIPTION
Fixes #424

The `stringJsonSchema` constructor now takes a `format: Option[String]` parameter that can be used to indicate a specific string format (see https://json-schema.org/understanding-json-schema/reference/string.html#format).

Implement `uuidJsonSchema` in terms of the new constructor (there is no need to override it in the `openapi` interpreter anymore).

The provided implicit `JsonSchema[String]` instance uses no `format` (as before).