### PR TITLE
Provide more helpful error messages when generic JsonSchema derivation fails

### DIFF
--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
@@ -5,6 +5,7 @@ import shapeless.labelled.{FieldType, field => shapelessField}
 import shapeless.ops.hlist.Tupler
 import shapeless.{:+:, ::, Annotation, Annotations, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, LabelledGeneric, Witness}
 
+import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
 
 /**
@@ -40,6 +41,15 @@ import scala.reflect.ClassTag
   */
 trait JsonSchemas extends algebra.JsonSchemas {
 
+  @implicitNotFound(
+    "Unable to derive an instance of JsonSchema[${A}].\n" +
+    "The type ${A} must be a sealed trait or a case class.\n" +
+    "If it is a sealed trait, make sure it is only extended by case classes and that a " +
+    "JsonSchema can be derived for each of these case classes (see hereafter).\n" +
+    "If it is a case class, make sure each field of the case class has an implicit JsonSchema.\n" +
+    "You can check that a JsonSchema is available for a type T by compiling the expression " +
+    "`implicitly[JsonSchema[T]]`."
+  )
   trait GenericJsonSchema[A] {
     def jsonSchema: JsonSchema[A]
   }
@@ -111,8 +121,23 @@ trait JsonSchemas extends algebra.JsonSchemas {
 
   trait GenericJsonSchemaLowLowPriority { this: GenericJsonSchema.type =>
 
+    @implicitNotFound(
+      "Unable to derive an instance of JsonSchema[${A}].\n" +
+      "The type ${A} must be a case class. Make sure each field of the case class has an implicit JsonSchema.\n" +
+      "You can check that a JsonSchema is available for a type T by compiling the expression " +
+      "`implicitly[JsonSchema[T]]`.\n" +
+      "If type ${A} is a sealed trait, use `genericTagged` or `genericJsonSchema` instead."
+    )
     class GenericRecord[A](val jsonSchema: Record[A]) extends GenericJsonSchema[A]
 
+    @implicitNotFound(
+      "Unable to derive an instance of JsonSchema[${A}].\n" +
+      "The type ${A} must be a sealed trait. Make sure it is only extended by case classes, and " +
+      "for each case class, make sure each field of the case class has an implicit JsonSchema.\n" +
+      "You can check that a JsonSchema is available for a type T by compiling the expression " +
+      "`implicitly[JsonSchema[T]]`.\n" +
+      "If type ${A} is a case class, use `genericRecord` or `genericJsonSchema` instead."
+    )
     class GenericTagged[A](val jsonSchema: Tagged[A]) extends GenericJsonSchema[A]
 
     trait DocumentedGenericRecord[A, D <: HList] {


### PR DESCRIPTION
Tested locally only.

Examples of errors:

~~~
[error] json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala:56:22: Unable to derive an instance of JsonSchema[GenericSchemas.this.SomeClass].
[error] The type GenericSchemas.this.SomeClass must be a sealed trait or a case class.
[error] If it is a sealed trait, make sure it is only extended by case classes and that a JsonSchema can be derived for each of these case classes (see hereafter).
[error] If it is a case class, make sure each field of the case class has an implicit JsonSchema.
[error] You can check that a JsonSchema is available for a type T by compiling the expression `implicitly[JsonSchema[T]]`.
[error]     genericJsonSchema[SomeClass]
[error]                      ^
[error] one error found
~~~

~~~
[error] json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala:58:18: Unable to derive an instance of JsonSchema[GenericSchemas.this.SomeClass].
[error] The type GenericSchemas.this.SomeClass must be a sealed trait. Make sure it is only extended by case classes, and for each case class, make sure each field of the case class has an implicit JsonSchema.
[error] You can check that a JsonSchema is available for a type T by compiling the expression `implicitly[JsonSchema[T]]`.
[error] If type GenericSchemas.this.SomeClass is a case class, use `genericRecord` or `genericJsonSchema` instead.
[error]     genericTagged[SomeClass]
[error]                  ^
[error] one error found
~~~

~~~
[error] json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala:57:31: Unable to derive an instance of JsonSchema[GenericSchemas.this.SomeClass].
[error] The type GenericSchemas.this.SomeClass must be a case class. Make sure each field of the case class has an implicit JsonSchema.
[error] You can check that a JsonSchema is available for a type T by compiling the expression `implicitly[JsonSchema[T]]`.
[error] If type GenericSchemas.this.SomeClass is a sealed trait, use `genericTagged` or `genericJsonSchema` instead.
[error]     genericRecord[SomeClass]
[error]                  ^
[error] one error found
~~~

