### PR TITLE
Rename request headers constructors

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -51,14 +51,14 @@ trait EndpointsWithCustomErrors
       }
   }
 
-  lazy val emptyHeaders: RequestHeaders[Unit] = (_, req) => req
+  lazy val emptyRequestHeaders: RequestHeaders[Unit] = (_, req) => req
 
   case class InvalidHeaderDefinition(parsingResult: ParsingResult) extends RuntimeException
 
-  def header(name: String, docs: Option[String]): (String, List[HttpHeader]) => List[HttpHeader] =
+  def requestHeader(name: String, docs: Option[String]): (String, List[HttpHeader]) => List[HttpHeader] =
     (value, headers) => createHeader(name, value) :: headers
 
-  def optHeader(name: String, docs: Option[String]): (Option[String], List[HttpHeader]) => List[HttpHeader] =
+  def optRequestHeader(name: String, docs: Option[String]): (Option[String], List[HttpHeader]) => List[HttpHeader] =
     (valueOpt, headers) => valueOpt match {
       case Some(value) => createHeader(name, value) :: headers
       case None => headers

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -82,11 +82,11 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
       HEADERS
   ************************* */
 
-  def emptyHeaders: RequestHeaders[Unit] = convToDirective1(Directives.pass)
+  def emptyRequestHeaders: RequestHeaders[Unit] = convToDirective1(Directives.pass)
 
-  def header(name: String, docs: Documentation): RequestHeaders[String] = Directives.headerValueByName(name)
+  def requestHeader(name: String, docs: Documentation): RequestHeaders[String] = Directives.headerValueByName(name)
 
-  def optHeader(name: String, docs: Documentation): RequestHeaders[Option[String]] = Directives.optionalHeaderValueByName(name)
+  def optRequestHeader(name: String, docs: Documentation): RequestHeaders[Option[String]] = Directives.optionalHeaderValueByName(name)
 
   implicit lazy val reqHeadersInvFunctor: InvariantFunctor[RequestHeaders] = directive1InvFunctor
   implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] = new Semigroupal[RequestHeaders] {
@@ -152,7 +152,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
     url: Url[A],
     entity: RequestEntity[B] = emptyRequest,
     docs: Documentation = None,
-    headers: RequestHeaders[C] = emptyHeaders
+    headers: RequestHeaders[C] = emptyRequestHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] = {
     val methodDirective = convToDirective1(Directives.method(method))
     val matchDirective = methodDirective & url.directive & headers

--- a/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/BasicAuthentication.scala
@@ -57,7 +57,7 @@ trait BasicAuthentication extends EndpointsWithCustomErrors {
     url: Url[U],
     response: Response[R],
     requestEntity: RequestEntity[E] = emptyRequest,
-    requestHeaders: RequestHeaders[H] = emptyHeaders,
+    requestHeaders: RequestHeaders[H] = emptyRequestHeaders,
     unauthenticatedDocs: Documentation = None,
     requestDocs: Documentation = None,
     endpointDocs: EndpointDocs = EndpointDocs()

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -7,7 +7,11 @@ import endpoints._
   */
 trait Requests extends Urls with Methods with SemigroupalSyntax {
 
-  /** Information carried by requests’ headers
+  /** Information carried by requests’ headers.
+    *
+    * You can construct values of type `RequestHeaders` by using the operations
+    * [[requestHeader]], [[optRequestHeader]], or [[emptyRequestHeaders]].
+    *
     * @note  This type has implicit methods provided by the [[SemigroupalSyntax]]
     *        and [[InvariantFunctorSyntax]] classes.
     * @group types */
@@ -22,21 +26,21 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * Use `description` of [[endpoints.algebra.Endpoints#endpoint]] to document empty headers.
     * @group operations
     */
-  def emptyHeaders: RequestHeaders[Unit]
+  def emptyRequestHeaders: RequestHeaders[Unit]
 
   /**
     * A required request header
     * @param name Header name (e.g., “Authorization”)
     * @group operations
     */
-  def header(name: String, docs: Documentation = None): RequestHeaders[String]
+  def requestHeader(name: String, docs: Documentation = None): RequestHeaders[String]
 
   /**
     * An optional request header
     * @param name Header name (e.g., “Authorization”)
     * @group operations
     */
-  def optHeader(name: String, docs: Documentation = None): RequestHeaders[Option[String]]
+  def optRequestHeader(name: String, docs: Documentation = None): RequestHeaders[Option[String]]
 
   /** Provides `++` operation.
     * @see [[SemigroupalSyntax]] */
@@ -91,7 +95,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     url: Url[UrlP],
     entity: RequestEntity[BodyP] = emptyRequest,
     docs: Documentation = None,
-    headers: RequestHeaders[HeadersP] = emptyHeaders
+    headers: RequestHeaders[HeadersP] = emptyRequestHeaders
   )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out]
 
   /**
@@ -103,7 +107,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
   final def get[UrlP, HeadersP, Out](
     url: Url[UrlP],
     docs: Documentation = None,
-    headers: RequestHeaders[HeadersP] = emptyHeaders
+    headers: RequestHeaders[HeadersP] = emptyRequestHeaders
   )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] =
     request(Get, url, docs = docs, headers = headers)
 
@@ -120,7 +124,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     url: Url[UrlP],
     entity: RequestEntity[BodyP],
     docs: Documentation = None,
-    headers: RequestHeaders[HeadersP] = emptyHeaders
+    headers: RequestHeaders[HeadersP] = emptyRequestHeaders
   )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] =
     request(Post, url, entity, docs, headers)
 
@@ -136,7 +140,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     url: Url[UrlP],
     entity: RequestEntity[BodyP],
     docs: Documentation = None,
-    headers: RequestHeaders[HeadersP] = emptyHeaders
+    headers: RequestHeaders[HeadersP] = emptyRequestHeaders
   )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled], tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] =
     request(Put, url, entity, docs, headers)
 
@@ -149,7 +153,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
   final def delete[UrlP, HeadersP, Out](
     url: Url[UrlP],
     docs: Documentation = None,
-    headers: RequestHeaders[HeadersP] = emptyHeaders
+    headers: RequestHeaders[HeadersP] = emptyRequestHeaders
   )(implicit tuplerUH: Tupler.Aux[UrlP, HeadersP, Out]): Request[Out] =
     request(Delete, url, docs = docs, headers = headers)
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala
@@ -25,7 +25,7 @@ trait EndpointsDocs extends Endpoints {
   //#request-construction
   // A request that uses the verb “GET”, the URL path “/foo”,
   // no entity, no documentation, and no headers
-  request(Get, path / "foo", emptyRequest, None, emptyHeaders)
+  request(Get, path / "foo", emptyRequest, None, emptyRequestHeaders)
   //#request-construction
 
   //#convenient-get

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -54,13 +54,13 @@ trait EndpointsTestApi extends algebra.Endpoints {
     wheneverFound(ok(textResponse))
   )
 
-  val headers1 = header("A") ++ header("B")
+  val headers1 = requestHeader("A") ++ requestHeader("B")
   val joinedHeadersEndpoint = endpoint(
     get(path / "joinedHeadersEndpoint", headers = headers1),
     ok(textResponse)
   )
 
-  val headers2 = header("C").xmap(_.toInt)(_.toString)
+  val headers2 = requestHeader("C").xmap(_.toInt)(_.toString)
   val xmapHeadersEndpoint = endpoint(
     get(path / "xmapHeadersEndpoint", headers = headers2),
     ok(textResponse)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Assets.scala
@@ -23,7 +23,7 @@ trait Assets
 
   def assetsEndpoint(url: Url[AssetPath], docs: Documentation, notFoundDocs: Documentation): Endpoint[AssetRequest, AssetResponse] =
     endpoint(
-      DocumentedRequest(Get, url, emptyHeaders, None, emptyRequest),
+      DocumentedRequest(Get, url, emptyRequestHeaders, None, emptyRequest),
       DocumentedResponse(OK, docs.getOrElse(""), emptyResponseHeaders, Map.empty) ::
         DocumentedResponse(NotFound, notFoundDocs.getOrElse(""), emptyResponseHeaders, Map.empty) ::
         Nil

--- a/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/BasicAuthentication.scala
@@ -36,7 +36,7 @@ trait BasicAuthentication
     url: Url[U],
     response: Response[R],
     requestEntity: RequestEntity[E] = emptyRequest,
-    requestHeaders: RequestHeaders[H] = emptyHeaders,
+    requestHeaders: RequestHeaders[H] = emptyRequestHeaders,
     unauthenticatedDocs: Documentation = None,
     requestDocs: Documentation = None,
     endpointDocs: EndpointDocs = EndpointDocs()

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -17,12 +17,12 @@ trait Requests
 
   type RequestHeaders[A] = DocumentedHeaders
 
-  def emptyHeaders = DocumentedHeaders(Nil)
+  def emptyRequestHeaders = DocumentedHeaders(Nil)
 
-  def header(name: String, docs: Documentation): RequestHeaders[String] =
+  def requestHeader(name: String, docs: Documentation): RequestHeaders[String] =
     DocumentedHeaders(List(DocumentedHeader(name, docs, required = true, Schema.simpleString)))
 
-  def optHeader(name: String, docs: Documentation): RequestHeaders[Option[String]] =
+  def optRequestHeader(name: String, docs: Documentation): RequestHeaders[Option[String]] =
     DocumentedHeaders(List(DocumentedHeader(name, docs, required = false, Schema.simpleString)))
 
 
@@ -47,7 +47,7 @@ trait Requests
     url: Url[A],
     entity: RequestEntity[B] = emptyRequest,
     docs: Documentation = None,
-    headers: RequestHeaders[C] = emptyHeaders
+    headers: RequestHeaders[C] = emptyRequestHeaders
   )(implicit tuplerAB: Tupler.Aux[A, B, AB], tuplerABC: Tupler.Aux[AB, C, Out]): Request[Out] =
     DocumentedRequest(method, url, headers, docs, entity)
 

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -40,12 +40,12 @@ trait EndpointsWithCustomErrors
   type RequestHeaders[A] = (A, WSRequest) => WSRequest
 
   /** Does not modify the request */
-  lazy val emptyHeaders: RequestHeaders[Unit] = (_, wsRequest) => wsRequest
+  lazy val emptyRequestHeaders: RequestHeaders[Unit] = (_, wsRequest) => wsRequest
 
-  def header(name: String, docs: Documentation): (String, WSRequest) => WSRequest =
+  def requestHeader(name: String, docs: Documentation): (String, WSRequest) => WSRequest =
     (value, req) => req.addHttpHeaders(name -> value)
 
-  def optHeader(name: String, docs: Documentation): (Option[String], WSRequest) => WSRequest = {
+  def optRequestHeader(name: String, docs: Documentation): (Option[String], WSRequest) => WSRequest = {
     case (Some(value), req) => req.addHttpHeaders(name -> value)
     case (None, req) => req
   }

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -65,15 +65,15 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
   type RequestHeaders[A] = Headers => Validated[A]
 
   /** Always succeeds in extracting no information from the headers */
-  lazy val emptyHeaders: RequestHeaders[Unit] = _ => Valid(())
+  lazy val emptyRequestHeaders: RequestHeaders[Unit] = _ => Valid(())
 
-  def header(name: String,docs: Option[String]): Headers => Validated[String] =
+  def requestHeader(name: String,docs: Option[String]): Headers => Validated[String] =
     headers => headers.get(name) match {
       case Some(value) => Valid(value)
       case None        => Invalid(s"Missing header $name")
     }
 
-  def optHeader(name: String,docs: Option[String]): Headers => Validated[Option[String]] =
+  def optRequestHeader(name: String,docs: Option[String]): Headers => Validated[Option[String]] =
     headers => Valid(headers.get(name))
 
   implicit lazy val reqHeadersInvFunctor: endpoints.InvariantFunctor[RequestHeaders] = new endpoints.InvariantFunctor[RequestHeaders] {

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -17,11 +17,11 @@ trait Requests extends algebra.Requests with Urls with Methods {
 
   type RequestEntity[A] = (A, HttpRequest) => HttpRequest
 
-  def emptyHeaders: RequestHeaders[Unit] = _ => Seq()
+  def emptyRequestHeaders: RequestHeaders[Unit] = _ => Seq()
 
-  def header(name: String, docs: Documentation): String => Seq[(String, String)] = value => Seq(name -> value)
+  def requestHeader(name: String, docs: Documentation): String => Seq[(String, String)] = value => Seq(name -> value)
 
-  def optHeader(name: String, docs: Documentation): Option[String] => Seq[(String, String)] =
+  def optRequestHeader(name: String, docs: Documentation): Option[String] => Seq[(String, String)] =
     valueOpt => valueOpt.map(v => name -> v).toSeq
 
   implicit def reqHeadersInvFunctor: InvariantFunctor[RequestHeaders] = new InvariantFunctor[RequestHeaders] {
@@ -53,7 +53,7 @@ trait Requests extends algebra.Requests with Urls with Methods {
     url: Url[U],
     entity: RequestEntity[E] = emptyRequest,
     docs: Documentation = None,
-    headers: RequestHeaders[H] = emptyHeaders
+    headers: RequestHeaders[H] = emptyRequestHeaders
   )(implicit tuplerUE: Tupler.Aux[U, E, UE], tuplerUEH: Tupler.Aux[UE, H, Out]): Request[Out] =
     (ueh) => {
       val (ue, h) = tuplerUEH.unapply(ueh)

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -44,11 +44,11 @@ trait EndpointsWithCustomErrors[R[_]] extends algebra.EndpointsWithCustomErrors
   type RequestHeaders[A] = (A, SttpRequest) => SttpRequest
 
   /** Does not modify the request */
-  lazy val emptyHeaders: RequestHeaders[Unit] = (_, request) => request
+  lazy val emptyRequestHeaders: RequestHeaders[Unit] = (_, request) => request
 
-  def header(name: String, docs: Documentation): RequestHeaders[String] = (value, request) => request.header(name, value)
+  def requestHeader(name: String, docs: Documentation): RequestHeaders[String] = (value, request) => request.header(name, value)
 
-  def optHeader(name: String, docs: Documentation): (Option[String], SttpRequest) => SttpRequest = {
+  def optRequestHeader(name: String, docs: Documentation): (Option[String], SttpRequest) => SttpRequest = {
     case (Some(value), request) => request.header(name, value)
     case (None, request) => request
   }

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -34,12 +34,12 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with U
   type RequestHeaders[A] = js.Function2[A, XMLHttpRequest, Unit]
 
   /** Sets up no headers on the given XMLHttpRequest */
-  lazy val emptyHeaders: RequestHeaders[Unit] = (_, _) => ()
+  lazy val emptyRequestHeaders: RequestHeaders[Unit] = (_, _) => ()
 
-  def header(name: String, docs: endpoints.algebra.Documentation): RequestHeaders[String] =
+  def requestHeader(name: String, docs: endpoints.algebra.Documentation): RequestHeaders[String] =
     (value, xhr) => xhr.setRequestHeader(name, value)
 
-  def optHeader(name: String, docs: endpoints.algebra.Documentation): RequestHeaders[Option[String]] =
+  def optRequestHeader(name: String, docs: endpoints.algebra.Documentation): RequestHeaders[Option[String]] =
     (valueOpt, xhr) => valueOpt.foreach(value => xhr.setRequestHeader(name, value))
 
   implicit lazy val reqHeadersInvFunctor: InvariantFunctor[RequestHeaders] = new InvariantFunctor[RequestHeaders] {

--- a/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
+++ b/xhr/client/src/test/scala/endpoints/xhr/EndpointsTest.scala
@@ -9,7 +9,7 @@ trait FixturesAlgebra extends endpoints.algebra.Endpoints {
   val bar = endpoint(post(path / "bar" /? qs[Int]("quux"), emptyRequest), ok(emptyResponse))
   // Currently, the fact that this line compiles is a test, as there's no way
   // to inspect the result of constructing headers at the moment.
-  val baz = endpoint(post(path / "baz", emptyRequest, headers = header("quuz") ++ header("corge") ++ optHeader("grault")), ok(emptyResponse))
+  val baz = endpoint(post(path / "baz", emptyRequest, headers = requestHeader("quuz") ++ requestHeader("corge") ++ optRequestHeader("grault")), ok(emptyResponse))
 }
 
 object Fixtures extends FixturesAlgebra with thenable.Endpoints


### PR DESCRIPTION
Related to #469. Rename request headers constructors to make it clear that they are related to *request* headers and by symmetry with response headers constructors.