### PR TITLE
http4s server interpreter

### DIFF
--- a/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesFromSchemasTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/JsonEntitiesFromSchemasTestApi.scala
@@ -1,0 +1,22 @@
+package endpoints.algebra
+
+trait JsonEntitiesFromSchemasTestApi
+  extends EndpointsTestApi
+    with JsonEntitiesFromSchemas {
+
+  implicit val userJsonSchema: JsonSchema[User] = {
+    field[String]("name") zip
+    field[Int]("age")
+  }.xmap(User.tupled)(user => (user.name, user.age))
+
+  val singleStaticGetSegment = endpoint[Unit, User](
+    get(path / "user"), ok(jsonResponse[User])
+  )
+
+  val updateUser =
+    endpoint(
+      put(path / "user" / segment[Long]("id"), jsonRequest[User]),
+      ok(jsonResponse[User])
+    )
+
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/ChunkedJsonEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/ChunkedJsonEntitiesTestSuite.scala
@@ -37,7 +37,7 @@ trait ChunkedJsonEntitiesTestSuite[T <: ChunkedJsonEntitiesTestApi] extends Endp
     httpClient.singleRequest(request).flatMap { response =>
       val chunksSource =
         response.entity.dataBytes
-          .map(chunk => Right(jsonCodec.decode(decodeEntityAsText(response, chunk)).toEither.right.get))
+          .map(chunk => Right(jsonCodec.decode(decodeEntityAsText(response, chunk)).toEither.toOption.get))
           .recover { case NonFatal(e) => Left(e) }
       chunksSource.runWith(Sink.seq).map { as =>
         (response, as)

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
@@ -1,49 +1,16 @@
 package endpoints.algebra.server
 
-import java.nio.charset.StandardCharsets
 import java.util.UUID
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{DateTime, HttpRequest, HttpResponse}
 import akka.http.scaladsl.model.HttpMethods.{DELETE, PUT}
-import akka.http.scaladsl.model.headers.{ETag, `Access-Control-Allow-Origin`, `Content-Type`, `Last-Modified`}
-import akka.util.ByteString
+import akka.http.scaladsl.model.headers.{ETag, `Access-Control-Allow-Origin`, `Last-Modified`}
+import akka.http.scaladsl.model.{DateTime, HttpRequest}
 import endpoints.{Invalid, Valid}
-
-import scala.concurrent.{ExecutionContext, Future}
 
 trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends ServerTestBase[T] {
 
-  import serverApi.{ segment => s, _}
   import DecodedUrl._
-
-  private[server] implicit val actorSystem: ActorSystem = ActorSystem()
-  implicit val executionContext: ExecutionContext = actorSystem.dispatcher
-
-  val httpClient = Http()
-
-  def sendAndDecodeEntityAsText(request: HttpRequest): Future[(HttpResponse, String)] = {
-    send(request).map { case (response, entity) =>
-      (response, decodeEntityAsText(response, entity))
-    }
-  }
-
-  def send(request: HttpRequest): Future[(HttpResponse, ByteString)] = {
-    httpClient.singleRequest(request).flatMap { response =>
-      response.entity.toStrict(patienceConfig.timeout).map { entity =>
-        (response, entity.data)
-      }
-    }
-  }
-
-  def decodeEntityAsText(response: HttpResponse, entity: ByteString): String = {
-    val charset =
-      response.header[`Content-Type`]
-        .flatMap(_.contentType.charsetOption.map(_.nioCharset))
-        .getOrElse(StandardCharsets.UTF_8)
-    entity.decodeString(charset)
-  }
+  import serverApi.{segment => s, _}
 
   "paths" should {
 
@@ -260,7 +227,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends Server
         val request = HttpRequest(uri = s"http://localhost:$port/user/$uuid/description?name=name1&age=18")
         whenReady(sendAndDecodeEntityAsText(request)) { case (response, entity) =>
           assert(entity == mockedResponse)
-          assert(response.status.intValue == 200)
+          assert(response.status.intValue() == 200)
           ()
         }
       }
@@ -269,7 +236,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends Server
         val request = HttpRequest(method = PUT, uri = s"http://localhost:$port/user/$uuid")
         whenReady(send(request)) { case (response, entity) =>
           assert(entity.isEmpty)
-          assert(response.status.intValue == 200)
+          assert(response.status.intValue() == 200)
           ()
         }
       }
@@ -278,7 +245,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends Server
         val request = HttpRequest(method = DELETE, uri = s"http://localhost:$port/user/$uuid")
         whenReady(send(request)) { case (response, entity) =>
           assert(entity.isEmpty)
-          assert(response.status.intValue == 200)
+          assert(response.status.intValue() == 200)
           ()
         }
       }
@@ -292,7 +259,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends Server
         val request = HttpRequest(uri = s"http://localhost:$port/user/userId/description?name=name1&age=18")
         whenReady(sendAndDecodeEntityAsText(request)) { case (response, entity) =>
           assert(entity == mockedResponse)
-          assert(response.status.intValue == 200)
+          assert(response.status.intValue() == 200)
           ()
         }
       }
@@ -301,7 +268,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends Server
         val request = HttpRequest(method = PUT, uri = s"http://localhost:$port/user/foo123")
         whenReady(send(request)) { case (response, entity) =>
           assert(entity.isEmpty)
-          assert(response.status.intValue == 200)
+          assert(response.status.intValue() == 200)
           ()
         }
       }
@@ -310,7 +277,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi] extends Server
         val request = HttpRequest(method = DELETE, s"http://localhost:$port/user/foo123")
         whenReady(send(request)) { case (response, entity) =>
           assert(entity.isEmpty)
-          assert(response.status.intValue == 200)
+          assert(response.status.intValue() == 200)
           ()
         }
       }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/JsonEntitiesFromSchemasTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/JsonEntitiesFromSchemasTestSuite.scala
@@ -1,0 +1,76 @@
+package endpoints.algebra.server
+
+import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest}
+import endpoints.algebra
+import endpoints.algebra.User
+
+trait JsonEntitiesFromSchemasTestSuite[T <: algebra.JsonEntitiesFromSchemasTestApi] extends ServerTestBase[T] {
+
+  "Single segment route" should {
+
+    "match single segment request" in {
+      serveEndpoint(serverApi.singleStaticGetSegment, User("Alice", 42)) { port =>
+        val request = HttpRequest(uri = s"http://localhost:$port/user")
+        whenReady(sendAndDecodeEntityAsText(request)) { case (response, entity) =>
+          assert(response.status.intValue() == 200)
+          ujson.read(entity) shouldEqual ujson.Obj("name" -> ujson.Str("Alice"), "age" -> ujson.Num(42))
+        }
+      }
+    }
+
+    "leave GET requests to other paths unhandled" in {
+      serveEndpoint(serverApi.singleStaticGetSegment, User("Alice", 42)) { port =>
+        val request = HttpRequest(uri = s"http://localhost:$port/user/profile")
+        whenReady(send(request)) { case (response, entity) =>
+          assert(response.status.intValue() == 404)
+        }
+      }
+    }
+  }
+
+  "JSON entities" should {
+
+    "validate query parameters and headers before validating the entity" in {
+      def request(path: String, jsonEntity: String) =
+        HttpRequest(HttpMethods.PUT, path)
+          .withEntity(ContentTypes.`application/json`, jsonEntity)
+
+      serveEndpoint(serverApi.updateUser, User("Alice", 55)) { port =>
+        // Invalid URL and entity
+        whenReady(
+          sendAndDecodeEntityAsText(request(s"http://localhost:$port/user/foo", "{\"name\":\"Alice\",\"age\":true}"))
+        ) { case (response, entity) =>
+          assert(response.status.intValue() == 400)
+          ujson.read(entity) shouldBe ujson.Arr(ujson.Str("Invalid integer value 'foo' for segment 'id'"))
+        }
+
+        // Valid URL and invalid entity
+        whenReady(
+          sendAndDecodeEntityAsText(request(s"http://localhost:$port/user/42", "something that is not JSON"))
+        ) { case (response, entity) =>
+          assert(response.status.intValue() == 400)
+          ujson.read(entity) shouldBe ujson.Arr(ujson.Str("Invalid JSON document"))
+        }
+
+        // Valid URL and invalid entity (2)
+        whenReady(
+          sendAndDecodeEntityAsText(request(s"http://localhost:$port/user/42", "{\"name\":\"Alice\",\"age\":true}"))
+        ) { case (response, entity) =>
+          assert(response.status.intValue() == 400)
+          ujson.read(entity) shouldBe ujson.Arr(ujson.Str("Invalid integer value: true."))
+        }
+
+        // Valid URL and entity
+        whenReady(
+          sendAndDecodeEntityAsText(request(s"http://localhost:$port/user/42", "{\"name\":\"Alice\",\"age\":55}"))
+        ) { case (response, entity) =>
+          assert(response.status.intValue() == 200)
+          ujson.read(entity) shouldBe ujson.Obj("name" -> ujson.Str("Alice"), "age" -> ujson.Num(55))
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/algebras/build.sbt
+++ b/algebras/build.sbt
@@ -13,7 +13,8 @@ val algebra =
         "org.scalatest" %%% "scalatest" % scalaTestVersion % Test,
         "com.typesafe.akka" %% "akka-http" % akkaHttpVersion % Test,
         "com.typesafe.akka" %% "akka-actor" % akkaActorVersion % Test,
-        "com.typesafe.akka" %% "akka-stream" % akkaActorVersion % Test
+        "com.typesafe.akka" %% "akka-stream" % akkaActorVersion % Test,
+        "com.lihaoyi" %% "ujson" % ujsonVersion % Test
       )
     )
     .dependsOnLocalCrossProjectsWithScope("json-schema" -> "test->test;compile->compile")

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val play = project.in(file("play")).settings(noPublishSettings)
 val `akka-http` = project.in(file("akka-http")).settings(noPublishSettings)
 val scalaj = project.in(file("scalaj")).settings(noPublishSettings)
 val sttp = project.in(file("sttp")).settings(noPublishSettings)
+val http4s = project.in(file("http4s")).settings(noPublishSettings)
 
 // Documentation and examples
 val documentation = project.in(file("documentation")).settings(noPublishSettings)

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -15,6 +15,8 @@ val `play-server-circe` = LocalProject("play-server-circe")
 val `akka-http-client` = LocalProject("akka-http-client")
 val `akka-http-server` = LocalProject("akka-http-server")
 
+val `http4s-server` = LocalProject("http4s-server")
+
 val `xhr-client` = LocalProject("xhr-client")
 val `xhr-client-circe` = LocalProject("xhr-client-circe")
 val `xhr-client-faithful` = LocalProject("xhr-client-faithful")
@@ -48,6 +50,7 @@ val apiDoc =
         `algebra-jvm`, `algebra-circe-jvm`, `algebra-playjson-jvm`,
         `akka-http-client`, `akka-http-server`,
         `play-client`, `play-server`, `play-server-circe`,
+        `http4s-server`,
         `xhr-client`, `xhr-client-circe`, `xhr-client-faithful`,
         `scalaj-client`,
         `sttp-client`,
@@ -358,3 +361,17 @@ val `example-authentication` =
       )
     )
     .dependsOn(`play-server`, `play-client`, `algebra-playjson-jvm`)
+
+val `example-basic-http4s-server` =
+  project.in(file("examples/basic/http4s-server"))
+    .settings(
+      commonSettings,
+      `scala 2.12 to latest`,
+      publishArtifact := false,
+      libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25",
+      libraryDependencies += "org.http4s" %%% "http4s-blaze-server" % http4sVersion,
+      libraryDependencies += "org.http4s" %% "http4s-circe" % http4sVersion
+    )
+    .dependsOn(`example-basic-shared-jvm`, `http4s-server`)
+
+

--- a/documentation/examples/basic/http4s-server/src/main/scala/sample/Api.scala
+++ b/documentation/examples/basic/http4s-server/src/main/scala/sample/Api.scala
@@ -1,0 +1,32 @@
+package sample
+
+import cats.effect.IO
+import endpoints.http4s.server.{BasicAuthentication, Endpoints, JsonEntitiesFromCodecs}
+import org.http4s.HttpRoutes
+
+import scala.util.Random
+
+object Api
+  extends Endpoints[IO]
+    with JsonEntitiesFromCodecs
+    with BasicAuthentication
+    with ApiAlg {
+
+  val router: HttpRoutes[IO] = HttpRoutes.of(
+    routesFromEndpoints(
+      index.implementedBy { case (name, age, _) => User(name, age) },
+      maybe.implementedBy(_ =>
+        if (util.Random.nextBoolean()) Some(()) else None) orElse
+        action.implementedBy { _ =>
+          ActionResult("Action")
+        },
+      actionFut.implementedByEffect { _ =>
+        IO.pure(ActionResult("Action"))
+      },
+      auth.implementedBy { credentials =>
+        println(s"Authenticated request: ${credentials.username}")
+        if (Random.nextBoolean()) Some(()) else None // Randomly return a forbidden
+      }
+    )
+  )
+}

--- a/documentation/examples/basic/http4s-server/src/main/scala/sample/Server.scala
+++ b/documentation/examples/basic/http4s-server/src/main/scala/sample/Server.scala
@@ -1,0 +1,18 @@
+package sample
+
+import cats.effect._
+import cats.implicits._
+import org.http4s.server.blaze._
+import org.http4s.implicits._
+
+//#app
+object Server extends IOApp {
+  override def run(args: List[String]): IO[ExitCode] =
+    BlazeServerBuilder[IO]
+      .bindHttp(8080, "localhost")
+      .withHttpApp(Api.router.orNotFound)
+      .resource
+      .use(_ => IO.never)
+      .as(ExitCode.Success)
+}
+//#app

--- a/documentation/manual/src/paradox/algebras-and-interpreters.md
+++ b/documentation/manual/src/paradox/algebras-and-interpreters.md
@@ -9,6 +9,7 @@
 * [Multiplexed endpoints](algebras/mux-endpoints.md)
 * [Akka HTTP](interpreters/akka-http.md)
 * [Play framework](interpreters/play.md)
+* [http4s](interpreters/http4s.md)
 * [Scala.js web client](interpreters/scalajs-web.md)
 * [scalaj-http](interpreters/scalaj-http.md)
 * [sttp](interpreters/sttp.md)
@@ -77,6 +78,7 @@ to do so. Pick the interpreters that fit your existing stack!
 |---|---|
 |@ref[Akka HTTP](interpreters/akka-http.md)|Client and server backed by [Akka HTTP](https://doc.akka.io/docs/akka-http/current/)|
 |@ref[Play framework](interpreters/play.md)|Client and server backed by [Play framework](https://www.playframework.com/)|
+|@ref[http4s](interpreters/http4s.md)|Server backed by [http4s](https://http4s.org)|
 |@ref[Scala.js web](interpreters/scalajs-web.md)|Scala.js web client using `XMLHttpRequest`|
 |@ref[scalaj-http](interpreters/scalaj-http.md)|JVM client backed by [scalaj-http](https://github.com/scalaj/scalaj-http)|
 |@ref[sttp](interpreters/sttp.md)|JVM client backed by [sttp](https://github.com/softwaremill/sttp)|

--- a/documentation/manual/src/paradox/index.md
+++ b/documentation/manual/src/paradox/index.md
@@ -42,7 +42,7 @@ which can be reused, combined, and abstracted over.
 The library currently supports the following backends:
 
 - clients: Akka-Http, Play-WS, sttp, scalaj, and XMLHttpRequest (Scala.js) ;
-- servers: Akka-Http and Play ;
+- servers: Akka-Http, Play, and http4s ;
 - documentation: OpenAPI document ;
 - JSON is supported via Circe or Play-Json ;
 

--- a/documentation/manual/src/paradox/interpreters/akka-http.md
+++ b/documentation/manual/src/paradox/interpreters/akka-http.md
@@ -96,13 +96,11 @@ having a `handleNotFound` clause.
 
 In that case, *endpoints* returns a “Bad Request” (400) response reporting all the errors in a
 JSON array. You can change this behavior by overriding the
-@scaladoc[handleClientErrors](endpoints.akkahttp.server.Urls#handleClientErrors(invalid:endpoints.Invalid):akka.http.scaladsl.server.StandardRoute)
-method.
+@scaladoc[handleClientErrors](endpoints.akkahttp.server.Urls) method.
 
 #### An exception is thrown
 
 If an exception is thrown during request decoding, or when running the business logic, or when
 encoding the response, *endpoints* returns an “Internal Server Error” (500) response reporting
 the error in a JSON array. You can change this behavior by overriding the
-[handleServerError](endpoints.akkahttp.server.Endpoints#handleServerError(throwable:Throwable):akka.http.scaladsl.server.StandardRoute)
-method.
+@scaladoc[handleServerError](endpoints.akkahttp.server.Endpoints) method.

--- a/documentation/manual/src/paradox/interpreters/http4s.md
+++ b/documentation/manual/src/paradox/interpreters/http4s.md
@@ -1,0 +1,53 @@
+# http4s
+
+Server backed by [http4s](http://http4s.org).
+
+@@@vars
+~~~ scala
+"org.julienrf" %% "endpoints-http4s-server" % "$version$"
+~~~
+@@@
+
+@scaladoc[API documentation](endpoints.http4s.server.index)
+
+## `Endpoints`
+
+The `Endpoints` interpreter provides a `routesFromEndpoints` operation that
+turns a sequence of endpoints with their implementation into an `org.http4s.HttpRoutes[F]`
+value that can be integrated to your http4s application.
+
+For instance, given the following endpoint definition:
+
+@@snip [EndpointsDocs.scala](/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsDocs.scala) { #endpoint-definition }
+
+It can be implemented as follows:
+
+@@snip [EndpointsDocs.scala](/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsDocs.scala) { #implementation }
+
+The result is a regular value of type `org.http4s.HttpRoute[IO]` that can be integrated in your application like
+any other http4s service.
+
+### Error handling
+
+When the server processes requests, three kinds of errors can happen: the incoming request doesn’t match
+any endpoint, the request does match an endpoint but is invalid (e.g. one parameter has a wrong type), or
+an exception is thrown.
+
+#### The incoming request doesn’t match any endpoint
+
+In that case, the router constructed by *endpoints* can’t do anything. You have to deal with such
+errors in the usual http4s way (usually, by adding a `.orNotFound` call to your application
+services).
+
+#### The incoming request is invalid
+
+In that case, *endpoints* returns a “Bad Request” (400) response reporting all the errors in a
+JSON array. You can change this behavior by overriding the
+@scaladoc[handleClientErrors](endpoints.http4s.server.EndpointsWithCustomErrors) method.
+
+#### An exception is thrown
+
+If an exception is thrown during request decoding, or when running the business logic, or when
+encoding the response, *endpoints* returns an “Internal Server Error” (500) response reporting
+the error in a JSON array. You can change this behavior by overriding the
+@scaladoc[handleServerError](endpoints.http4s.server.EndpointsWithCustomErrors) method.

--- a/documentation/manual/src/paradox/interpreters/play.md
+++ b/documentation/manual/src/paradox/interpreters/play.md
@@ -81,13 +81,11 @@ errors in the usual Play way: by using a custom `play.api.http.HttpErrorHandler`
 
 In that case, *endpoints* returns a “Bad Request” (400) response reporting all the errors in a
 JSON array. You can change this behavior by overriding the
-@scaladoc[handleClientErrors](endpoints.play.server.Urls#handleClientErrors(invalid:endpoints.Invalid):play.api.mvc.Result)
-method.
+@scaladoc[handleClientErrors](endpoints.play.server.Urls) method.
 
 #### An exception is thrown
 
 If an exception is thrown during request decoding, or when running the business logic, or when
 encoding the response, *endpoints* returns an “Internal Server Error” (500) response reporting
 the error in a JSON array. You can change this behavior by overriding the
-@scaladoc[handleServerError](endpoints.play.server.Endpoints.html#handleServerError(throwable:Throwable):play.api.mvc.Result)
-method.
+@scaladoc[handleServerError](endpoints.play.server.Endpoints) method.

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -1,0 +1,22 @@
+import EndpointsSettings._
+
+val `algebra-jvm` = LocalProject("algebraJVM")
+val `algebra-circe-jvm` = LocalProject("algebra-circeJVM")
+val `json-schema-circe-jvm` = LocalProject("json-schema-circeJVM")
+val `openapi-jvm` = LocalProject("openapiJVM")
+
+val `http4s-server` =
+  project
+    .in(file("server"))
+    .settings(
+      publishSettings,
+      `scala 2.12 to latest`,
+      name := "endpoints-http4s-server",
+      libraryDependencies ++= Seq(
+        "org.http4s" %%% "http4s-core" % http4sVersion,
+        "org.http4s" %% "http4s-dsl" % http4sVersion,
+        "org.http4s" %% "http4s-blaze-server" % http4sVersion % Test
+      )
+    )
+    .dependsOn(`algebra-jvm` % "test->test;compile->compile")
+    .dependsOn(`openapi-jvm`)

--- a/http4s/server/src/main/scala/endpoints/http4s/server/BasicAuthentication.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/BasicAuthentication.scala
@@ -1,0 +1,58 @@
+package endpoints.http4s.server
+
+import cats.data.NonEmptyList
+import cats.syntax.functor._
+import endpoints.{Tupler, Valid}
+import endpoints.algebra.BasicAuthentication.Credentials
+import endpoints.algebra.Documentation
+import org.http4s
+import org.http4s.headers.{Authorization, `WWW-Authenticate`}
+import org.http4s.{BasicCredentials, Challenge}
+
+/**
+  * @group interpreters
+  */
+trait BasicAuthentication
+    extends EndpointsWithCustomErrors
+    with endpoints.algebra.BasicAuthentication {
+
+  private val unauthorizedRequestResponse = http4s
+    .Response[Effect](Unauthorized)
+    .withHeaders(`WWW-Authenticate`(
+      NonEmptyList.of(Challenge("Basic", "Realm", Map("charset" -> "UTF-8")))))
+
+  private[endpoints] def basicAuthenticationHeader: RequestHeaders[Option[Credentials]] =
+    headers =>
+      Valid(
+        headers
+          .get(Authorization)
+          .flatMap { authHeader =>
+            authHeader.credentials match {
+              case BasicCredentials(username, password) =>
+                Some(Credentials(username, password))
+              case _ => None
+            }
+          }
+      )
+
+  def authenticatedRequest[U, E, H, UE, HC, Out](
+    method: Method,
+    url: Url[U],
+    entity: RequestEntity[E],
+    headers: RequestHeaders[H],
+    requestDocs: Documentation = None
+  )(implicit
+    tuplerUE: Tupler.Aux[U, E, UE],
+    tuplerHC: Tupler.Aux[H, Credentials, HC],
+    tuplerUEHC: Tupler.Aux[UE, HC, Out]
+  ): Request[Out] =
+    extractUrlAndHeaders(method, url, headers ++ basicAuthenticationHeader) {
+      case (_, (_, None)) =>
+        _ => Effect.pure(Left(unauthorizedRequestResponse))
+      case (u, (h, Some(credentials))) =>
+        http4sRequest =>
+          entity(http4sRequest)
+            .map(_.map(e => tuplerUEHC(tuplerUE(u, e), tuplerHC(h, credentials))))
+    }
+
+}

--- a/http4s/server/src/main/scala/endpoints/http4s/server/BuiltInErrors.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/BuiltInErrors.scala
@@ -1,0 +1,26 @@
+package endpoints.http4s.server
+
+import java.nio.charset.StandardCharsets
+
+import endpoints.{Invalid, algebra}
+import fs2.Chunk
+import org.http4s.EntityEncoder
+import org.http4s.MediaType
+import org.http4s.headers.`Content-Type`
+
+/**
+  * @group interpreters
+  */
+trait BuiltInErrors extends algebra.BuiltInErrors { this: EndpointsWithCustomErrors =>
+
+  def clientErrorsResponseEntity: ResponseEntity[Invalid] = {
+    val hdr = `Content-Type`(MediaType.application.json)
+    EntityEncoder.simple(hdr) { invalid =>
+      val s = endpoints.ujson.codecs.invalidCodec.encode(invalid)
+      Chunk.bytes(s.getBytes(StandardCharsets.UTF_8))
+    }
+  }
+
+  def serverErrorResponseEntity: ResponseEntity[Throwable] =
+    clientErrorsResponseEntity.contramap(th => Invalid(th.getMessage))
+}

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
@@ -1,0 +1,273 @@
+package endpoints.http4s.server
+
+import cats.effect.Sync
+import cats.implicits._
+import endpoints.algebra.Documentation
+import endpoints.{Invalid, InvariantFunctor, PartialInvariantFunctor, Semigroupal, Tupler, Valid, Validated, algebra}
+import fs2._
+import org.http4s
+import org.http4s.{EntityEncoder, Header, Headers}
+
+import scala.util.control.NonFatal
+
+/**
+  * Interpreter for [[algebra.Endpoints]] based on http4s. It uses [[algebra.BuiltInErrors]]
+  * to model client and server errors.
+  *
+  * Consider the following endpoint definition:
+  *
+  * {{{
+  *   trait MyEndpoints extends algebra.Endpoints with algebra.JsonEntitiesFromSchemas {
+  *     val inc = endpoint(get(path / "inc" /? qs[Int]("x")), ok(jsonResponse[Int]))
+  *   }
+  * }}}
+  *
+  * You can get an http4s service for it as follow:
+  *
+  * {{{
+  *   object MyService
+  *     extends endpoints.http4s.server.Endpoints[IO]
+  *       with endpoints.http4s.server.JsonEntitiesFromSchemas
+  *       with MyEndpoints {
+  *
+  *     val service: org.http4s.HttpRoutes[IO] = HttpRoutes.of(
+  *       routesFromEndpoints(
+  *         inc.implementedBy(x => x + 1)
+  *       )
+  *     )
+  *   }
+  * }}}
+  *
+  * @tparam F Effect type
+  */
+abstract class Endpoints[F[_]](implicit F: Sync[F]) extends algebra.Endpoints with EndpointsWithCustomErrors with BuiltInErrors {
+
+  final type Effect[A] = F[A]
+  final implicit def Effect: Sync[Effect] = F
+
+}
+
+/**
+  * Interpreter for [[algebra.EndpointsWithCustomErrors]] based on http4s.
+  * @group interpreters
+  */
+trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with Methods with Urls {
+  type Effect[A]
+  implicit def Effect: Sync[Effect]
+
+  type RequestHeaders[A] = http4s.Headers => Validated[A]
+
+  type Request[A] =
+    PartialFunction[http4s.Request[Effect], Effect[Either[http4s.Response[Effect], A]]]
+
+  type RequestEntity[A] = http4s.Request[Effect] => Effect[Either[http4s.Response[Effect], A]]
+
+  type Response[A] = A => http4s.Response[Effect]
+
+  type ResponseEntity[A] = http4s.EntityEncoder[Effect, A]
+
+  type ResponseHeaders[A] = A => http4s.Headers
+
+  case class Endpoint[A, B](request: Request[A], response: Response[B]) {
+    def implementedBy(implementation: A => B)
+      : PartialFunction[http4s.Request[Effect], Effect[http4s.Response[Effect]]] =
+      implementedByEffect(implementation(_).pure[Effect])
+
+    def implementedByEffect(implementation: A => Effect[B]): PartialFunction[http4s.Request[Effect], Effect[http4s.Response[Effect]]] = {
+      val handler = { (http4sRequest: http4s.Request[Effect]) =>
+        try {
+          request.lift.apply(http4sRequest).map(_.flatMap {
+            case Right(a) =>
+              try {
+                implementation(a)
+                  .map(response)
+                  .recover {
+                    case NonFatal(t) => handleServerError(t)
+                  }
+              } catch {
+                case NonFatal(t) => handleServerError(t).pure[Effect]
+              }
+            case Left(errorResponse) => errorResponse.pure[Effect]
+          })
+        } catch {
+          case NonFatal(t) => Some(handleServerError(t).pure[Effect])
+        }
+      }
+      Function.unlift(handler)
+    }
+  }
+
+  def routesFromEndpoints(endpoints: PartialFunction[http4s.Request[Effect], Effect[http4s.Response[Effect]]]*) =
+    endpoints.reduceLeft(_ orElse _)
+
+  /**
+    * HEADERS
+    */
+  def emptyRequestHeaders: RequestHeaders[Unit] = _ => Valid(())
+
+  def requestHeader(name: String, docs: Documentation): RequestHeaders[String] =
+    headers =>
+      headers.collectFirst {
+        case h if h.name.value == name => h.value
+      } match {
+        case Some(value) => Valid(value)
+        case None        => Invalid(s"Missing header $name")
+    }
+
+  def optRequestHeader(name: String,
+                docs: Documentation): RequestHeaders[Option[String]] =
+    headers =>
+      Valid(headers.collectFirst {
+        case h if h.name.value == name => h.value
+      })
+
+  /**
+    * RESPONSES
+    */
+  implicit lazy val responseInvFunctor: endpoints.InvariantFunctor[Response] =
+    new endpoints.InvariantFunctor[Response] {
+      def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] = fa compose g
+    }
+
+  def response[A, B, R](statusCode: StatusCode, entity: ResponseEntity[A],
+                                 docs: Documentation, headers: ResponseHeaders[B])
+                                (implicit tupler: Tupler.Aux[A, B, R]): Response[R] =
+    r => {
+      val (a, b) = tupler.unapply(r)
+      http4s.Response[Effect](status = statusCode, headers = headers(b) ++ entity.headers, body = entity.toEntity(a).body)
+    }
+
+  def choiceResponse[A, B](responseA: Response[A], responseB: Response[B]): Response[Either[A, B]] = {
+    case Left(a) => responseA(a)
+    case Right(b) => responseB(b)
+  }
+
+  def emptyResponse: ResponseEntity[Unit] =
+    EntityEncoder.emptyEncoder[Effect, Unit]
+
+  def textResponse: ResponseEntity[String] =
+    EntityEncoder.stringEncoder
+
+  implicit def responseHeadersSemigroupal: Semigroupal[ResponseHeaders] =
+    new Semigroupal[ResponseHeaders] {
+      def product[A, B](fa: ResponseHeaders[A], fb: ResponseHeaders[B])(implicit tupler: Tupler[A, B]): ResponseHeaders[tupler.Out] =
+        out => {
+          val (a, b) = tupler.unapply(out)
+          fa(a) ++ fb(b)
+        }
+    }
+
+  implicit def responseHeadersInvFunctor: PartialInvariantFunctor[ResponseHeaders] =
+    new PartialInvariantFunctor[ResponseHeaders] {
+      def xmapPartial[A, B](fa: ResponseHeaders[A], f: A => Validated[B], g: B => A): ResponseHeaders[B] =
+        fa compose g
+    }
+
+  def emptyResponseHeaders: ResponseHeaders[Unit] =
+    _ => Headers.empty
+
+  def responseHeader(name: String, docs: Documentation = None): ResponseHeaders[String] =
+    value => Headers.of(Header(name, value))
+
+  def optResponseHeader(name: String, docs: Documentation = None): ResponseHeaders[Option[String]] = {
+    case Some(value) => responseHeader(name, docs)(value)
+    case None => emptyResponseHeaders(())
+  }
+
+  def endpoint[A, B](request: Request[A],
+                     response: Response[B],
+                     docs: EndpointDocs = EndpointDocs()): Endpoint[A, B] =
+    Endpoint(request, response)
+
+
+
+  /**
+    * REQUESTS
+    */
+  def emptyRequest: RequestEntity[Unit] = _ => Effect.pure(Right(()))
+
+  def textRequest: RequestEntity[String] =
+    req => req.body.through(text.utf8Decode).compile.toList.map(chunks => Right(chunks.mkString))
+
+  def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
+      method: Method,
+      url: Url[UrlP],
+      entity: RequestEntity[BodyP] = emptyRequest,
+      docs: Documentation = None,
+      headers: RequestHeaders[HeadersP] = emptyRequestHeaders
+  )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled],
+    tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] =
+    extractUrlAndHeaders(method, url, headers) {
+      case (u, h) =>
+        http4sRequest =>
+          entity(http4sRequest).map(_.map(body => tuplerUBH(tuplerUB(u, body), h)))
+    }
+
+  private[server] def extractUrlAndHeaders[U, H, E](
+    method: Method,
+    url: Url[U],
+    headers: RequestHeaders[H]
+  )(
+    entity: ((U, H)) => RequestEntity[E]
+  ): Request[E] =
+    Function.unlift { http4sRequest =>
+      if (http4sRequest.method == method) {
+        url
+          .decodeUrl(http4sRequest.uri)
+          .map(_.zip(headers(http4sRequest.headers)))
+          .map {
+            case Valid(urlAndHeaders) => entity(urlAndHeaders)(http4sRequest)
+            case inv: Invalid         => Effect.pure(Left(handleClientErrors(inv)))
+          }
+      } else None
+    }
+
+  implicit def reqEntityInvFunctor: endpoints.InvariantFunctor[RequestEntity] =
+    new InvariantFunctor[RequestEntity] {
+      def xmap[From, To](
+          f: RequestEntity[From],
+          map: From => To,
+          contramap: To => From): RequestEntity[To] =
+        body => f(body).map(_.map(map))
+    }
+
+  implicit def reqHeadersInvFunctor: endpoints.InvariantFunctor[RequestHeaders] =
+    new InvariantFunctor[RequestHeaders] {
+      def xmap[From, To](f: RequestHeaders[From], map: From => To, contramap: To => From): RequestHeaders[To] =
+        headers => f(headers).map(map)
+    }
+
+  implicit def reqHeadersSemigroupal: endpoints.Semigroupal[RequestHeaders] =
+    new Semigroupal[RequestHeaders] {
+      def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(
+          implicit tupler: Tupler[A, B]): RequestHeaders[tupler.Out] =
+        headers =>
+          fa(headers)
+            .flatMap(a => fb(headers).map(b => tupler(a, b)))
+    }
+
+
+  /**
+    * This method is called by ''endpoints'' when decoding a request failed.
+    *
+    * The provided implementation calls `clientErrorsResponse` to construct
+    * a response containing the errors.
+    *
+    * This method can be overridden to customize the error reporting logic.
+    */
+  def handleClientErrors(invalid: Invalid): http4s.Response[Effect] =
+    clientErrorsResponse(invalidToClientErrors(invalid))
+
+  /**
+    * This method is called by ''endpoints'' when an exception is thrown during
+    * request processing.
+    *
+    * The provided implementation calls [[serverErrorResponse]] to construct
+    * a response containing the error message.
+    *
+    * This method can be overridden to customize the error reporting logic.
+    */
+  def handleServerError(throwable: Throwable): http4s.Response[Effect] =
+    serverErrorResponse(throwableToServerError(throwable))
+
+}

--- a/http4s/server/src/main/scala/endpoints/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/JsonEntities.scala
@@ -1,0 +1,55 @@
+package endpoints.http4s.server
+
+import cats.implicits._
+import endpoints.algebra.Codec
+import endpoints.{Invalid, Valid, algebra}
+import fs2.Chunk
+import org.http4s
+import org.http4s.headers.`Content-Type`
+import org.http4s.{EntityEncoder, MediaType}
+
+/**
+  * Interpreter for [[algebra.JsonEntitiesFromCodecs]] that decodes JSON requests
+  * and encodes JSON responses.
+  *
+  * @group interpreters
+  */
+trait JsonEntitiesFromCodecs
+  extends algebra.JsonEntitiesFromCodecs
+    with EndpointsWithCustomErrors {
+
+  def jsonRequest[A](implicit codec: JsonCodec[A]): RequestEntity[A] =
+    req => {
+      http4s.EntityDecoder
+        .decodeString(req)
+        .map { value =>
+          stringCodec(codec)
+            .decode(value) match {
+            case Valid(a)     => Right(a)
+            case inv: Invalid => Left(handleClientErrors(inv))
+          }
+        }
+
+    }
+
+  def jsonResponse[A](implicit codec: JsonCodec[A]): ResponseEntity[A] =
+    EntityEncoder[Effect, Chunk[Byte]]
+      .contramap[A](value => Chunk.bytes(stringCodec(codec).encode(value).getBytes()))
+      .withContentType(`Content-Type`(MediaType.application.json))
+
+}
+
+/**
+  * Interpreter for [[algebra.JsonEntitiesFromSchemas]] that decodes JSON requests
+  * and encodes JSON responses.
+  *
+  * @group interpreters
+  */
+trait JsonEntitiesFromSchemas
+  extends algebra.JsonEntitiesFromSchemas
+    with JsonEntitiesFromCodecs
+    with endpoints.ujson.JsonSchemas {
+
+  def stringCodec[A](implicit codec: JsonCodec[A]): Codec[String, A] = codec.stringCodec
+
+}

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Methods.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Methods.scala
@@ -1,0 +1,20 @@
+package endpoints.http4s.server
+
+import endpoints.algebra
+import org.http4s
+
+/**
+  * [[algebra.Methods]] interpreter that decodes and encodes methods.
+  *
+  * @group interpreters
+  */
+trait Methods extends algebra.Methods {
+  type Method = http4s.Method
+
+  def Get: Method = http4s.Method.GET
+  def Post: Method = http4s.Method.POST
+  def Put: Method = http4s.Method.PUT
+  def Delete: Method = http4s.Method.DELETE
+  def Patch: Method = http4s.Method.PATCH
+  def Options: Method = http4s.Method.OPTIONS
+}

--- a/http4s/server/src/main/scala/endpoints/http4s/server/StatusCodes.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/StatusCodes.scala
@@ -1,0 +1,27 @@
+package endpoints.http4s.server
+
+
+import endpoints.algebra
+import org.http4s.{Status => Http4sStatus}
+
+/**
+  * [[algebra.StatusCodes]] interpreter that decodes and encodes methods.
+  *
+  * @group interpreters
+  */
+trait StatusCodes extends algebra.StatusCodes {
+
+  type StatusCode = Http4sStatus
+
+  def OK = Http4sStatus.Ok
+  def Created = Http4sStatus.Created
+  def Accepted = Http4sStatus.Accepted
+  def NoContent = Http4sStatus.NoContent
+  def BadRequest= Http4sStatus.BadRequest
+  def Unauthorized = Http4sStatus.Unauthorized
+  def Forbidden = Http4sStatus.Forbidden
+  def NotFound = Http4sStatus.NotFound
+  def InternalServerError = Http4sStatus.InternalServerError
+  def NotImplemented = Http4sStatus.NotImplemented
+}
+

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Urls.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Urls.scala
@@ -1,0 +1,185 @@
+package endpoints.http4s.server
+
+import java.net.{URLDecoder, URLEncoder}
+import java.nio.charset.StandardCharsets.UTF_8
+
+import endpoints.algebra.Documentation
+import endpoints.{Invalid, PartialInvariantFunctor, Tupler, Valid, Validated, algebra}
+import org.http4s
+import org.http4s.Uri
+
+import scala.collection.compat._
+import scala.collection.mutable
+
+/**
+  * [[algebra.Urls]] interpreter that decodes and encodes URLs.
+  *
+  * @group interpreters
+  */
+trait Urls extends algebra.Urls with StatusCodes { this: EndpointsWithCustomErrors =>
+  type Effect[A]
+  val utf8Name = UTF_8.name()
+
+  type Params = Map[String, Seq[String]]
+
+  type QueryString[A] = Params => Validated[A]
+  type QueryStringParam[A] = (String, Params) => Validated[A]
+
+  trait Url[A] {
+    def decodeUrl(uri: http4s.Uri): Option[Validated[A]]
+  }
+
+  trait Path[A] extends Url[A] {
+    def decode(paths: List[String]): Option[(Validated[A], List[String])]
+
+    final def decodeUrl(uri: http4s.Uri): Option[Validated[A]] =
+      pathExtractor(this, uri)
+  }
+
+  type Segment[A] = String => Validated[A]
+
+  /** Concatenates two `QueryString`s */
+  def combineQueryStrings[A, B](first: QueryString[A], second: QueryString[B])(
+      implicit tupler: Tupler[A, B]): QueryString[tupler.Out] =
+    map => first(map).zip(second(map))
+
+  def qs[A](name: String, docs: Documentation = None)(
+      implicit value: QueryStringParam[A]): QueryString[A] =
+    params => value(name, params).mapErrors(_.map(error => s"$error for query parameter '$name'"))
+
+  implicit def optionalQueryStringParam[A](
+      implicit param: QueryStringParam[A]): QueryStringParam[Option[A]] =
+    (name, params) =>
+      params.get(name) match {
+        case None    => Valid(None)
+        case Some(_) => param(name, params).map(Some(_))
+    }
+
+  implicit def repeatedQueryStringParam[A, CC[X] <: Iterable[X]](
+      implicit param: QueryStringParam[A],
+      factory: Factory[A, CC[A]]): QueryStringParam[CC[A]] =
+    (name: String, qs: Map[String, Seq[String]]) =>
+      qs.get(name) match {
+        case None     => Valid(factory.newBuilder.result())
+        case Some(vs) =>
+          // ''traverse'' the list of decoded values
+          vs.foldLeft[Validated[mutable.Builder[A, CC[A]]]](Valid(factory.newBuilder)) {
+            case (inv: Invalid, v) =>
+              // Pretend that this was the query string and delegate to the `A` query string param
+              param(name, Map(name -> (v :: Nil)))
+                .fold(_ => inv, errors => Invalid(inv.errors ++ errors))
+            case (Valid(b), v) =>
+              // Pretend that this was the query string and delegate to the `A` query string param
+              param(name, Map(name -> (v :: Nil))).map(b += _)
+          }.map(_.result())
+      }
+
+  implicit def queryStringParamPartialInvFunctor: PartialInvariantFunctor[QueryStringParam] =
+    new PartialInvariantFunctor[QueryStringParam] {
+      def xmapPartial[A, B](fa: QueryStringParam[A], f: A => Validated[B], g: B => A): QueryStringParam[B] =
+        (str, params) => fa(str, params).flatMap(f)
+    }
+
+  implicit def stringQueryString: QueryStringParam[String] =
+    (name, params) => {
+      val maybeValue = params.get(name).flatMap(_.headOption)
+      Validated.fromOption(maybeValue)("Missing value")
+  }
+
+  implicit def segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+    new PartialInvariantFunctor[Segment] {
+      def xmapPartial[A, B](fa: Segment[A], f: A => Validated[B], g: B => A): Segment[B] =
+        s => fa(s).flatMap(f)
+    }
+
+  implicit def pathPartialInvariantFunctor: PartialInvariantFunctor[Path] =
+    new PartialInvariantFunctor[Path] {
+      def xmapPartial[A, B](fa: Path[A], f: A => Validated[B], g: B => A): Path[B] =
+        new Path[B] {
+          def decode(paths: List[String]): Option[(Validated[B], List[String])] =
+            fa.decode(paths).map { case (validA, rs) => (validA.flatMap(f), rs) }
+        }
+    }
+
+  def staticPathSegment(segment: String): Path[Unit] = new Path[Unit] {
+    def decode(paths: List[String]): Option[(Validated[Unit], List[String])] =
+      paths match {
+        case s :: ss if s == segment => Some((Valid(()), ss))
+        case _ => None
+      }
+  }
+
+  def segment[A](name: String = "", docs: Documentation = None)(
+      implicit A: Segment[A]): Path[A] = new Path[A] {
+    def decode(segments: List[String]): Option[(Validated[A], List[String])] = {
+      segments match {
+        case head :: tail =>
+          val validatedA =
+            A(head)
+              .mapErrors(_.map(error => s"$error for segment${ if (name.isEmpty) "" else s" '$name'" }"))
+          Some((validatedA, tail))
+        case Nil => None
+      }
+    }
+  }
+
+  implicit def stringSegment: Segment[String] = Valid(_)
+
+  def remainingSegments(name: String = "", docs: Documentation = None): Path[String] =
+    new Path[String] {
+      def decode(segments: List[String]): Option[(Validated[String], List[String])] =
+        if (segments.isEmpty) None
+        else Some((Valid(segments.map(URLEncoder.encode(_, utf8Name)).mkString("/")), Nil))
+    }
+
+  def chainPaths[A, B](first: Path[A], second: Path[B])(
+      implicit tupler: Tupler[A, B]): Path[tupler.Out] = new Path[tupler.Out] {
+    def decode(segments: List[String]): Option[(Validated[tupler.Out], List[String])] =
+      first.decode(segments).flatMap { case (validA, segments2) =>
+        second.decode(segments2).map { case (validB, segments3) =>
+          (validA zip validB, segments3)
+        }
+      }
+  }
+
+  implicit def urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+    new PartialInvariantFunctor[Url] {
+      def xmapPartial[A, B](fa: Url[A], f: A => Validated[B], g: B => A): Url[B] = new Url[B] {
+        def decodeUrl(uri: Uri): Option[Validated[B]] =
+          fa.decodeUrl(uri).map(_.flatMap(f))
+      }
+    }
+
+  /** Builds an URL from the given path and query string */
+  def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(
+      implicit tupler: Tupler[A, B]): Url[tupler.Out] = new Url[tupler.Out] {
+    def decodeUrl(
+        uri: Uri): Option[Validated[tupler.Out]] =
+      pathExtractor(path, uri).map(_.zip(qs(uri.multiParams)))
+  }
+
+  private def pathExtractor[A](
+      path: Path[A],
+      uri: http4s.Uri): Option[Validated[A]] = {
+    val segments =
+      uri.path
+        .split("/")
+        .map(URLDecoder.decode(_, utf8Name))
+        .toList
+
+    path.decode(if (segments.isEmpty) List("") else segments).flatMap {
+      case (validated, Nil) => Some(validated)
+      case (_, _)           => None
+    }
+  }
+
+  implicit def queryStringPartialInvFunctor
+    : PartialInvariantFunctor[QueryString] =
+    new PartialInvariantFunctor[QueryString] {
+      def xmapPartial[A, B](fa: Params => Validated[A],
+                                     f: A => Validated[B],
+                                     g: B => A): Params => Validated[B] =
+        params => fa(params).flatMap(f)
+    }
+
+}

--- a/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsDocs.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsDocs.scala
@@ -1,0 +1,15 @@
+package endpoints.http4s.server
+
+import cats.effect.IO
+import endpoints.algebra
+import org.http4s.HttpRoutes
+
+trait EndpointsDocs extends Endpoints[IO] with algebra.EndpointsDocs {
+  //#implementation
+  val routes: HttpRoutes[IO] = HttpRoutes.of(
+    routesFromEndpoints(
+      someResource.implementedBy(x => s"Received $x")
+    ))
+  //#implementation
+
+}

--- a/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
@@ -1,0 +1,12 @@
+package endpoints.http4s.server
+
+import cats.effect.IO
+import endpoints.algebra
+
+class EndpointsTestApi
+    extends Endpoints[IO]
+    with BasicAuthentication
+    with JsonEntitiesFromSchemas
+    with algebra.EndpointsTestApi
+    with algebra.BasicAuthenticationTestApi
+    with algebra.JsonEntitiesFromSchemasTestApi

--- a/http4s/server/src/test/scala/endpoints/http4s/server/ServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/ServerInterpreterTest.scala
@@ -1,0 +1,51 @@
+package endpoints.http4s.server
+
+import java.net.ServerSocket
+
+import cats.effect.{ContextShift, IO, Timer}
+import endpoints.{Invalid, Valid}
+import endpoints.algebra.server.{BasicAuthenticationTestSuite, DecodedUrl, EndpointsTestSuite, JsonEntitiesFromSchemasTestSuite}
+import org.http4s.server.Router
+import org.http4s.{HttpRoutes, Uri}
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.syntax.kleisli._
+
+import scala.concurrent.ExecutionContext
+
+class ServerInterpreterTest
+  extends EndpointsTestSuite[EndpointsTestApi]
+    with BasicAuthenticationTestSuite[EndpointsTestApi]
+    with JsonEntitiesFromSchemasTestSuite[EndpointsTestApi] {
+
+  val serverApi = new EndpointsTestApi()
+
+  def decodeUrl[A](url: serverApi.Url[A])(rawValue: String): DecodedUrl[A] = {
+    val uri = Uri.fromString(rawValue).getOrElse(sys.error(s"Illegal URI: $rawValue"))
+
+    url.decodeUrl(uri) match {
+      case None                  => DecodedUrl.NotMatched
+      case Some(Invalid(errors)) => DecodedUrl.Malformed(errors)
+      case Some(Valid(a))        => DecodedUrl.Matched(a)
+    }
+  }
+
+  def serveEndpoint[Resp](endpoint: serverApi.Endpoint[_, Resp], response: => Resp)(runTests: Int => Unit): Unit = {
+    val port = {
+      val socket = new ServerSocket(0)
+      try socket.getLocalPort
+      finally if (socket != null) socket.close()
+    }
+    implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+    implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+    val service = HttpRoutes.of[IO](endpoint.implementedBy(_ => response))
+    val httpApp = Router("/" -> service).orNotFound
+    val server = BlazeServerBuilder[IO].bindHttp(port, "localhost").withHttpApp(httpApp)
+    val fiber = server.resource.use(_ => IO.never).start.unsafeRunSync()
+    try {
+      runTests(port)
+    } finally {
+      fiber.cancel.unsafeRunSync()
+    }
+  }
+
+}

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -9,7 +9,7 @@ lazy val openapi =
       `scala 2.12 to latest`,
       name := "endpoints-openapi",
       (Compile / boilerplateSource) := (Compile / baseDirectory).value / ".." / "src" / "main" / "boilerplate",
-      libraryDependencies += "com.lihaoyi" %%% "ujson" % "0.9.9"
+      libraryDependencies += "com.lihaoyi" %%% "ujson" % ujsonVersion
     )
     .enablePlugins(spray.boilerplate.BoilerplatePlugin)
     .dependsOnLocalCrossProjectsWithScope(

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -82,7 +82,8 @@ object EndpointsSettings {
   val sttpVersion = "1.7.2"
   val akkaActorVersion = "2.6.3"
   val akkaHttpVersion = "10.1.11"
-
+  val http4sVersion = "0.21.1"
+  val ujsonVersion = "0.9.9"
 
   val scalaTestVersion = "3.1.1"
   val scalaTestDependency = "org.scalatest" %% "scalatest" % scalaTestVersion % Test


### PR DESCRIPTION
Fixes #283.

Following up on the initial work done by @jkobejs and with the help of @hygt here is an http4s server interpreter!

Only the basic modules are supported (`Endpoints`, `BasicAuthentication` and `JsonEntities`). Support for other modules like `ChunkedEntities` could be added in a separate PR.

I plan to squash all the commits into a single one, if that’s fine with you, @jkobejs and @hygt?