### PR TITLE
Drop Scala 2.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ jobs:
   include:
 
     - stage: test
-      scala: 2.11.12
-      script: sbt "++ $TRAVIS_SCALA_VERSION test"
-    - stage: test
       scala: 2.12.10
       script: sbt ++$TRAVIS_SCALA_VERSION test manual/makeSite
     - stage: test
@@ -61,7 +58,7 @@ jobs:
         - chmod 600 ci/travis-key
         - eval "$(ssh-agent -s)"
         - ssh-add ci/travis-key
-        - sbt "++ 2.11.12 publishSigned" "++ 2.12.10 publishSigned" "++ 2.13.1 publishSigned" sonatypeReleaseAll "++ 2.12.10 manual/makeSite" manual/ghpagesPushSite
+        - sbt "++ 2.12.10 publishSigned" "++ 2.13.1 publishSigned" sonatypeReleaseAll "++ 2.12.10 manual/makeSite" manual/ghpagesPushSite
 
 env:
   global:

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -119,7 +119,7 @@ trait EndpointsWithCustomErrors
     mapPartialResponseEntity(entity)(a => Right(f(a)))
 
   private[client] def mapPartialResponseEntity[A, B](entity: ResponseEntity[A])(f: A => Either[Throwable, B]): ResponseEntity[B] =
-    httpEntity => entity(httpEntity).map(_.right.flatMap(f))
+    httpEntity => entity(httpEntity).map(_.flatMap(f))
 
   def emptyResponse: ResponseEntity[Unit] =
     entity => {

--- a/akka-http/server/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
+++ b/akka-http/server/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
@@ -26,7 +26,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends endpoi
           implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
           val response  = sttp.get(uri"http://localhost:$port/user/$uuid/description?name=name1&age=18").send()
           assert(response.body.isRight)
-          assert(response.body.right.get == mockedResponse)
+          assert(response.body.getOrElse(sys.error("")) == mockedResponse)
           assert(response.code == 200)
           ()
         }
@@ -35,7 +35,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends endpoi
           implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
           val response  = sttp.put(uri"http://localhost:$port/user/$uuid").send()
           assert(response.body.isRight)
-          assert(response.body.right.get == "")
+          assert(response.body.getOrElse(sys.error("")) == "")
           assert(response.code == 200)
           ()
         }
@@ -44,7 +44,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends endpoi
           implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
           val response  = sttp.delete(uri"http://localhost:$port/user/$uuid").send()
           assert(response.body.isRight)
-          assert(response.body.right.get == "")
+          assert(response.body.getOrElse(sys.error("")) == "")
           assert(response.code == 200)
           ()
         }
@@ -58,7 +58,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends endpoi
           implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
           val response  = sttp.get(uri"http://localhost:$port/user/userId/description?name=name1&age=18").send()
           assert(response.body.isRight)
-          assert(response.body.right.get == mockedResponse)
+          assert(response.body.getOrElse(sys.error("")) == mockedResponse)
           assert(response.code == 200)
           ()
         }
@@ -67,7 +67,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends endpoi
           implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
           val response  = sttp.put(uri"http://localhost:$port/user/foo123").send()
           assert(response.body.isRight)
-          assert(response.body.right.get == "")
+          assert(response.body.getOrElse(sys.error("")) == "")
           assert(response.code == 200)
           ()
         }
@@ -76,7 +76,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends endpoi
           implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
           val response  = sttp.delete(uri"http://localhost:$port/user/foo123").send()
           assert(response.body.isRight)
-          assert(response.body.right.get == "")
+          assert(response.body.getOrElse(sys.error("")) == "")
           assert(response.code == 200)
           ()
         }

--- a/algebras/algebra-circe/src/main/scala/endpoints/algebra/circe/JsonEntitiesFromCodecs.scala
+++ b/algebras/algebra-circe/src/main/scala/endpoints/algebra/circe/JsonEntitiesFromCodecs.scala
@@ -67,7 +67,7 @@ trait JsonEntitiesFromCodecs extends endpoints.algebra.JsonEntitiesFromCodecs {
 
     def decode(from: String): Validated[A] =
       parser.parse(from).left.map(Show[ParsingFailure].show)
-        .right.flatMap { json =>
+        .flatMap { json =>
           codec.decoder.decodeJson(json).left.map(Show[DecodingFailure].show)
         }
         .fold(Invalid(_), Valid(_))

--- a/algebras/algebra-playjson/src/main/scala/endpoints/algebra/playjson/JsonEntitiesFromCodecs.scala
+++ b/algebras/algebra-playjson/src/main/scala/endpoints/algebra/playjson/JsonEntitiesFromCodecs.scala
@@ -68,7 +68,7 @@ trait JsonEntitiesFromCodecs extends endpoints.algebra.JsonEntitiesFromCodecs {
       (Try(Json.parse(from)) match {
         case Failure(_) => Left(Invalid("Unable to parse entity as JSON"))
         case Success(a) => Right(a)
-      }).right.flatMap { json =>
+      }).flatMap { json =>
           def showErrors(errors: collection.Seq[(JsPath, collection.Seq[JsonValidationError])]): Invalid =
             Invalid((
               for {
@@ -78,7 +78,7 @@ trait JsonEntitiesFromCodecs extends endpoints.algebra.JsonEntitiesFromCodecs {
             ).toSeq)
           Json.fromJson[A](json).asEither
             .left.map(showErrors)
-            .right.map(Valid(_))
+            .map(Valid(_))
         }.merge
 
     def encode(from: A): String = Json.stringify(Json.toJson(from))

--- a/algebras/build.sbt
+++ b/algebras/build.sbt
@@ -6,7 +6,7 @@ val algebra =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("algebra"))
     .settings(
       publishSettings,
-      `scala 2.11 to latest`,
+      `scala 2.12 to latest`,
       name := "endpoints-algebra",
       libraryDependencies ++= Seq(
         "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test,

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -59,7 +59,7 @@ val manual =
     .enablePlugins(OrnatePlugin, GhpagesPlugin)
     .settings(
       noPublishSettings,
-      `scala 2.12`,
+      `scala 2.12`, // Ornate does not support Scala 2.13
       coverageEnabled := false,
       git.remoteRepo := "git@github.com:julienrf/endpoints.git",
       ornateSettings := Map("version" -> version.value),
@@ -79,7 +79,7 @@ val manual =
 val `example-quickstart-endpoints` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
     .in(file("examples/quickstart/endpoints"))
-    .settings(noPublishSettings, `scala 2.11 to latest`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .jsSettings(
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false
@@ -214,11 +214,11 @@ val `example-cqrs-web-client` =
     .enablePlugins(ScalaJSPlugin)
     .settings(
       noPublishSettings,
-      `scala 2.12`,
+      `scala 2.12 to latest`,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies ++= Seq(
-        "in.nvilla" %%% "monadic-html" % "0.2.3",
+        "in.nvilla" %%% "monadic-html" % "0.4.0",
         "org.julienrf" %%% "faithful-cats" % "2.0.0",
         "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3"
       ),
@@ -232,7 +232,7 @@ val `example-cqrs-public-server` =
   project.in(file("examples/cqrs/public-server"))
     .settings(
       noPublishSettings,
-      `scala 2.12`,
+      `scala 2.12 to latest`,
       unmanagedResources in Compile += (fastOptJS in (`example-cqrs-web-client`, Compile)).map(_.data).value,
       (sourceGenerators in Compile) += Def.task {
         assets.AssetsTasks.generateDigests(
@@ -290,7 +290,7 @@ val `example-cqrs-queries` =
 // this one exists only for the sake of simplifying the infrastructure: it runs all the HTTP services
 val `example-cqrs` =
   project.in(file("examples/cqrs/infra"))
-    .settings(noPublishSettings, `scala 2.12`)
+    .settings(noPublishSettings, `scala 2.12 to latest`)
     .settings(
       cancelable in Global := true,
       libraryDependencies ++= Seq(

--- a/documentation/examples/cqrs/web-client/src/main/scala/cqrs/webclient/Main.scala
+++ b/documentation/examples/cqrs/web-client/src/main/scala/cqrs/webclient/Main.scala
@@ -37,7 +37,7 @@ object Main {
         val eventuallyCreatedMeter: Future[Meter] = PublicEndpoints.createMeter(CreateMeter(name))
         //#webapps-invocation
         eventuallyCreatedMeter.map { createdMeter =>
-          metersVar := metersVar.value + (createdMeter.id -> createdMeter)
+          metersVar.update(_ + (createdMeter.id -> createdMeter))
           input.value = ""
         }.handleError(error => dom.window.alert(s"Unable to create the meter (error is $error)"))
         ()
@@ -53,7 +53,7 @@ object Main {
           case None => dom.window.alert("Unable to parse the value as a number")
           case Some(decimal) =>
             PublicEndpoints.addRecord((meter.id, AddRecord(Instant.now(), decimal))).map { updatedMeter =>
-              metersVar := metersVar.value + (updatedMeter.id -> updatedMeter)
+              metersVar.update(_ + (updatedMeter.id -> updatedMeter))
             }.handleError(error => dom.window.alert(s"Unable to add the value (error is $error)"))
             ()
         }
@@ -74,7 +74,7 @@ object Main {
             } else {
               <div>
                 {
-                  meters.to[Seq].map { case (_, meter) =>
+                  meters.toSeq.map { case (_, meter) =>
                     <section>
                       <h2>{ meter.label }</h2>
                       <p>
@@ -84,8 +84,8 @@ object Main {
                           </thead>
                           <tbody>
                             {
-                              meter.timeSeries.to[Seq].map { case (instant, value) =>
-                                <tr><td>{ instant.toString }</td><td>{ value.toString }</td></tr>
+                              meter.timeSeries.toSeq.map { case (instant, value) =>
+                                <tr><td>{ instant.toString() }</td><td>{ value.toString() }</td></tr>
                               }
                             }
                           </tbody>

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -6,7 +6,7 @@ val `json-schema` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("json-schema"))
     .settings(
       publishSettings,
-      `scala 2.11 to latest`,
+      `scala 2.12 to latest`,
       name := "endpoints-algebra-json-schema",
       addScalaTestCrossDependency,
       libraryDependencies += "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.2",
@@ -21,7 +21,7 @@ lazy val `json-schema-generic` =
   crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("json-schema-generic"))
     .settings(
       publishSettings,
-      `scala 2.11 to latest`,
+      `scala 2.12 to latest`,
       name := "endpoints-json-schema-generic",
       libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.3",
       addScalaTestCrossDependency,

--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -76,7 +76,7 @@ trait JsonSchemas
       }
     final def decoder: Decoder[A] =
       Decoder.instance { cursor =>
-        cursor.as[JsonObject].right.flatMap { jsonObject =>
+        cursor.as[JsonObject].flatMap { jsonObject =>
           jsonObject(discriminator).flatMap(_.asString) match {
             case Some(tag) =>
               taggedDecoder(tag) match {

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -20,10 +20,10 @@ class JsonSchemasTest extends AnyFreeSpec {
       )
     val user = User("Julien", 32)
 
-    assert(User.schema.decoder.decodeJson(userJson).right.exists(_ == user))
+    assert(User.schema.decoder.decodeJson(userJson).exists(_ == user))
     assert(User.schema.encoder.apply(user) == userJson)
 
-    assert(User.schema2.decoder.decodeJson(userJson).right.exists(_ == user))
+    assert(User.schema2.decoder.decodeJson(userJson).exists(_ == user))
     assert(User.schema2.encoder.apply(user) == userJson)
   }
 
@@ -34,25 +34,25 @@ class JsonSchemasTest extends AnyFreeSpec {
         "s" -> Json.fromString("foo")
       )
     val bar = Bar("foo")
-    assert(Foo.schema.decoder.decodeJson(barJson).right.exists(_ == bar))
+    assert(Foo.schema.decoder.decodeJson(barJson).exists(_ == bar))
     assert(Foo.schema.encoder.apply(bar) == barJson)
 
-    assert(Foo.schema.decoder.decodeJson(Json.obj()).swap.right.exists(_ == DecodingFailure("Missing type discriminator field 'type'!", Nil)))
+    assert(Foo.schema.decoder.decodeJson(Json.obj()).swap.exists(_ == DecodingFailure("Missing type discriminator field 'type'!", Nil)))
     val wrongJson = Json.obj("type" -> Json.fromString("Unknown"), "s" -> Json.fromString("foo"))
-    assert(Foo.schema.decoder.decodeJson(wrongJson).swap.right.exists(_ == DecodingFailure("No decoder for discriminator 'Unknown'!", Nil)))
+    assert(Foo.schema.decoder.decodeJson(wrongJson).swap.exists(_ == DecodingFailure("No decoder for discriminator 'Unknown'!", Nil)))
   }
 
   "recursive type" in {
     val json = Json.obj("next" -> Json.obj("next" -> Json.obj()))
     val rec = JsonSchemasCodec.Recursive(Some(JsonSchemasCodec.Recursive(Some(JsonSchemasCodec.Recursive(None)))))
-    assert(JsonSchemasCodec.recursiveSchema.decoder.decodeJson(json).right.exists(_ == rec))
+    assert(JsonSchemasCodec.recursiveSchema.decoder.decodeJson(json).exists(_ == rec))
     assert(JsonSchemasCodec.recursiveSchema.encoder(rec) == json)
   }
 
   "tuple" in {
     val json = Json.arr(Json.True, Json.fromInt(42), Json.fromString("foo"))
     val value = (true, 42, "foo")
-    assert(JsonSchemasCodec.boolIntString.decoder.decodeJson(json).right.exists(_ == value))
+    assert(JsonSchemasCodec.boolIntString.decoder.decodeJson(json).exists(_ == value))
     assert(JsonSchemasCodec.boolIntString.encoder(value) == json)
   }
 
@@ -60,7 +60,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     val validJson = Json.fromInt(42)
     val validValue = 42
     assert(JsonSchemasCodec.evenNumberSchema.encoder(validValue) == validJson)
-    assert(JsonSchemasCodec.evenNumberSchema.decoder.decodeJson(validJson).right.exists(_ == validValue))
+    assert(JsonSchemasCodec.evenNumberSchema.decoder.decodeJson(validJson).exists(_ == validValue))
 
     val invalidJson = Json.fromInt(41)
     val invalidValue = 41
@@ -76,7 +76,7 @@ class JsonSchemasTest extends AnyFreeSpec {
       )
     val validValue = JsonSchemasCodec.RefinedTagged(42)
     assert(JsonSchemasCodec.refinedTaggedSchema.encoder(validValue) == validJson)
-    assert(JsonSchemasCodec.refinedTaggedSchema.decoder.decodeJson(validJson).right.exists(_ == validValue))
+    assert(JsonSchemasCodec.refinedTaggedSchema.decoder.decodeJson(validJson).exists(_ == validValue))
 
     val invalidJson =
       Json.obj(
@@ -91,7 +91,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     val validValue = Foo("bar")
     val validJson = Json.obj("quux" -> Json.fromString("bar"))
     assert(enumSchema.encoder(validValue) == validJson)
-    assert(enumSchema.decoder.decodeJson(validJson).right.exists(_ == validValue))
+    assert(enumSchema.decoder.decodeJson(validJson).exists(_ == validValue))
     val invalidJson = Json.obj("quux" -> Json.fromString("wrong"))
     assert(enumSchema.decoder.decodeJson(invalidJson).left.exists(_ == DecodingFailure("Invalid value: {\n  \"quux\" : \"wrong\"\n}. Valid values are: {\n  \"quux\" : \"bar\"\n}, {\n  \"quux\" : \"baz\"\n}.", Nil)))
   }

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -113,7 +113,7 @@ trait EndpointsWithCustomErrors
     mapPartialResponseEntity(entity)(a => Right(f(a)))
 
   private[client] def mapPartialResponseEntity[A, B](entity: ResponseEntity[A])(f: A => Either[Throwable, B]): ResponseEntity[B] =
-    wsResp => entity(wsResp).right.flatMap(f)
+    wsResp => entity(wsResp).flatMap(f)
 
   /** Discards response entity */
   def emptyResponse: ResponseEntity[Unit] =
@@ -150,8 +150,7 @@ trait EndpointsWithCustomErrors
     a =>
       request(a).flatMap { wsResp =>
         futureFromEither(
-          decodeResponse(response, wsResp)
-            .right.flatMap(entity => entity(wsResp))
+          decodeResponse(response, wsResp).flatMap(entity => entity(wsResp))
         )
       }
 

--- a/play/client/src/main/scala/endpoints/play/client/MuxEndpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/MuxEndpoints.scala
@@ -23,8 +23,8 @@ trait MuxEndpoints extends algebra.Endpoints { self: EndpointsWithCustomErrors =
     ): Future[req.Response] =
       request(encoder.encode(req)).flatMap { wsResponse =>
         futureFromEither(
-          decodeResponse(response, wsResponse).right.flatMap { entity =>
-            entity(wsResponse).right.flatMap { t =>
+          decodeResponse(response, wsResponse).flatMap { entity =>
+            entity(wsResponse).flatMap { t =>
               decoder.decode(t)
                 .fold(resp => Right(resp.asInstanceOf[req.Response]), errors => Left(new Exception(errors.mkString(". "))))
             }

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
@@ -25,7 +25,7 @@ trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
   def jsonRequest[A : CirceDecoder]: RequestEntity[A] =
     playComponents.playBodyParsers.tolerantText.validate { text =>
       parser.parse(text).left.map(Show[ParsingFailure].show)
-        .right.flatMap { json =>
+        .flatMap { json =>
           CirceDecoder[A].decodeJson(json).left.map(Show[DecodingFailure].show)
         }
         .left.map(error => handleClientErrors(Invalid(error)))

--- a/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
@@ -15,7 +15,7 @@ trait LowLevelEndpoints extends algebra.LowLevelEndpoints with Endpoints {
     BodyParser { requestHeader =>
       val accumulator =
         playComponents.playBodyParsers.anyContent.apply(requestHeader)
-      accumulator.map(_.right.map(anyContent => Request(requestHeader, anyContent)))
+      accumulator.map(_.map(anyContent => Request(requestHeader, anyContent)))
     }
 
   /** An HTTP response is a Play `Result` */

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -38,14 +38,6 @@ object EndpointsSettings {
     scalaVersion := "2.12.10",
     crossScalaVersions := Seq("2.12.10")
   )
-  val `scala 2.11 to 2.12` = Seq(
-    scalaVersion := "2.12.10",
-    crossScalaVersions := Seq("2.12.10", "2.11.12")
-  )
-  val `scala 2.11 to latest` = Seq(
-    scalaVersion := "2.12.10",
-    crossScalaVersions := Seq("2.13.1", "2.12.10", "2.11.12")
-  )
   val `scala 2.12 to latest` = Seq(
     scalaVersion := "2.12.10",
     crossScalaVersions := Seq("2.13.1", "2.12.10")

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BuiltInErrors.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BuiltInErrors.scala
@@ -10,6 +10,6 @@ trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErr
         .fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
 
   def serverErrorResponseEntity: ResponseEntity[Throwable] =
-    resp => clientErrorsResponseEntity(resp).right.map(invalid => new Throwable(invalid.errors.mkString(". ")))
+    resp => clientErrorsResponseEntity(resp).map(invalid => new Throwable(invalid.errors.mkString(". ")))
 
 }

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Endpoints.scala
@@ -42,7 +42,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with R
 
     def call(args: Req): Either[Throwable, Resp] = {
       def mapPartialResponseEntity[A](entity: ResponseEntity[A])(f: A => Either[Throwable, Resp]): ResponseEntity[Resp] =
-        httpEntity => entity(httpEntity).right.flatMap(f)
+        httpEntity => entity(httpEntity).flatMap(f)
 
       val resp = request(args).asString
       val maybeResponse = response(resp)
@@ -54,7 +54,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with R
           .map(mapPartialResponseEntity(_)(serverError => Left(serverErrorToThrowable(serverError))))
       maybeResponse.orElse(maybeClientErrors).orElse(maybeServerError)
         .toRight(new Throwable(s"Unexpected response status: ${resp.code}"))
-        .right.flatMap(_(resp.body))
+        .flatMap(_(resp.body))
     }
   }
 

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
@@ -14,7 +14,7 @@ trait Responses extends algebra.Responses with StatusCodes { this: algebra.Error
   implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] =
-        resp => fa(resp).map(entity => s => entity(s).right.map(f))
+        resp => fa(resp).map(entity => s => entity(s).map(f))
     }
 
   type ResponseEntity[A] = String => Either[Throwable, A]
@@ -32,7 +32,7 @@ trait Responses extends algebra.Responses with StatusCodes { this: algebra.Error
 
   def choiceResponse[A, B](responseA: Response[A], responseB: Response[B]): Response[Either[A, B]] =
     resp =>
-      responseA(resp).map(entity => (s: String) => entity(s).right.map(Left(_)))
-        .orElse(responseB(resp).map(entity => (s: String) => entity(s).right.map(Right(_))))
+      responseA(resp).map(entity => (s: String) => entity(s).map(Left(_)))
+        .orElse(responseB(resp).map(entity => (s: String) => entity(s).map(Right(_))))
 
 }

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
@@ -24,6 +24,6 @@ trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
   }
 
   def jsonResponse[A](implicit decoder: CirceDecoder[A]): ResponseEntity[A] =
-    xhr => parser.parse(xhr.responseText).right.flatMap(decoder.decodeJson)
+    xhr => parser.parse(xhr.responseText).flatMap(decoder.decodeJson)
 
 }

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -134,7 +134,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
     mapPartialResponseEntity(entity)(a => Right(f(a)))
 
   private[xhr] def mapPartialResponseEntity[A, B](entity: ResponseEntity[A])(f: A => Either[Throwable, B]): ResponseEntity[B] =
-    xhr => entity(xhr).right.flatMap(f)
+    xhr => entity(xhr).flatMap(f)
 
   def stringCodecResponse[A](implicit codec: Decoder[String, A]): ResponseEntity[A] =
     xhr => codec.decode(xhr.responseText).fold(Right(_), errors => Left(new Exception(errors.mkString(". "))))
@@ -193,7 +193,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
       val maybeB =
         maybeResponse.orElse(maybeClientErrors).orElse(maybeServerError)
           .toRight(new Exception(s"Unexpected response status: ${xhr.status}"))
-          .right.flatMap(_(xhr))
+          .flatMap(_(xhr))
       onload(maybeB)
     }
     xhr.onerror = _ => onerror(xhr)

--- a/xhr/client/src/main/scala/endpoints/xhr/MuxEndpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/MuxEndpoints.scala
@@ -21,7 +21,7 @@ trait MuxEndpoints extends algebra.MuxEndpoints with EndpointsWithCustomErrors {
     decoder: Decoder[Transport, Resp]
   ): Unit =
     performXhr(request, response, encoder.encode(req))(
-      errorOrResp => onload(errorOrResp.right.flatMap(decoder.decode(_).asInstanceOf[Either[Throwable, req.Response]])),
+      errorOrResp => onload(errorOrResp.flatMap(decoder.decode(_).asInstanceOf[Either[Throwable, req.Response]])),
       onError
     )
 


### PR DESCRIPTION
Scala 2.11 was only supported by a few modules, but most of the interpreters had already dropped Scala 2.11 support.