### PR TITLE
Remove explicit dependency override of scala-java8-compat

### DIFF
--- a/play/build.sbt
+++ b/play/build.sbt
@@ -15,8 +15,7 @@ val `play-server` =
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play-netty-server" % playVersion,
         "com.typesafe.play" %% "play-test" % playVersion % Test,
-        "com.typesafe.play" %% "play-ahc-ws" % playVersion % Test,
-        "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0" % Test, // See https://github.com/playframework/play-ws/issues/371
+        "com.typesafe.play" %% "play-ahc-ws" % playVersion % Test
       )
     )
     .dependsOn(`algebra-jvm` % "test->test;compile->compile")
@@ -40,8 +39,7 @@ val `play-client` =
       `scala 2.12 to latest`,
       name := "endpoints-play-client",
       libraryDependencies ++= Seq(
-        "com.typesafe.play" %% "play-ahc-ws" % playVersion,
-        "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0", // See https://github.com/playframework/play-ws/issues/371
+        "com.typesafe.play" %% "play-ahc-ws" % playVersion
       )
     )
     .dependsOn(`algebra-jvm` % "test->test;compile->compile", `algebra-circe-jvm` % "compile->test;test->test")


### PR DESCRIPTION
Doesn’t seem to be necessary anymore.