### PR TITLE
Add more structure and links between API documentation pages

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/BuiltInErrors.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/BuiltInErrors.scala
@@ -2,6 +2,9 @@ package endpoints.akkahttp.client
 
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] =

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/BuiltInErrors.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/BuiltInErrors.scala
@@ -4,6 +4,9 @@ import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] =

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntities.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/JsonEntities.scala
@@ -69,7 +69,7 @@ trait JsonEntitiesFromSchemas
   *
   * It is especially useful to encode `OpenApi` documents into JSON entities.
   *
-  * @group interpreter
+  * @group interpreters
   */
 trait JsonEntitiesFromEncodersAndDecoders extends algebra.JsonEntities with EndpointsWithCustomErrors {
 

--- a/algebras/algebra-circe/src/main/scala/endpoints/algebra/circe/JsonEntitiesFromCodecs.scala
+++ b/algebras/algebra-circe/src/main/scala/endpoints/algebra/circe/JsonEntitiesFromCodecs.scala
@@ -56,6 +56,7 @@ import io.circe.{DecodingFailure, Json, ParsingFailure, parser, Decoder => Circe
   *   }
   * }}}
   *
+  * @group interpreters
   */
 trait JsonEntitiesFromCodecs extends endpoints.algebra.JsonEntitiesFromCodecs {
 

--- a/algebras/algebra-playjson/src/main/scala/endpoints/algebra/playjson/JsonEntitiesFromCodecs.scala
+++ b/algebras/algebra-playjson/src/main/scala/endpoints/algebra/playjson/JsonEntitiesFromCodecs.scala
@@ -55,6 +55,7 @@ import scala.util.{Failure, Success, Try}
   *   }
   * }}}
   *
+  * @group interpreters
   */
 trait JsonEntitiesFromCodecs extends endpoints.algebra.JsonEntitiesFromCodecs {
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Assets.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Assets.scala
@@ -7,11 +7,14 @@ package endpoints.algebra
   */
 trait Assets extends EndpointsWithCustomErrors {
 
-  /** An HTTP request to retrieve an asset */
+  /** An HTTP request to retrieve an asset
+    * @group types */
   type AssetRequest
-  /** The path of the asset */
+  /** The path of the asset
+    * @group types */
   type AssetPath
-  /** An HTTP response containing an asset */
+  /** An HTTP response containing an asset
+    * @group types */
   type AssetResponse
 
   /**
@@ -25,6 +28,7 @@ trait Assets extends EndpointsWithCustomErrors {
     * Then, here is how the following requests are decoded:
     * - `/assets/foo` => `foo`
     * - `/assets/foo/bar` => `foo/bar`
+    * @group operations
     */
   def assetSegments(name: String = "", docs: Documentation = None): Path[AssetPath]
 
@@ -33,10 +37,12 @@ trait Assets extends EndpointsWithCustomErrors {
     * @param docs description of a response when asset is found. Required by openapi
     * @param notFoundDocs description of a not found asset response. Required by openapi
     * @return An HTTP endpoint serving assets
+    * @group operations
     */
   def assetsEndpoint(url: Url[AssetPath], docs: Documentation = None, notFoundDocs: Documentation = None): Endpoint[AssetRequest, AssetResponse]
 
-  /** The digests of the assets */
+  /** The digests of the assets
+    * @group operations */
   def digests: Map[String, String]
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -50,6 +50,7 @@ trait BasicAuthentication extends EndpointsWithCustomErrors {
 
   /**
     * Describes an endpoint protected by Basic HTTP authentication
+    * @group operations
     */
   def authenticatedEndpoint[U, E, R, H, UE, HCred, Out](
     method: Method,

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BuiltInErrors.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BuiltInErrors.scala
@@ -3,13 +3,14 @@ package endpoints.algebra
 import endpoints.Invalid
 
 /**
-  * Uses ''endpoints'' built-in error types:
+  * Interpreter for the [[Errors]] algebra that uses ''endpoints'' built-in error types:
   *
-  * - [[Invalid]] for client errors,
-  *
-  * - and `Throwable` for server error.
+  *   - [[Invalid]] for client errors,
+  *   - and `Throwable` for server error.
   *
   * Both types of errors are serialized into a JSON array containing string error values.
+  *
+  * @group interpreters
   */
 trait BuiltInErrors extends Errors { this: EndpointsWithCustomErrors =>
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
@@ -33,6 +33,7 @@ trait EndpointsWithCustomErrors extends Requests with Responses with Errors {
     *
     * @tparam A Information carried by the request
     * @tparam B Information carried by the response
+    * @group types
     */
   type Endpoint[A, B]
 
@@ -42,6 +43,7 @@ trait EndpointsWithCustomErrors extends Requests with Responses with Errors {
     * @param request  Request
     * @param response Response
     * @param docs     Documentation (used by documentation interpreters)
+    * @group operations
     */
   def endpoint[A, B](
     request: Request[A],

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Errors.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Errors.scala
@@ -19,18 +19,36 @@ import endpoints.Invalid
   * operations defined here to handle client and server errors, respectively.
   *
   * @see [[BuiltInErrors]]
+  * @group algebras
+  * @groupname types Types
+  * @groupdesc types Types introduced by the algebra
+  * @groupprio types 1
+  * @groupname operations Operations
+  * @groupdesc operations Operations creating and transforming values
+  * @groupprio operations 2
   */
 trait Errors { this: Responses =>
 
-  /** Errors in a request built by a client */
+  /** Errors in a request built by a client
+    * @group types
+    */
   type ClientErrors
-  /** Error raised by the business logic of a server */
+  /** Error raised by the business logic of a server
+    * @group types
+    */
   type ServerError
 
+  /** Convert the ''endpoints'' internal client error type into the [[ClientErrors]] type
+    * @group operations */
   def invalidToClientErrors(invalid: Invalid): ClientErrors
+  /** Convert the [[ClientErrors]] type into the ''endpoints'' internal client error type
+    * @group operations */
   def clientErrorsToInvalid(clientErrors: ClientErrors): Invalid
-
+  /** Convert the ''endpoints'' internal server error type into the [[ServerError]] type
+    * @group operations */
   def throwableToServerError(throwable: Throwable): ServerError
+  /** Convert the [[ServerError]] type into the ''endpoints'' internal server error type
+    * @group operations */
   def serverErrorToThrowable(serverError: ServerError): Throwable
 
   /**
@@ -38,11 +56,14 @@ trait Errors { this: Responses =>
     * a request fails.
     *
     * The provided implementation forwards to `badRequest`.
+    *
+    * @group operations
     */
   lazy val clientErrorsResponse: Response[ClientErrors] = badRequest(docs = Some("Client error"))
 
   /**
     * Format of the response entity carrying the client errors.
+    * @group operations
     */
   def clientErrorsResponseEntity: ResponseEntity[ClientErrors]
 
@@ -51,11 +72,13 @@ trait Errors { this: Responses =>
     * business logic of an endpoint fails.
     *
     * The provided implementation forwards to `internalServerError`
+    * @group operations
     */
   lazy val serverErrorResponse: Response[ServerError] = internalServerError(docs = Some("Server error"))
 
   /**
     * Format of the response entity carrying the server error.
+    * @group operations
     */
   def serverErrorResponseEntity: ResponseEntity[ServerError]
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
@@ -17,16 +17,20 @@ package endpoints.algebra
   */
 trait JsonEntities extends EndpointsWithCustomErrors {
 
-  /** Type class defining how to represent the `A` information as a JSON request entity */
+  /** Type class defining how to represent the `A` information as a JSON request entity
+    * @group types */
   type JsonRequest[A]
 
-  /** Type class defining how to represent the `A` information as a JSON response entity */
+  /** Type class defining how to represent the `A` information as a JSON response entity
+    * @group types */
   type JsonResponse[A]
 
-  /** Defines a `RequestEntity[A]` given an implicit `JsonRequest[A]` */
+  /** Defines a `RequestEntity[A]` given an implicit `JsonRequest[A]`
+    * @group operations */
   def jsonRequest[A : JsonRequest]: RequestEntity[A]
 
-  /** Defines a `Response[A]` given an implicit `JsonResponse[A]` */
+  /** Defines a `Response[A]` given an implicit `JsonResponse[A]`
+    * @group operations */
   def jsonResponse[A : JsonResponse]: ResponseEntity[A]
 }
 
@@ -43,8 +47,9 @@ trait JsonCodecs extends JsonEntities {
   type JsonRequest[A] = JsonCodec[A]
   type JsonResponse[A] = JsonCodec[A]
 
+  /** A JSON codec type class
+    * @group types */
 //#json-codec-type
-  /** A JSON codec type class */
   type JsonCodec[A]
 //#json-codec-type
 
@@ -57,7 +62,8 @@ trait JsonCodecs extends JsonEntities {
   */
 trait JsonEntitiesFromCodecs extends JsonCodecs {
 
-  /** Turns a JsonCodec[A] into a Codec[String, A] */
+  /** Turns a JsonCodec[A] into a Codec[String, A]
+    * @group operations */
   def stringCodec[A : JsonCodec]: Codec[String, A]
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/LowLevelEndpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/LowLevelEndpoints.scala
@@ -28,6 +28,8 @@ package endpoints.algebra
   *   someEndpoint(xhr => "Foo")
   *     .map(response => println(response.responseText))
   * }}}
+  *
+  * @group algebras
   */
 trait LowLevelEndpoints extends EndpointsWithCustomErrors {
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Methods.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Methods.scala
@@ -2,22 +2,35 @@ package endpoints.algebra
 
 /**
   * @group algebras
+  * @groupname types Types
+  * @groupdesc types Types introduced by the algebra
+  * @groupprio types 1
+  * @groupname operations Operations
+  * @groupdesc operations Operations creating and transforming values
+  * @groupprio operations 2
   */
 trait Methods {
 
-  /** HTTP Method */
+  /** HTTP Method
+    * @group types */
   type Method
 
+  /** @group operations */
   def Get: Method
 
+  /** @group operations */
   def Post: Method
 
+  /** @group operations */
   def Put: Method
 
+  /** @group operations */
   def Delete: Method
 
+  /** @group operations */
   def Patch: Method
 
+  /** @group operations */
   def Options: Method
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/MuxEndpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/MuxEndpoints.scala
@@ -10,6 +10,7 @@ trait MuxEndpoints extends EndpointsWithCustomErrors {
 
   /**
     * Information carried by a multiplexed HTTP endpoint.
+    * @group types
     */
   type MuxEndpoint[Req <: MuxRequest, Resp, Transport]
 
@@ -26,6 +27,7 @@ trait MuxEndpoints extends EndpointsWithCustomErrors {
     * @tparam Req The base type of possible requests
     * @tparam Resp The base type of possible responses
     * @tparam Transport The data type used to transport the requests and responses
+    * @group operations
     */
   def muxEndpoint[Req <: MuxRequest, Resp, Transport](
     request: Request[Transport],
@@ -38,5 +40,6 @@ trait MuxEndpoints extends EndpointsWithCustomErrors {
   * Multiplexed request type
   */
 trait MuxRequest {
+  /** Type of the response for `this` specific request */
   type Response
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -7,7 +7,10 @@ import endpoints._
   */
 trait Requests extends Urls with Methods with SemigroupalSyntax {
 
-  /** Information carried by requests’ headers */
+  /** Information carried by requests’ headers
+    * @note  This type has implicit methods provided by the [[SemigroupalSyntax]]
+    *        and [[InvariantFunctorSyntax]] classes.
+    * @group types */
   type RequestHeaders[A]
 
   /**
@@ -17,33 +20,55 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * headers will be built in the request.
     *
     * Use `description` of [[endpoints.algebra.Endpoints#endpoint]] to document empty headers.
+    * @group operations
     */
   def emptyHeaders: RequestHeaders[Unit]
 
+  /**
+    * A required request header
+    * @param name Header name (e.g., “Authorization”)
+    * @group operations
+    */
   def header(name: String, docs: Documentation = None): RequestHeaders[String]
 
+  /**
+    * An optional request header
+    * @param name Header name (e.g., “Authorization”)
+    * @group operations
+    */
   def optHeader(name: String, docs: Documentation = None): RequestHeaders[Option[String]]
 
+  /** Provides `++` operation.
+    * @see [[SemigroupalSyntax]] */
   implicit def reqHeadersSemigroupal: Semigroupal[RequestHeaders]
+  /** Provides `xmap` operation.
+    * @see [[InvariantFunctorSyntax]] */
   implicit def reqHeadersInvFunctor: InvariantFunctor[RequestHeaders]
 
 
-  /** Information carried by a whole request (headers and entity) */
+  /** Information carried by a whole request (headers and entity)
+    * @group types */
   type Request[A]
 
-  /** Information carried by request entity */
+  /** Information carried by request entity
+    * @note  This type has implicit methods provided by the [[InvariantFunctorSyntax]] class.
+    * @group types */
   type RequestEntity[A]
 
+  /** Provides `xmap` operation.
+    * @see [[InvariantFunctorSyntax]] */
   implicit def reqEntityInvFunctor: InvariantFunctor[RequestEntity]
 
   /**
     * Empty request -- request without a body.
     * Use `description` of [[endpoints.algebra.Endpoints#endpoint]] to document an empty body.
+    * @group operations
     */
   def emptyRequest: RequestEntity[Unit]
 
   /**
     * Request with a `String` body.
+    * @group operations
     */
   def textRequest: RequestEntity[String]
 
@@ -59,6 +84,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * @tparam BodyP Payload carried by body
     * @tparam HeadersP Payload carried by headers
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
+    * @group operations
     */
   def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     method: Method,
@@ -72,6 +98,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * Helper method to perform GET request
     * @tparam UrlP Payload carried by url
     * @tparam HeadersP Payload carried by headers
+    * @group operations
     */
   final def get[UrlP, HeadersP, Out](
     url: Url[UrlP],
@@ -87,6 +114,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * @tparam BodyP Payload carried by body
     * @tparam HeadersP Payload carried by headers
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
+    * @group operations
     */
   final def post[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     url: Url[UrlP],
@@ -102,6 +130,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * @tparam BodyP Payload carried by body
     * @tparam HeadersP Payload carried by headers
     * @tparam UrlAndBodyPTupled Payloads of Url and Body tupled together by [[Tupler]]
+    * @group operations
     */
   final def put[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
     url: Url[UrlP],
@@ -115,6 +144,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * Helper method to perform DELETE request
     * @tparam UrlP Payload carried by url
     * @tparam HeadersP Payload carried by headers
+    * @group operations
     */
   final def delete[UrlP, HeadersP, Out](
     url: Url[UrlP],

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
@@ -7,31 +7,44 @@ import endpoints.{InvariantFunctor, InvariantFunctorSyntax}
   */
 trait Responses extends StatusCodes with InvariantFunctorSyntax { this: Errors =>
 
-  /** An HTTP response (status, headers, and entity) carrying an information of type A */
+  /** An HTTP response (status, headers, and entity) carrying an information of type A
+    *
+    * @note This type has implicit methods provided by the [[InvariantFunctorSyntax]]
+    *       and [[ResponseSyntax]] class
+    * @group types
+    */
   type Response[A]
 
+  /** Provides the operation `xmap` to the type `Response`
+    * @see [[InvariantFunctorSyntax]]
+    */
   implicit def responseInvFunctor: InvariantFunctor[Response]
 
-  /** An HTTP response entity carrying an information of type A */
+  /** An HTTP response entity carrying an information of type A
+    * @group types
+    */
   type ResponseEntity[A]
 
   /**
     * Empty response entity
+    * @group operations
     */
   def emptyResponse: ResponseEntity[Unit]
 
   /**
     * Text response entity
+    * @group operations
     */
   def textResponse: ResponseEntity[String]
 
   /**
+    * Server interpreters construct a response with the given status and entity.
+    * Client interpreters accept a response only if it has a corresponding status code.
+    *
     * @param statusCode Response status code
     * @param entity     Response entity
     * @param docs       Response documentation
-    *
-    * Server interpreters construct a response with the given status and entity.
-    * Client interpreters accept a response only if it has a corresponding status code.
+    * @group operations
     */
   def response[A](statusCode: StatusCode, entity: ResponseEntity[A], docs: Documentation = None): Response[A]
 
@@ -46,6 +59,7 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax { this: Errors =
 
   /**
     * OK (200) Response with the given entity
+    * @group operations
     */
   final def ok[A](entity: ResponseEntity[A], docs: Documentation = None): Response[A] =
     response(OK, entity, docs)
@@ -53,6 +67,7 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax { this: Errors =
   /**
     * Bad Request (400) response, with an entity of type `ClientErrors`.
     * @see [[endpoints.algebra.Errors]] and [[endpoints.algebra.BuiltInErrors]]
+    * @group operations
     */
   final def badRequest(docs: Documentation = None): Response[ClientErrors] =
     response(BadRequest, clientErrorsResponseEntity, docs)
@@ -60,6 +75,7 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax { this: Errors =
   /**
     * Internal Server Error (500) response, with an entity of type `ServerError`.
     * @see [[endpoints.algebra.Errors]] and [[endpoints.algebra.BuiltInErrors]]
+    * @group operations
     */
   final def internalServerError(docs: Documentation = None): Response[ServerError] =
     response(InternalServerError, serverErrorResponseEntity, docs)
@@ -69,12 +85,17 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax { this: Errors =
     *
     * Interpreters represent `None` with
     * an empty HTTP response whose status code is 404 (Not Found).
+    *
+    * @group operations
     */
   final def wheneverFound[A](responseA: Response[A], notFoundDocs: Documentation = None): Response[Option[A]] =
     responseA.orElse(response(NotFound, emptyResponse, notFoundDocs))
       .xmap(_.fold[Option[A]](Some(_), _ => None))(_.toLeft(()))
 
-  /** Extension methods for [[Response]]. */
+  /** Extension methods for [[Response]].
+    *
+    * @group operations
+    */
   implicit class ResponseSyntax[A](response: Response[A]) {
     /**
       * Turns a `Response[A]` into a `Response[Option[A]]`.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/StatusCodes.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/StatusCodes.scala
@@ -2,19 +2,31 @@ package endpoints.algebra
 
 /**
   * @group algebras
+  * @groupname types Types
+  * @groupdesc types Types introduced by the algebra
+  * @groupprio types 1
+  * @groupname operations Operations
+  * @groupdesc operations Operations creating and transforming values
+  * @groupprio operations 2
   */
 trait StatusCodes {
 
-  /** HTTP Status Code */
+  /** HTTP Status Code
+    * @group types
+    */
   type StatusCode
 
   // 2xx Success
+  /** @group operations */
   def OK: StatusCode
 
+  /** @group operations */
   def Created: StatusCode
 
+  /** @group operations */
   def Accepted: StatusCode
 
+  /** @group operations */
   def NoContent: StatusCode
 
   // 4xx Client Error
@@ -22,13 +34,17 @@ trait StatusCodes {
     * @note You should use the `badRequest` constructor provided by the [[endpoints.algebra.Responses]]
     *       trait to ensure that errors produced by ''endpoints'' are consistently
     *       handled by interpreters.
+    * @group operations
     */
   def BadRequest: StatusCode
 
+  /** @group operations */
   def Unauthorized: StatusCode
 
+  /** @group operations */
   def Forbidden: StatusCode
 
+  /** @group operations */
   def NotFound: StatusCode
 
   // 5xx Server Error
@@ -36,9 +52,11 @@ trait StatusCodes {
     * @note You should use the `internalServerError` constructor provided by the
     *       [[endpoints.algebra.Responses]] trait to ensure that errors produced by ''endpoints''
     *       are consistently handled by interpreters.
+    * @group operations
     */
   def InternalServerError: StatusCode
 
+  /** @group operations */
   def NotImplemented: StatusCode
 
 }

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
@@ -30,6 +30,12 @@ import scala.util.{Failure, Success, Try}
   * }}}
   *
   * @group algebras
+  * @groupname types Types
+  * @groupdesc types Types introduced by the algebra
+  * @groupprio types 1
+  * @groupname operations Operations
+  * @groupdesc operations Operations creating and transforming values
+  * @groupprio operations 2
   */
 trait Urls extends PartialInvariantFunctorSyntax {
 
@@ -43,12 +49,18 @@ trait Urls extends PartialInvariantFunctorSyntax {
     *     qs[Int]("page") & qs[Option[String]]("lang")
     * }}}
     *
-    * */
+    * @note  This type has implicit methods provided by the [[QueryStringSyntax]],
+    *        [[InvariantFunctorSyntax]], and the [[PartialInvariantFunctorSyntax]] classes.
+    * @group types
+    */
   type QueryString[A]
 
+  /** Provides `xmap` and `xmapPartial` operations.
+    * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
   implicit def queryStringPartialInvFunctor: PartialInvariantFunctor[QueryString]
 
-  /** Extension methods on [[QueryString]]. */
+  /** Extension methods on [[QueryString]].
+    * @group operations */
   implicit class QueryStringSyntax[A](first: QueryString[A]) {
     /**
       * Convenient method to concatenate two [[QueryString]]s.
@@ -81,6 +93,7 @@ trait Urls extends PartialInvariantFunctorSyntax {
     *
     * @param name Parameter’s name
     * @tparam A Type of the value carried by the parameter
+    * @group operations
     */
   def qs[A](name: String, docs: Documentation = None)(implicit value: QueryStringParam[A]): QueryString[A]
 
@@ -95,6 +108,8 @@ trait Urls extends PartialInvariantFunctorSyntax {
     * Server interpreters must accept incoming requests whose optional query string parameters are missing.
     * Server interpreters must report a failure for incoming requests whose optional query string
     * parameters are present, but malformed.
+    *
+    * @group operations
     */
   implicit def optionalQueryStringParam[A: QueryStringParam]: QueryStringParam[Option[A]]
 
@@ -107,14 +122,21 @@ trait Urls extends PartialInvariantFunctorSyntax {
     *
     * Server interpreters must accept incoming requests where such parameters are missing (in such a
     * case, its value is an empty collection), and report a failure if at least one value is malformed.
+    *
+    * @group operations
     */
   implicit def repeatedQueryStringParam[A: QueryStringParam, CC[X] <: Iterable[X]](implicit factory: Factory[A, CC[A]]): QueryStringParam[CC[A]]
 
   /**
-    * A single query string parameter carrying an `A` information.
+    * A query string parameter codec for type `A`.
+    * @note  This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]]
+    *        and the [[InvariantFunctorSyntax]] classes.
+    * @group types
     */
   type QueryStringParam[A]
 
+  /** Provides `xmap` and `xmapPartial` operations.
+    * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
   implicit def queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam]
 
   def tryParseString[A](`type`: String)(parse: String => A): String => Validated[A] =
@@ -124,22 +146,27 @@ trait Urls extends PartialInvariantFunctorSyntax {
         case Success(a) => Valid(a)
       }
 
-  /** Ability to define `String` query string parameters */
+  /** Ability to define `String` query string parameters
+    * @group operations */
   implicit def stringQueryString: QueryStringParam[String]
 
-  /** Ability to define `UUID` query string parameters */
+  /** Ability to define `UUID` query string parameters
+    * @group operations */
   implicit def uuidQueryString: QueryStringParam[UUID] =
     stringQueryString.xmapPartial(tryParseString("UUID")(UUID.fromString))(_.toString())
 
-  /** Ability to define `Int` query string parameters */
+  /** Ability to define `Int` query string parameters
+    * @group operations */
   implicit def intQueryString: QueryStringParam[Int] =
     stringQueryString.xmapPartial(tryParseString("integer")(_.toInt))(_.toString())
 
-  /** Query string parameter containing a `Long` value */
+  /** Query string parameter containing a `Long` value
+    * @group operations */
   implicit def longQueryString: QueryStringParam[Long] =
     stringQueryString.xmapPartial(tryParseString("integer")(_.toLong))(_.toString())
 
-  /** Query string parameter containing a `Boolean` value */
+  /** Query string parameter containing a `Boolean` value
+    * @group operations */
   implicit def booleanQueryString: QueryStringParam[Boolean] =
     stringQueryString.xmapPartial[Boolean] {
       case "true"  | "1" => Valid(true)
@@ -147,46 +174,68 @@ trait Urls extends PartialInvariantFunctorSyntax {
       case s             => Invalid(s"Invalid boolean value '$s'")
     }(_.toString())
 
+  /** Codec for query string parameters of type `Double`
+    * @group operations */
   implicit def doubleQueryString: QueryStringParam[Double] =
     stringQueryString.xmapPartial(tryParseString("number")(_.toDouble))(_.toString())
 
   /**
-    * An URL path segment carrying an `A` information.
+    * An URL path segment codec for type `A`.
+    * @note  This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]]
+    *        and the [[InvariantFunctorSyntax]] classes.
+    * @group types
     */
   type Segment[A]
 
+  /** Provides `xmap` and `xmapPartial` operations.
+    * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
   implicit def segmentPartialInvFunctor: PartialInvariantFunctor[Segment]
 
   /** Ability to define `String` path segments
     * Servers should return an URL-decoded string value,
     * and clients should take an URL-decoded string value.
+    * @group operations
     */
   implicit def stringSegment: Segment[String]
 
-  /** Ability to define `UUID` path segments */
+  /** Ability to define `UUID` path segments
+    * @group operations */
   implicit def uuidSegment: Segment[UUID] =
     stringSegment.xmapPartial(tryParseString("UUID")(UUID.fromString))(_.toString())
 
-  /** Ability to define `Int` path segments */
+  /** Ability to define `Int` path segments
+    * @group operations */
   implicit def intSegment: Segment[Int] =
     stringSegment.xmapPartial(tryParseString("integer")(_.toInt))(_.toString())
 
-  /** Segment containing a `Long` value */
+  /** Segment containing a `Long` value
+    * @group operations */
   implicit def longSegment: Segment[Long] =
     stringSegment.xmapPartial(tryParseString("integer")(_.toLong))(_.toString())
 
+  /**
+    * Segment codec for type `Double`
+    * @group operations
+    */
   implicit def doubleSegment: Segment[Double] =
     stringSegment.xmapPartial(tryParseString("number")(_.toDouble))(_.toString())
 
-  /** An URL path carrying an `A` information */
+  /** An URL path carrying an `A` information
+    * @note  This type has implicit methods provided by the [[PathOps]],
+    *        [[InvariantFunctorSyntax]], and the [[PartialInvariantFunctorSyntax]] classes.
+    * @group types */
   type Path[A] <: Url[A]
 
+  /** Provides `xmap` and `xmapPartial` operations.
+    * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
   implicit def pathPartialInvariantFunctor: PartialInvariantFunctor[Path]
 
-  /** Implicit conversion to get rid of intellij errors when defining paths. Effectively should not be called.*/
+  /** Implicit conversion to get rid of intellij errors when defining paths. Effectively should not be called.
+    * @see [[https://youtrack.jetbrains.com/issue/SCL-16284]] */
   implicit def dummyPathToUrl[A](p: Path[A]): Url[A] = p
 
-  /** Convenient methods for [[Path]]s. */
+  /** Convenient methods for [[Path]]s.
+    * @group operations */
   implicit class PathOps[A](first: Path[A]) {
     /** Chains this path with the `second` constant path segment */
     final def / (second: String): Path[A] = chainPaths(first, staticPathSegment(second))
@@ -196,13 +245,16 @@ trait Urls extends PartialInvariantFunctorSyntax {
     final def /? [B](qs: QueryString[B])(implicit tupler: Tupler[A, B]): Url[tupler.Out] = urlWithQueryString(first, qs)
   }
 
-  /** A path segment whose value is the given `segment` */
+  /** A path segment whose value is the given `segment`
+    * @group operations */
   def staticPathSegment(segment: String): Path[Unit]
 
-  /** A path segment carrying an `A` information */
+  /** A path segment carrying an `A` information
+    * @group operations */
   def segment[A](name: String = "", docs: Documentation = None)(implicit s: Segment[A]): Path[A]
 
-  /** The remaining segments of the path. The `String` value carried by this `Path` is still URL-encoded. */
+  /** The remaining segments of the path. The `String` value carried by this `Path` is still URL-encoded.
+    * @group operations */
   def remainingSegments(name: String = "", docs: Documentation = None): Path[String] // TODO Make it impossible to chain it with another path (ie, `path / remainingSegments() / "foo"` should not compile)
 
   /** Chains the two paths */
@@ -217,14 +269,20 @@ trait Urls extends PartialInvariantFunctorSyntax {
     *   path / "foo" / segment[Int] /? qs[String]("bar")
     * }}}
     *
+    * @group operations
     */
   val path: Path[Unit] = staticPathSegment("")
 
   /**
     * An URL carrying an `A` information
+    * @note  This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]]
+    *        and [[InvariantFunctorSyntax]] classes.
+    * @group types
     */
   type Url[A]
 
+  /** Provides `xmap` and `xmapPartial` operations
+    * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
   implicit def urlPartialInvFunctor: PartialInvariantFunctor[Url]
 
   /** Builds an URL from the given path and query string */

--- a/algebras/algebra/src/main/scala/endpoints/algebra/package.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/package.scala
@@ -2,6 +2,7 @@ package endpoints
 
 /**
   * @groupname algebras Algebras
+  * @groupname interpreters Interpreters
   */
 package object algebra {
 

--- a/json-schema/json-schema-circe/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/json-schema/json-schema-circe/src/main/boilerplate/TuplesSchemas.scala.template
@@ -3,6 +3,9 @@ package endpoints.circe
 import endpoints.algebra
 import io.circe.{Encoder, Decoder}
 
+/**
+  * @group interpreters
+  */
 trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
   [2..#
   implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] = {

--- a/json-schema/json-schema-playjson/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/json-schema/json-schema-playjson/src/main/boilerplate/TuplesSchemas.scala.template
@@ -3,6 +3,9 @@ package endpoints.playjson
 import endpoints.algebra
 import play.api.libs.json.{Reads, Writes}
 
+/**
+  * @group interpreters
+  */
 trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
   [2..#
   implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] = {

--- a/json-schema/json-schema/src/main/boilerplate/TuplesSchemas.scala.template
+++ b/json-schema/json-schema/src/main/boilerplate/TuplesSchemas.scala.template
@@ -2,6 +2,8 @@ package endpoints.algebra
 
 /**
   * Generated trait that provides `JsonSchema` constructors for tuples from 2 to 22 elements.
+  *
+  * @group algebras
   */
 trait TuplesSchemas { this: JsonSchemas =>
   [2..#

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -63,7 +63,7 @@ import scala.util.control.Exception
   *
   * @group algebras
   * @groupname types Types
-  * @groupdesc types Types introduced by the algebra interface
+  * @groupdesc types Types introduced by the algebra
   * @groupprio types 1
   * @groupname operations Operations
   * @groupdesc operations Operations creating and transforming values
@@ -253,6 +253,10 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
 
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A]
 
+  /**
+    * Implicit methods for values of type [[JsonSchema]]
+    * @group operations
+    */
   final implicit class JsonSchemaOps[A](schemaA: JsonSchema[A]) {
     def withExample(example: A): JsonSchema[A] = withExampleJsonSchema(schemaA, example)
   }

--- a/openapi/openapi/src/main/boilerplate/endpoints/openapi/TuplesSchemas.scala.template
+++ b/openapi/openapi/src/main/boilerplate/endpoints/openapi/TuplesSchemas.scala.template
@@ -2,6 +2,9 @@ package endpoints.openapi
 
 import endpoints.algebra
 
+/**
+  * @group interpreters
+  */
 trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
   [2..#
   implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] =

--- a/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
+++ b/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
@@ -2,6 +2,9 @@ package endpoints.ujson
 
 import endpoints.{ algebra, Invalid }
 
+/**
+  * @group interpreters
+  */
 trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
   [2..#
   implicit def tuple1JsonSchema[[#T1#]](implicit [#schema1: JsonSchema[T1]#]): JsonSchema[([#T1#])] =

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BuiltInErrors.scala
@@ -4,6 +4,9 @@ import endpoints.openapi.model.{MediaType, Schema}
 import endpoints.ujson.codecs.schemas
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   private lazy val invalidJsonEntity =

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -6,6 +6,9 @@ import endpoints.algebra.{Codec, Decoder, Encoder}
 import scala.collection.compat._
 import scala.collection.mutable
 
+/**
+  * @group interpreters
+  */
 trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {

--- a/openapi/openapi/src/main/scala/endpoints/ujson/package.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/package.scala
@@ -1,0 +1,8 @@
+package endpoints
+
+/**
+  * Interpreters producing JSON codecs using ''ujson''.
+  *
+  * @groupname interpreters Interpreters
+  */
+package object ujson

--- a/play/client/src/main/scala/endpoints/play/client/BuiltInErrors.scala
+++ b/play/client/src/main/scala/endpoints/play/client/BuiltInErrors.scala
@@ -2,6 +2,9 @@ package endpoints.play.client
 
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] =

--- a/play/client/src/main/scala/endpoints/play/client/StatusCodes.scala
+++ b/play/client/src/main/scala/endpoints/play/client/StatusCodes.scala
@@ -2,6 +2,9 @@ package endpoints.play.client
 
 import endpoints.algebra
 
+/**
+  * @group interpreters
+  */
 trait StatusCodes extends algebra.StatusCodes {
 
   type StatusCode = Int

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
@@ -11,6 +11,8 @@ import play.api.http.Writeable
   * Interpreter for [[algebra.JsonEntities]] that uses circe’s [[io.circe.Decoder]] to decode
   * JSON entities in HTTP requests, and circe’s [[io.circe.Encoder]] to build JSON entities
   * in HTTP responses.
+  *
+  * @group interpreters
   */
 trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
 

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntitiesFromCodecs.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntitiesFromCodecs.scala
@@ -3,6 +3,8 @@ package endpoints.play.server.circe
 /**
   * Convenient trait that groups together [[endpoints.play.server.JsonEntitiesFromCodecs]]
   * and [[endpoints.algebra.circe.JsonEntitiesFromCodecs]].
+  *
+  * @group interpreters
   */
 trait JsonEntitiesFromCodecs
   extends endpoints.play.server.JsonEntitiesFromCodecs

--- a/play/server/src/main/scala/endpoints/play/server/BuiltInErrors.scala
+++ b/play/server/src/main/scala/endpoints/play/server/BuiltInErrors.scala
@@ -3,6 +3,9 @@ package endpoints.play.server
 import endpoints.{Invalid, algebra}
 import play.api.http.{ContentTypes, Writeable}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] = {

--- a/play/server/src/main/scala/endpoints/play/server/JsonEntities.scala
+++ b/play/server/src/main/scala/endpoints/play/server/JsonEntities.scala
@@ -47,7 +47,7 @@ trait JsonEntitiesFromSchemas
   *
   * It is especially useful to encode `OpenApi` documents into JSON entities.
   *
-  * @group interpreter
+  * @group interpreters
   */
 trait JsonEntitiesFromEncodersAndDecoders extends algebra.JsonEntities with EndpointsWithCustomErrors {
 

--- a/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
@@ -4,6 +4,9 @@ import endpoints.algebra
 import play.api.mvc
 import play.api.mvc._
 
+/**
+  * @group interpreters
+  */
 trait LowLevelEndpoints extends algebra.LowLevelEndpoints with Endpoints {
 
   import playComponents.executionContext

--- a/play/server/src/main/scala/endpoints/play/server/StatusCodes.scala
+++ b/play/server/src/main/scala/endpoints/play/server/StatusCodes.scala
@@ -1,9 +1,11 @@
 package endpoints.play.server
 
 import endpoints.algebra
-
 import play.api.mvc.Results
 
+/**
+  * @group interpreters
+  */
 trait StatusCodes extends algebra.StatusCodes {
 
   type StatusCode = Results.Status

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/BuiltInErrors.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/BuiltInErrors.scala
@@ -2,6 +2,9 @@ package endpoints.scalaj.client
 
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] =

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/StatusCodes.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/StatusCodes.scala
@@ -2,6 +2,9 @@ package endpoints.scalaj.client
 
 import endpoints.algebra
 
+/**
+  * @group interpreters
+  */
 trait StatusCodes extends algebra.StatusCodes {
 
   type StatusCode = Int

--- a/sttp/client/src/main/scala/endpoints/sttp/client/BuiltInErrors.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/BuiltInErrors.scala
@@ -2,6 +2,9 @@ package endpoints.sttp.client
 
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors[R[_]] extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors[R] =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] =

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -27,6 +27,7 @@ class Endpoints[R[_]](val host: String, val backend: sttp.SttpBackend[R, Nothing
   * a sttp’s `com.softwaremill.sttp.SttpBackend`.
   *
   * @tparam R The monad wrapping the response. It is defined by the backend
+  * @group interpreters
   */
 trait EndpointsWithCustomErrors[R[_]] extends algebra.EndpointsWithCustomErrors
   with Urls with Methods with StatusCodes {

--- a/sttp/client/src/main/scala/endpoints/sttp/client/StatusCodes.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/StatusCodes.scala
@@ -2,6 +2,9 @@ package endpoints.sttp.client
 
 import endpoints.algebra
 
+/**
+  * @group interpreters
+  */
 trait StatusCodes extends algebra.StatusCodes {
 
   type StatusCode = Int

--- a/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
+++ b/xhr/client-circe/src/main/scala/endpoints/xhr/circe/JsonEntities.scala
@@ -9,6 +9,8 @@ import org.scalajs.dom.XMLHttpRequest
   * An interpreter for [[algebra.JsonEntities]] that uses circe’s [[io.circe.Encoder]] to build JSON
   * entities in HTTP requests, and circe’s [[io.circe.Decoder]] to decode JSON entities from
   * HTTP responses.
+  *
+  * @group interpreters
   */
 trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
 

--- a/xhr/client/src/main/scala/endpoints/xhr/BuiltInErrors.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/BuiltInErrors.scala
@@ -2,6 +2,9 @@ package endpoints.xhr
 
 import endpoints.{Invalid, algebra}
 
+/**
+  * @group interpreters
+  */
 trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
 
   def clientErrorsResponseEntity: ResponseEntity[Invalid] =


### PR DESCRIPTION
The architecture of _endpoints_ does not render well in the API documentation. Consider for instance the type `Response[A]` introduced by the `Responses` algebra. This type has a method `orElse`, but this method is not shown in the documentation because the type `Response[A]` is an abstract type member, and the method is provided via an implicit conversion. Similarly, types that have a `PartialInvariantFunctor` instance have the methods `xmap` and `xmapPartial` but those don’t show up in the documentation. Last, some types and operations do show up in the documentation but they exist only for technical reasons (e.g., `ResponseSyntax` is the implicit class that provides additional operations to the `Response` type), and introduce noise in the API documentation.

This commit meticulously classifies types and operations introduced by algebras so that “technical” irrelevant members (e.g., implicit classes) are separated from relevant members. It also systematically adds a note to each type that has implicit methods, with links to those methods.