### PR TITLE
Specify behavior of `optField`

### DIFF
--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsJsonSchemaTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsJsonSchemaTest.scala
@@ -71,7 +71,7 @@ class EndpointsJsonSchemaTest extends AnyWordSpec with Matchers with ScalatestRo
       request("/user/42", "{\"name\":\"Alice\",\"age\":true}") ~> testRoutes.updateUser ~> check {
         handled shouldBe true
         status shouldBe BadRequest
-        ujson.read(responseAs[String]) shouldBe ujson.Arr(ujson.Str("Invalid integer value: true."))
+        ujson.read(responseAs[String]) shouldBe ujson.Arr(ujson.Str("Invalid integer value: true"))
       }
 
       // Valid URL and entity

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/JsonEntitiesFromSchemasTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/JsonEntitiesFromSchemasTestSuite.scala
@@ -57,7 +57,7 @@ trait JsonEntitiesFromSchemasTestSuite[T <: algebra.JsonEntitiesFromSchemasTestA
           sendAndDecodeEntityAsText(request(s"http://localhost:$port/user/42", "{\"name\":\"Alice\",\"age\":true}"))
         ) { case (response, entity) =>
           assert(response.status.intValue() == 400)
-          ujson.read(entity) shouldBe ujson.Arr(ujson.Str("Invalid integer value: true."))
+          ujson.read(entity) shouldBe ujson.Arr(ujson.Str("Invalid integer value: true"))
         }
 
         // Valid URL and entity

--- a/documentation/manual/src/paradox/algebras/json-schemas.md
+++ b/documentation/manual/src/paradox/algebras/json-schemas.md
@@ -84,7 +84,7 @@ The examples above show how to use `xmap` to transform a `JsonSchema[A]` into a 
 case the transformation function from `A` to `B` can fail (for example, if it applies additional
 validation), you can use `xmapPartial` instead of `xmap`:
 
-@@snip [JsonSchemasTest.scala](/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala) { #refined }
+@@snip [JsonSchemasFixtures.scala](/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasFixtures.scala) { #refined }
 
 In this example, we check that the decoded integer is even. If it is not, we return an error message.
 
@@ -135,7 +135,7 @@ by wrapping it in the `lazyRecord` or `lazyTagged` constructor:
 You can define a schema as an alternative between other schemas with the operation
 `orFallbackTo`:
 
-@@snip [JsonSchemasTest.scala](/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasTest.scala) { #one-of }
+@@snip [JsonSchemasFixtures.scala](/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasFixtures.scala) { #one-of }
 
 @@@warning
 Because decoders derived from schemas defined with the operation `orFallbackTo` literally

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasOptionalFieldsTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasOptionalFieldsTest.scala
@@ -1,0 +1,27 @@
+package endpoints
+package circe
+
+import org.scalatest.freespec.AnyFreeSpec
+
+class JsonSchemasOptionalFieldsTest extends AnyFreeSpec with algebra.JsonSchemasOptionalFieldsTest with JsonSchemas {
+
+  object Json extends Json {
+    type Json = io.circe.Json
+    def obj(fields: (String, Json)*): Json = io.circe.Json.obj(fields: _*)
+    def arr(items: Json*): Json            = io.circe.Json.arr(items: _*)
+    def num(x: BigDecimal): Json           = io.circe.Json.fromBigDecimal(x)
+    def str(s: String): Json               = io.circe.Json.fromString(s)
+    def bool(b: Boolean): Json             = io.circe.Json.fromBoolean(b)
+    def `null`: Json                       = io.circe.Json.Null
+  }
+
+  def decodeJson[A](schema: JsonSchema[A], json: Json.Json): Validated[A] =
+    schema.decoder.decodeAccumulating(json.hcursor) match {
+      case cats.data.Validated.Valid(a)   => Valid(a)
+      case cats.data.Validated.Invalid(e) => Invalid(e.toList.map(_.message))
+    }
+
+  def encodeJson[A](schema: JsonSchema[A], value: A): Json.Json =
+    schema.encoder(value)
+
+}

--- a/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints/circe/JsonSchemasTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.freespec.AnyFreeSpec
 class JsonSchemasTest extends AnyFreeSpec {
 
   object JsonSchemasCodec
-    extends algebra.JsonSchemasTest
+    extends algebra.JsonSchemasFixtures
       with circe.JsonSchemas
 
   import JsonSchemasCodec.{User, Foo, Bar}
@@ -93,7 +93,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     assert(enumSchema.encoder(validValue) == validJson)
     assert(enumSchema.decoder.decodeJson(validJson).exists(_ == validValue))
     val invalidJson = Json.obj("quux" -> Json.fromString("wrong"))
-    assert(enumSchema.decoder.decodeJson(invalidJson).left.exists(_ == DecodingFailure("Invalid value: {\n  \"quux\" : \"wrong\"\n}. Valid values are: {\n  \"quux\" : \"bar\"\n}, {\n  \"quux\" : \"baz\"\n}.", Nil)))
+    assert(enumSchema.decoder.decodeJson(invalidJson).left.exists(_ == DecodingFailure("Invalid value: {\n  \"quux\" : \"wrong\"\n} ; valid values are: {\n  \"quux\" : \"bar\"\n}, {\n  \"quux\" : \"baz\"\n}", Nil)))
   }
 
   "oneOf" in {

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -64,7 +64,7 @@ trait JsonSchemas
         if (values.contains(a)) {
           Reads.pure(a)
         } else {
-          Reads.failed(s"Invalid value: ${Json.stringify(jsonSchema.writes.writes(a))}. Valid values are: ${values.map(a => Json.stringify(jsonSchema.writes.writes(a))).mkString(", ")}.")
+          Reads.failed(s"Invalid value: ${Json.stringify(jsonSchema.writes.writes(a))} ; valid values are: ${values.map(a => Json.stringify(jsonSchema.writes.writes(a))).mkString(", ")}")
         }
       },
       jsonSchema.writes
@@ -90,13 +90,13 @@ trait JsonSchemas
     def emptyRecord: Record[Unit] =
     Record(
       new Reads[Unit] {
-        override def reads(json: JsValue): JsResult[Unit] = json match {
+        def reads(json: JsValue): JsResult[Unit] = json match {
           case JsObject(_) => JsSuccess(())
-          case _ => JsError("expected JSON object, but found: " + json)
+          case _ => JsError(s"Invalid JSON object: $json")
         }
       },
       new OWrites[Unit] {
-        override def writes(o: Unit): JsObject = Json.obj()
+        def writes(o: Unit): JsObject = Json.obj()
       }
     )
 
@@ -118,7 +118,7 @@ trait JsonSchemas
     val reads =
       schemaA.reads.map[Either[A, B]](Left(_))
         .orElse(schemaB.reads.map[Either[A, B]](Right(_)))
-        .orElse(Reads(json => JsError(s"Invalid value: $json.")))
+        .orElse(Reads(json => JsError(s"Invalid value: $json")))
     val writes =
       Writes[Either[A, B]] { case Left(a) => schemaA.writes.writes(a) case Right(b) => schemaB.writes.writes(b)}
     JsonSchema(reads, writes)

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasOptionalFieldsTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints/playjson/JsonSchemasOptionalFieldsTest.scala
@@ -1,0 +1,35 @@
+package endpoints.playjson
+
+import endpoints.{Invalid, Valid, Validated, algebra}
+import play.api.libs.json.{JsArray, JsBoolean, JsError, JsNull, JsNumber, JsObject, JsString, JsSuccess, JsValue}
+import org.scalatest.freespec.AnyFreeSpec
+
+class JsonSchemasOptionalFieldsTest extends AnyFreeSpec with algebra.JsonSchemasOptionalFieldsTest with JsonSchemas {
+
+  object Json extends Json {
+    type Json = JsValue
+    def obj(fields: (String, Json)*): Json = JsObject(fields)
+    def arr(items: Json*): Json            = JsArray(items)
+    def num(x: BigDecimal): Json           = JsNumber(x)
+    def str(s: String): Json               = JsString(s)
+    def bool(b: Boolean): Json             = JsBoolean(b)
+    def `null`: Json                       = JsNull
+  }
+
+  def decodeJson[A](schema: JsonSchema[A], json: Json.Json): Validated[A] =
+    schema.reads.reads(json) match {
+      case JsSuccess(a, _) => Valid(a)
+      case JsError(errors) =>
+        val stringErrors =
+          for {
+            (_, pathErrors) <- errors
+            error           <- pathErrors
+            message         <- error.messages
+          } yield message
+        Invalid(stringErrors.toList)
+    }
+
+  def encodeJson[A](schema: JsonSchema[A], value: A): Json.Json =
+    schema.writes.writes(value)
+
+}

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasFixtures.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasFixtures.scala
@@ -9,7 +9,7 @@ import endpoints.{Invalid, Valid}
   *
   * Its content can be used as fixtures by [[JsonSchemas]] interpreters.
   */
-trait JsonSchemasTest extends JsonSchemas {
+trait JsonSchemasFixtures extends JsonSchemas {
 
   case class User(name: String, age: Int)
 

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasOptionalFieldsTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasOptionalFieldsTest.scala
@@ -1,0 +1,121 @@
+package endpoints.algebra
+
+import java.util.UUID
+
+import endpoints.{Invalid, Valid, Validated}
+import org.scalatest.freespec.AnyFreeSpec
+
+/**
+  * Tests that must be run on all [[JsonSchemas]] interpreters.
+  */
+trait JsonSchemasOptionalFieldsTest extends AnyFreeSpec with JsonSchemasFixtures {
+
+  // Abstract over concrete JSON library (such as circe, Play JSON, or ujson)
+  trait Json {
+    type Json
+    def obj(fields: (String, Json)*): Json
+    def arr(items: Json*): Json
+    def num(x: BigDecimal): Json
+    def str(s: String): Json
+    def bool(b: Boolean): Json
+    def `null`: Json
+  }
+  val Json: Json
+  def decodeJson[A](schema: JsonSchema[A], json: Json.Json): Validated[A]
+  def encodeJson[A](schema: JsonSchema[A], value: A): Json.Json
+
+  "empty record" in {
+    checkRoundTrip(
+      emptyRecord,
+      Json.obj(),
+      ()
+    )
+  }
+
+  "invalid empty record" in {
+    val jsonSchema = emptyRecord
+    val json = Json.arr()
+    checkDecodingFailure(jsonSchema, json, Seq("Invalid JSON object: []"))
+  }
+
+  "missing optional field" in {
+    checkRoundTrip(
+      optField[Int]("relevant"),
+      Json.obj(),
+      None
+    )
+  }
+
+  "optional field" in {
+    checkRoundTrip(
+      optField[Int]("relevant"),
+      Json.obj("relevant" -> Json.num(123)),
+      Some(123)
+    )
+  }
+
+  "optional field null" in {
+    val schema = optField[Int]("relevant")
+    val json = Json.obj("relevant" -> Json.`null`)
+
+    // We don’t use “testRoundtrip” here because we decode a `null` field
+    // but we don’t produce that field when encoding
+    decodeJson(schema, json) match {
+      case Valid(None) =>
+        assert(encodeJson(schema, None) == Json.obj())
+      case Valid(Some(n))  => fail(s"Decoded $n")
+      case Invalid(errors) => fail(errors.mkString(". "))
+    }
+  }
+
+  "nested optional field" in {
+    checkRoundTrip(
+      optField[Int]("level1")(field[Int]("level2")),
+      Json.obj("level1" -> Json.obj("level2" -> Json.num(123))),
+      Some(123)
+    )
+  }
+
+  "missing nested optional field" in {
+    checkRoundTrip(
+      optField[Int]("level1")(field[Int]("level2")),
+      Json.obj(),
+      None
+    )
+  }
+
+  "single record" in {
+    checkRoundTrip(
+      field[String]("field1"),
+      Json.obj("field1" -> Json.str("string1")),
+      "string1"
+    )
+  }
+
+  "ignore extra record fields" in {
+    val schema  = field[Int]("relevant")
+    val json    = Json.obj("relevant" -> Json.num(1), "irrelevant" -> Json.num(0))
+    val decoded = decodeJson(schema, json)
+    decoded match {
+      case Valid(n)        => assert(n == 1)
+      case Invalid(errors) => fail(errors.toString)
+    }
+    val encoded = encodeJson(schema, 1)
+    assert(encoded == Json.obj("relevant" -> Json.num(1)))
+  }
+
+  def checkRoundTrip[A](schema: JsonSchema[A], json: Json.Json, decoded: A) =
+    decodeJson(schema, json) match {
+      case Valid(a) =>
+        assert(encodeJson(schema, a) == json)
+      case Invalid(errors) =>
+        fail(errors.mkString(". "))
+    }
+
+  def checkDecodingFailure[A](schema: JsonSchema[A], json: Json.Json, expectedErrors: Seq[String]) =
+    decodeJson(schema, json) match {
+      case Valid(_)        => fail("Expected decoding failure")
+      case Invalid(errors) => assert(errors == expectedErrors)
+    }
+
+}

--- a/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
+++ b/openapi/openapi/src/main/boilerplate/endpoints/ujson/TuplesSchemas.scala.template
@@ -11,7 +11,7 @@ trait TuplesSchemas extends algebra.TuplesSchemas { this: JsonSchemas =>
     new JsonSchema[([#T1#])] {
       val decoder = {
         case ujson.Arr(items) if items.length == 1 => [#schema1.decoder.decode(items(0))# zip ]
-        case json => Invalid(s"Invalid JSON array of 1 elements: $json.")
+        case json => Invalid(s"Invalid JSON array of 1 elements: $json")
       }
       val encoder = { case ([#t1#]) => ujson.Arr([#schema1.encoder.encode(t1)#]) }
     }#

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -38,11 +38,11 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
           case Some(ujson.Str(tag)) =>
             findDecoder(tag) match {
               case Some(decoder) => decoder.decode(json)
-              case None          => Invalid(s"Invalid type discriminator: '$tag'.")
+              case None          => Invalid(s"Invalid type discriminator: '$tag'")
             }
-          case _ => Invalid(s"Missing type discriminator property '$discriminator': $json.")
+          case _ => Invalid(s"Missing type discriminator property '$discriminator': $json")
         }
-      case json => Invalid(s"Invalid JSON object: $json.")
+      case json => Invalid(s"Invalid JSON object: $json")
     }
     final val encoder = value => {
       val (tag, json) = tagAndObj(value)
@@ -87,7 +87,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         if (values.contains(a)) {
           Valid(a)
         } else {
-          Invalid(s"Invalid value: ${tpe.encoder.encode(a)}. Valid values are ${values.map(a => tpe.encoder.encode(a)).mkString(", ")}.")
+          Invalid(s"Invalid value: ${tpe.encoder.encode(a)} ; valid values are: ${values.map(a => tpe.encoder.encode(a)).mkString(", ")}")
         }
       }
       val encoder = tpe.encoder
@@ -112,7 +112,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   lazy val emptyRecord: Record[Unit] = new Record[Unit] {
     val decoder = {
       case _: ujson.Obj => Valid(())
-      case json         => Invalid(s"Invalid JSON object: $json.")
+      case json         => Invalid(s"Invalid JSON object: $json")
     }
     val encoder = _ => ujson.Obj()
   }
@@ -123,9 +123,9 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         case obj @ ujson.Obj(fields) =>
           fields.get(name) match {
             case Some(json) => tpe.decoder.decode(json)
-            case None       => Invalid(s"Missing property '$name' in JSON object: $obj.")
+            case None       => Invalid(s"Missing property '$name' in JSON object: $obj")
           }
-        case json => Invalid(s"Invalid JSON object: $json.")
+        case json => Invalid(s"Invalid JSON object: $json")
       }
       val encoder = value => ujson.Obj(name -> tpe.encoder.encode(value))
     }
@@ -136,10 +136,11 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       val decoder = {
         case ujson.Obj(fields) =>
           fields.get(name) match {
-            case Some(json) => tpe.decoder.decode(json).map(Some(_))
-            case None       => Valid(None)
+            case Some(ujson.Null) => Valid(None)
+            case Some(json)       => tpe.decoder.decode(json).map(Some(_))
+            case None             => Valid(None)
           }
-        case json => Invalid(s"Invalid JSON object: $json.")
+        case json => Invalid(s"Invalid JSON object: $json")
       }
       val encoder = new Encoder[Option[A], ujson.Obj] {
         def encode(maybeValue: Option[A]) = maybeValue match {
@@ -192,7 +193,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       val decoder: Decoder[ujson.Value, Either[A, B]] = json => {
         schemaA.decoder.decode(json) match {
           case Valid(value) => Valid(Left(value))
-          case Invalid(_)   => schemaB.decoder.decode(json).map(Right(_)).mapErrors(_ => s"Invalid value: $json." :: Nil)
+          case Invalid(_)   => schemaB.decoder.decode(json).map(Right(_)).mapErrors(_ => s"Invalid value: $json" :: Nil)
         }
       }
       val encoder: Encoder[Either[A, B], ujson.Value] = {
@@ -204,7 +205,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   def stringJsonSchema(format: Option[String]): JsonSchema[String] = new JsonSchema[String] {
     val decoder = {
       case ujson.Str(str) => Valid(str)
-      case json           => Invalid(s"Invalid string value: $json.")
+      case json           => Invalid(s"Invalid string value: $json")
     }
     val encoder = ujson.Str(_)
   }
@@ -212,7 +213,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   implicit def intJsonSchema: JsonSchema[Int] = new JsonSchema[Int] {
     val decoder = {
       case ujson.Num(x) if x.isValidInt => Valid(x.toInt)
-      case json                         => Invalid(s"Invalid integer value: $json.")
+      case json                         => Invalid(s"Invalid integer value: $json")
     }
     val encoder = n => ujson.Num(n.toDouble)
   }
@@ -222,7 +223,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       case json @ ujson.Num(x) =>
         val y = BigDecimal(x) // no `isValidLong` operation on `Double`, so convert to `BigDecimal`
         if (y.isValidLong) Valid(y.toLong) else Invalid(s"Invalid integer value: $json")
-      case json => Invalid(s"Invalid number value: $json.")
+      case json => Invalid(s"Invalid number value: $json")
     }
     val encoder = n => ujson.Num(n.toDouble)
   }
@@ -230,7 +231,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   implicit def bigdecimalJsonSchema: JsonSchema[BigDecimal] = new JsonSchema[BigDecimal] {
     val decoder = {
       case ujson.Num(x) => Valid(BigDecimal(x))
-      case json         => Invalid(s"Invalid number value: $json.")
+      case json         => Invalid(s"Invalid number value: $json")
     }
     val encoder = x => ujson.Num(x.doubleValue)
   }
@@ -238,7 +239,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   implicit def floatJsonSchema: JsonSchema[Float] = new JsonSchema[Float] {
     val decoder = {
       case ujson.Num(x) => Valid(x.toFloat)
-      case json         => Invalid(s"Invalid number value: $json.")
+      case json         => Invalid(s"Invalid number value: $json")
     }
     val encoder = x => ujson.Num(x.toDouble)
   }
@@ -246,7 +247,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   implicit def doubleJsonSchema: JsonSchema[Double] = new JsonSchema[Double] {
     val decoder = {
       case ujson.Num(x) => Valid(x)
-      case json         => Invalid(s"Invalid number value: $json.")
+      case json         => Invalid(s"Invalid number value: $json")
     }
     val encoder = ujson.Num(_)
   }
@@ -254,7 +255,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   implicit def booleanJsonSchema: JsonSchema[Boolean] = new JsonSchema[Boolean] {
     val decoder = {
       case ujson.Bool(b) => Valid(b)
-      case json          => Invalid(s"Invalid boolean value: $json.")
+      case json          => Invalid(s"Invalid boolean value: $json")
     }
     val encoder = ujson.Bool(_)
   }
@@ -262,7 +263,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   implicit def byteJsonSchema: JsonSchema[Byte] = new JsonSchema[Byte] {
     val decoder = {
       case ujson.Num(x) if x.isValidByte => Valid(x.toByte)
-      case json                          => Invalid(s"Invalid byte value: $json.")
+      case json                          => Invalid(s"Invalid byte value: $json")
     }
     val encoder = b => ujson.Num(b.toDouble)
   }
@@ -279,7 +280,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
           .foldLeft[Validated[collection.mutable.Builder[A, C[A]]]](Valid(builder)) {
             case (acc, value) => acc.zip(value).map { case (b, a) => b += a }
           }.map(_.result())
-      case json => Invalid(s"Invalid JSON array: $json.")
+      case json => Invalid(s"Invalid JSON array: $json")
     }
     val encoder = as => ujson.Arr(as.map(jsonSchema.codec.encode): _*)
   }
@@ -294,7 +295,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
             .foldLeft[Validated[collection.mutable.Builder[(String, A), Map[String, A]]]](Valid(builder)) {
               case (acc, value) => acc.zip(value).map { case (b, name, value) => b += name -> value }
             }.map(_.result())
-        case json => Invalid(s"Invalid JSON object: $json.")
+        case json => Invalid(s"Invalid JSON object: $json")
       }
       val encoder = map => {
         new ujson.Obj(mutable.LinkedHashMap(map.map { case (k, v) => (k, jsonSchema.codec.encode(v)) }.toSeq: _*))

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -209,7 +209,7 @@ trait Fixtures extends algebra.Endpoints with algebra.ChunkedEntities {
 
 object Fixtures
   extends Fixtures
-    with algebra.JsonSchemasTest
+    with algebra.JsonSchemasFixtures
     with Endpoints
     with JsonEntitiesFromSchemas
     with ChunkedEntities {

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.freespec.AnyFreeSpec
 class JsonSchemasTest extends AnyFreeSpec {
 
   object DocumentedJsonSchemas
-    extends algebra.JsonSchemasTest
+    extends algebra.JsonSchemasFixtures
       with JsonSchemas
 
   import DocumentedJsonSchemas.DocumentedJsonSchema._

--- a/openapi/openapi/src/test/scala/endpoints/openapi/OneOfTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/OneOfTest.scala
@@ -20,6 +20,6 @@ class OneOfTest extends AnyWordSpec with Matchers {
     }
   }
 
-  trait Fixtures extends algebra.JsonSchemasTest with JsonSchemas
+  trait Fixtures extends algebra.JsonSchemasFixtures with JsonSchemas
 
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -29,7 +29,7 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
     )(Fixtures.listBooks, Fixtures.postBook)
   }
 
-  trait Fixtures extends algebra.Endpoints with algebra.JsonEntitiesFromSchemas with generic.JsonSchemas with algebra.BasicAuthentication with algebra.JsonSchemasTest {
+  trait Fixtures extends algebra.Endpoints with algebra.JsonEntitiesFromSchemas with generic.JsonSchemas with algebra.BasicAuthentication with algebra.JsonSchemasFixtures {
 
     implicit private val schemaStorage: JsonSchema[Storage] =
       genericTagged[Storage]

--- a/openapi/openapi/src/test/scala/endpoints/ujson/JsonSchemasOptionalFieldsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/ujson/JsonSchemasOptionalFieldsTest.scala
@@ -1,0 +1,26 @@
+package endpoints.ujson
+
+import endpoints.{Validated, algebra}
+import org.scalatest.freespec.AnyFreeSpec
+
+import scala.collection.mutable
+
+class JsonSchemasOptionalFieldsTest extends AnyFreeSpec with algebra.JsonSchemasOptionalFieldsTest with JsonSchemas {
+
+  object Json extends Json {
+    type Json = ujson.Value
+    def obj(fields: (String, Json)*): Json = ujson.Obj(new mutable.LinkedHashMap ++= fields)
+    def arr(items: Json*): Json            = ujson.Arr(items: _*)
+    def num(x: BigDecimal): Json           = ujson.Num(x.doubleValue)
+    def str(s: String): Json               = ujson.Str(s)
+    def bool(b: Boolean): Json             = ujson.Bool(b)
+    def `null`: Json                       = ujson.Null
+  }
+
+  def decodeJson[A](schema: JsonSchema[A], json: Json.Json): Validated[A] =
+    schema.decoder.decode(json)
+
+  def encodeJson[A](schema: JsonSchema[A], value: A): Json.Json =
+    schema.encoder.encode(value)
+
+}

--- a/openapi/openapi/src/test/scala/endpoints/ujson/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/ujson/JsonSchemasTest.scala
@@ -7,60 +7,24 @@ import org.scalatest.freespec.AnyFreeSpec
 
 class JsonSchemasTest extends AnyFreeSpec {
 
-  object JsonSchemasCodec extends algebra.JsonSchemasTest with endpoints.ujson.JsonSchemas
+  object JsonSchemasCodec extends algebra.JsonSchemasFixtures with endpoints.ujson.JsonSchemas
   import JsonSchemasCodec._
-
-  "empty record" in {
-    checkRoundTrip(
-      emptyRecord,
-      ujson.Obj(),
-      ()
-    )
-  }
-
-  "invalid empty record" in {
-    checkDecodingFailure(
-      emptyRecord,
-      ujson.Arr(),
-      "Invalid JSON object: []." :: Nil
-    )
-  }
-
-  "single record" in {
-    checkRoundTrip(
-      field[String]("field1"),
-      ujson.Obj("field1" -> ujson.Str("string1")),
-      "string1"
-    )
-  }
-
-  "ignore extra record fields" in {
-    val schema  = field[Int]("relevant")
-    val json    = ujson.Obj("relevant" -> ujson.Num(1), "irrelevant" -> ujson.Num(0))
-    val decoded = schema.codec.decode(json)
-    decoded match {
-      case Valid(n)        => assert(n == 1)
-      case Invalid(errors) => fail(errors.toString)
-    }
-    val encoded = schema.codec.encode(1)
-    assert(encoded == ujson.Obj("relevant" -> ujson.Num(1)))
-  }
 
   "invalid records" in {
     checkDecodingFailure(
       field[Int]("foo"),
       ujson.True,
-      "Invalid JSON object: true." :: Nil
+      "Invalid JSON object: true" :: Nil
     )
     checkDecodingFailure(
       field[Int]("foo"),
       ujson.Obj("bar" -> ujson.True),
-      "Missing property 'foo' in JSON object: {\"bar\":true}." :: Nil
+      "Missing property 'foo' in JSON object: {\"bar\":true}" :: Nil
     )
     checkDecodingFailure(
       field[Int]("foo"),
       ujson.Obj("foo" -> ujson.True),
-      "Invalid integer value: true." :: Nil
+      "Invalid integer value: true" :: Nil
     )
   }
 
@@ -81,7 +45,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       optField[Int]("x"),
       ujson.Obj("x" -> ujson.Str("foo")),
-      "Invalid integer value: \"foo\"." :: Nil
+      "Invalid integer value: \"foo\"" :: Nil
     )
   }
 
@@ -135,7 +99,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       field[Int]("foo") zip field[Boolean]("bar"),
       ujson.Obj("foo" -> ujson.Str("quux")),
-      "Invalid integer value: \"quux\"." :: "Missing property 'bar' in JSON object: {\"foo\":\"quux\"}." :: Nil
+      "Invalid integer value: \"quux\"" :: "Missing property 'bar' in JSON object: {\"foo\":\"quux\"}" :: Nil
     )
   }
 
@@ -172,12 +136,12 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       arrayJsonSchema[List, Int],
       ujson.Obj(),
-      "Invalid JSON array: {}." :: Nil
+      "Invalid JSON array: {}" :: Nil
     )
     checkDecodingFailure(
       arrayJsonSchema[List, Int],
       ujson.Arr(ujson.Num(0), ujson.Str("foo"), ujson.Num(3.14)),
-      "Invalid integer value: \"foo\"." :: "Invalid integer value: 3.14." :: Nil
+      "Invalid integer value: \"foo\"" :: "Invalid integer value: 3.14" :: Nil
     )
   }
 
@@ -190,12 +154,12 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       boolIntString,
       ujson.Arr(ujson.True, ujson.Str("foo"), ujson.Num(42)),
-      "Invalid integer value: \"foo\"." :: "Invalid string value: 42." :: Nil
+      "Invalid integer value: \"foo\"" :: "Invalid string value: 42" :: Nil
     )
     checkDecodingFailure(
       boolIntString,
       ujson.Arr(ujson.True),
-      "Invalid JSON array of 3 elements: [true]." :: Nil
+      "Invalid JSON array of 3 elements: [true]" :: Nil
     )
   }
 
@@ -208,7 +172,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       mapJsonSchema[Boolean],
       ujson.Obj("foo" -> ujson.Num(42)),
-      "Invalid boolean value: 42." :: Nil
+      "Invalid boolean value: 42" :: Nil
     )
   }
 
@@ -228,22 +192,22 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       schema,
       ujson.Arr(),
-      "Invalid JSON object: []." :: Nil
+      "Invalid JSON object: []" :: Nil
     )
     checkDecodingFailure(
       schema,
       ujson.Obj("s" -> ujson.Str("string")),
-      "Missing type discriminator property 'type': {\"s\":\"string\"}." :: Nil
+      "Missing type discriminator property 'type': {\"s\":\"string\"}" :: Nil
     )
     checkDecodingFailure(
       schema,
       ujson.Obj("type" -> ujson.Str("B"), "s" -> ujson.Str("string")),
-      "Invalid type discriminator: 'B'." :: Nil
+      "Invalid type discriminator: 'B'" :: Nil
     )
     checkDecodingFailure(
       schema,
       ujson.Obj("type" -> ujson.Str("I"), "s" -> ujson.Str("string")),
-      "Missing property 'i' in JSON object: {\"type\":\"I\",\"s\":\"string\"}." :: Nil
+      "Missing property 'i' in JSON object: {\"type\":\"I\",\"s\":\"string\"}" :: Nil
     )
   }
 
@@ -274,12 +238,12 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       Enum.colorSchema,
       ujson.Num(42),
-      "Invalid string value: 42." :: Nil
+      "Invalid string value: 42" :: Nil
     )
     checkDecodingFailure(
       Enum.colorSchema,
       ujson.Str("Orange"),
-      "Invalid value: Orange. Valid values are Red, Blue." :: Nil
+      "Invalid value: Orange ; valid values are: Red, Blue" :: Nil
     )
   }
 
@@ -331,14 +295,14 @@ class JsonSchemasTest extends AnyFreeSpec {
     checkDecodingFailure(
       uuidJsonSchema,
       ujson.Str("foo"),
-      "Invalid UUID value: 'foo'." :: Nil
+      "Invalid UUID value: 'foo'" :: Nil
     )
   }
 
   "oneOf" in {
     checkRoundTrip(intOrBoolean, ujson.Num(42), Left(42))
     checkRoundTrip(intOrBoolean, ujson.Bool(true), Right(true))
-    checkDecodingFailure(intOrBoolean, ujson.Str("foo"), Seq("Invalid value: \"foo\"."))
+    checkDecodingFailure(intOrBoolean, ujson.Str("foo"), Seq("Invalid value: \"foo\""))
   }
 
   def checkRoundTrip[A](schema: JsonSchema[A], json: ujson.Value, expected: A): Unit = {


### PR DESCRIPTION
Fixes #123

- Decoders of optional fields successfully decode `None` if the field is absent from the JSON object or if it is present with the value `null`,
- Decoders of optional fields fail if the field is present but has an invalid value,
- Encoders of optional fields can omit the field or emit it with value `null`.

I was not sure whether it was a good idea or not to successfully decode fields with value `null` as `None`. As long as we don’t give another meaning to `null` this seems safe to me. Since it seems to be a common practice to use fields with value `null` to model the absence of value, I thought that was important that we support it.

The tests for the behavior of optional fields have been factored in a generic class that should be used (as a set of law) to validate any codec interpreter of `JsonSchemas`.