### PR TITLE
Support `title` and `description` on `JsonSchema`

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -291,6 +291,16 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionJsonSchema[A](
+      schema: JsonSchema[A],
+      description: String
+  ): JsonSchema[A] = schema
+
+  def withTitleJsonSchema[A](
+      schema: JsonSchema[A],
+      title: String
+  ): JsonSchema[A] = schema
+
   def orFallbackToJsonSchema[A, B](
       schemaA: JsonSchema[A],
       schemaB: JsonSchema[B]

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -112,6 +112,16 @@ class JsonSchemasTest extends AnyFreeSpec {
     ): JsonSchema[A] =
       schema
 
+    def withDescriptionJsonSchema[A](
+        schema: JsonSchema[A],
+        description: String
+    ): JsonSchema[A] = schema
+
+    def withTitleJsonSchema[A](
+        schema: JsonSchema[A],
+        title: String
+    ): JsonSchema[A] = schema
+
     def orFallbackToJsonSchema[A, B](
         schemaA: JsonSchema[A],
         schemaB: JsonSchema[B]

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -162,6 +162,16 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionJsonSchema[A](
+      schema: JsonSchema[A],
+      description: String
+  ): JsonSchema[A] = schema
+
+  def withTitleJsonSchema[A](
+      schema: JsonSchema[A],
+      title: String
+  ): JsonSchema[A] = schema
+
   def orFallbackToJsonSchema[A, B](
       schemaA: JsonSchema[A],
       schemaB: JsonSchema[B]

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -288,6 +288,18 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Include an example value within the given schema */
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A]
 
+  /** Add a description to the given schema */
+  def withDescriptionJsonSchema[A](
+      schema: JsonSchema[A],
+      description: String
+  ): JsonSchema[A]
+
+  /** Add a title to the given schema */
+  def withTitleJsonSchema[A](
+      schema: JsonSchema[A],
+      title: String
+  ): JsonSchema[A]
+
   /**
     * A schema that can be either `schemaA` or `schemaB`.
     *
@@ -326,6 +338,23 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       withExampleJsonSchema(schemaA, example)
 
     /**
+      * Include a description of what this schema represents. Documentation
+      * interpreters can show this description. Encoder and decoder interpreters
+      * ignore this description.
+      * @param description information about the values described by the schema
+      */
+    def withDescription(description: String): JsonSchema[A] =
+      withDescriptionJsonSchema(schemaA, description)
+
+    /**
+      * Include a title for the schema. Documentation interpreters can show
+      * this title. Encoder and decoder interpreters ignore the title.
+      * @param title short title to attach to the schema
+      */
+    def withTitle(title: String): JsonSchema[A] =
+      withTitleJsonSchema(schemaA, title)
+
+    /**
       * A schema that can be either `schemaA` or `schemaB`.
       *
       * Documentation interpreter produce a `oneOf` JSON schema.
@@ -362,6 +391,11 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       * Give a name to the schema.
       * Documentation interpreters use that name to refer to this schema.
       * Encoder and decoder interpreters ignore the name.
+      *
+      * @note Names are used by documentation interpreters to construct
+      *       references and that the JSON schema specification requires these
+      *       to be valid URI's. Consider using `withTitle` if you just want
+      *       to override the heading displayed in documentation.
       */
     def named(name: String): Record[A] = namedRecord(recordA, name)
   }
@@ -375,6 +409,11 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       * Give a name to the schema.
       * Documentation interpreters use that name to refer to this schema.
       * Encoder and decoder interpreters ignore the name.
+      *
+      * @note Names are used by documentation interpreters to construct
+      *       references and that the JSON schema specification requires these
+      *       to be valid URI's. Consider using `withTitle` if you just want
+      *       to override the heading displayed in documentation.
       */
     def named(name: String): Tagged[A] = namedTagged(taggedA, name)
 
@@ -392,6 +431,11 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       * Give a name to the schema.
       * Documentation interpreters use that name to refer to this schema.
       * Encoder and decoder interpreters ignore the name.
+      *
+      * @note Names are used by documentation interpreters to construct
+      *       references and that the JSON schema specification requires these
+      *       to be valid URI's. Consider using `withTitle` if you just want
+      *       to override the heading displayed in documentation.
       */
     def named(name: String): Enum[A] = namedEnum(enumA, name)
   }

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -393,7 +393,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       * Encoder and decoder interpreters ignore the name.
       *
       * @note Names are used by documentation interpreters to construct
-      *       references and that the JSON schema specification requires these
+      *       references and the JSON schema specification requires these
       *       to be valid URI's. Consider using `withTitle` if you just want
       *       to override the heading displayed in documentation.
       */
@@ -411,7 +411,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       * Encoder and decoder interpreters ignore the name.
       *
       * @note Names are used by documentation interpreters to construct
-      *       references and that the JSON schema specification requires these
+      *       references and the JSON schema specification requires these
       *       to be valid URI's. Consider using `withTitle` if you just want
       *       to override the heading displayed in documentation.
       */
@@ -433,7 +433,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       * Encoder and decoder interpreters ignore the name.
       *
       * @note Names are used by documentation interpreters to construct
-      *       references and that the JSON schema specification requires these
+      *       references and the JSON schema specification requires these
       *       to be valid URI's. Consider using `withTitle` if you just want
       *       to override the heading displayed in documentation.
       */

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -209,7 +209,7 @@ trait EndpointsWithCustomErrors
     } yield recSchema
 
     allReferencedSchemas.collect {
-      case Schema.Reference(name, Some(original), _, _) => name -> original
+      case Schema.Reference(name, Some(original), _, _, _) => name -> original
     }.toMap
   }
 
@@ -217,18 +217,18 @@ trait EndpointsWithCustomErrors
       schema: Schema
   ): Seq[Schema.Reference] =
     schema match {
-      case Schema.Object(properties, additionalProperties, _, _) =>
+      case Schema.Object(properties, additionalProperties, _, _, _) =>
         properties.map(_.schema).flatMap(captureReferencedSchemasRec) ++
           additionalProperties.toList.flatMap(captureReferencedSchemasRec)
-      case Schema.Array(Left(elementType), _, _) =>
+      case Schema.Array(Left(elementType), _, _, _) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Array(Right(elementTypes), _, _) =>
+      case Schema.Array(Right(elementTypes), _, _, _) =>
         elementTypes.flatMap(captureReferencedSchemasRec)
-      case Schema.Enum(elementType, _, _, _) =>
+      case Schema.Enum(elementType, _, _, _, _) =>
         captureReferencedSchemasRec(elementType)
-      case Schema.Primitive(_, _, _, _) =>
+      case Schema.Primitive(_, _, _, _, _) =>
         Nil
-      case Schema.OneOf(alternatives, _, _) =>
+      case Schema.OneOf(alternatives, _, _, _) =>
         val alternativeSchemas =
           alternatives match {
             case Schema.DiscriminatedAlternatives(_, alternatives) =>
@@ -236,7 +236,7 @@ trait EndpointsWithCustomErrors
             case Schema.EnumeratedAlternatives(alternatives) => alternatives
           }
         alternativeSchemas.flatMap(captureReferencedSchemasRec)
-      case Schema.AllOf(schemas, _, _) =>
+      case Schema.AllOf(schemas, _, _, _) =>
         schemas.flatMap {
           case _: Schema.Reference => Nil
           case s                   => captureReferencedSchemasRec(s)

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -107,7 +107,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     ) extends DocumentedJsonSchema
 
     // A documented JSON schema that is unevaluated unless its `value` is accessed
-    sealed trait LazySchema extends DocumentedJsonSchema {
+    sealed abstract class LazySchema extends DocumentedJsonSchema {
       def value: DocumentedJsonSchema
     }
     object LazySchema {

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
@@ -64,7 +64,12 @@ trait Urls extends algebra.Urls {
       factory: Factory[A, CC[A]]
   ): QueryStringParam[CC[A]] =
     DocumentedQueryStringParam(
-      Schema.Array(Left(param.schema), description = None, example = None),
+      Schema.Array(
+        Left(param.schema),
+        description = None,
+        example = None,
+        title = None
+      ),
       isRequired = false
     )
 

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -243,6 +243,16 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionJsonSchema[A](
+      schema: JsonSchema[A],
+      description: String
+  ): JsonSchema[A] = schema
+
+  def withTitleJsonSchema[A](
+      schema: JsonSchema[A],
+      title: String
+  ): JsonSchema[A] = schema
+
   def orFallbackToJsonSchema[A, B](
       schemaA: JsonSchema[A],
       schemaB: JsonSchema[B]

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ChunkedEntitiesTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ChunkedEntitiesTest.scala
@@ -39,11 +39,13 @@ class ChunkedEntitiesTest extends AnyWordSpec {
                         "endpoints.Errors",
                         Some(
                           Array(
-                            Left(Primitive("string", None, None, None)),
+                            Left(Primitive("string", None, None, None, None)),
+                            None,
                             None,
                             None
                           )
                         ),
+                        None,
                         None,
                         None
                       )
@@ -61,11 +63,13 @@ class ChunkedEntitiesTest extends AnyWordSpec {
                         "endpoints.Errors",
                         Some(
                           Array(
-                            Left(Primitive("string", None, None, None)),
+                            Left(Primitive("string", None, None, None, None)),
+                            None,
                             None,
                             None
                           )
                         ),
+                        None,
                         None,
                         None
                       )

--- a/openapi/openapi/src/test/scala/endpoints/openapi/DescriptionsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/DescriptionsTest.scala
@@ -1,0 +1,61 @@
+package endpoints.openapi
+
+import endpoints.openapi.model.OpenApi
+import endpoints.{algebra, openapi}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DescriptionsTest extends AnyWordSpec with Matchers {
+
+  "Schemas" should {
+
+    "Include descriptions in documentation" in new Fixtures {
+      checkDescription(recordSchema)("a foo bar record")
+      checkDescription(coprodSchema)("a foo or a bar coprod")
+      checkDescription(enumSchema)("a foo or a bar enum")
+      checkDescription(arraySchema)("a list of ints")
+      checkDescription(mapSchema)("a map of ints")
+      checkDescription(pairSchema)("a pair of int and string")
+    }
+
+  }
+
+  trait FixturesAlg extends algebra.JsonSchemas {
+
+    override def defaultDiscriminatorName: String = "kind"
+
+    val recordSchema = (
+      field[String]("foo") zip
+        field[Int]("bar")
+    ).withDescription("a foo bar record")
+
+    val coprodSchema = {
+      val left = field[String]("foo").tagged("L")
+      val right = field[Int]("bar").tagged("R")
+      left.orElse(right).withDescription("a foo or a bar coprod")
+    }
+
+    val enumSchema =
+      stringEnumeration(Seq("foo", "bar"))(identity).withDescription("a foo or a bar enum")
+
+    val arraySchema = arrayJsonSchema[List, Int].withDescription("a list of ints")
+
+    val mapSchema = mapJsonSchema[Int].withDescription("a map of ints")
+
+    val pairSchema =
+      implicitly[JsonSchema[(Int, String)]].withDescription("a pair of int and string")
+
+  }
+
+  trait Fixtures
+      extends FixturesAlg
+      with openapi.Endpoints
+      with openapi.JsonEntitiesFromSchemas {
+
+    def checkDescription[A](schema: JsonSchema[A])(description: String) = {
+      assert(OpenApi.schemaJson(toSchema(schema.docs))("description") == ujson.Str(description))
+    }
+
+  }
+
+}

--- a/openapi/openapi/src/test/scala/endpoints/openapi/DescriptionsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/DescriptionsTest.scala
@@ -16,6 +16,8 @@ class DescriptionsTest extends AnyWordSpec with Matchers {
       checkDescription(arraySchema)("a list of ints")
       checkDescription(mapSchema)("a map of ints")
       checkDescription(pairSchema)("a pair of int and string")
+      checkDescription(hexSchema)("a hex string")
+      checkDescription(fallbackSchema)("a foo or 1 or 4")
     }
 
   }
@@ -45,6 +47,13 @@ class DescriptionsTest extends AnyWordSpec with Matchers {
     val pairSchema =
       implicitly[JsonSchema[(Int, String)]].withDescription("a pair of int and string")
 
+    val hexSchema =
+      stringJsonSchema(Some("hex")).withDescription("a hex string")
+
+    val fallbackSchema =
+      defaultStringJsonSchema
+        .orFallbackTo(longJsonSchema)
+        .withDescription("a foo or 1 or 4")
   }
 
   trait Fixtures

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -40,7 +40,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
             In.Query,
             required = false,
             description = None,
-            schema = Schema.Array(Left(Schema.simpleInteger), None, None)
+            schema = Schema.Array(Left(Schema.simpleInteger), None, None, None)
           ) ::
           Nil
       Fixtures.quux.item
@@ -68,17 +68,18 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
         Schema.Object(
           Schema.Property(
             "name",
-            Schema.Primitive("string", None, None, None),
+            Schema.Primitive("string", None, None, None, None),
             isRequired = true,
             description = Some("Name of the user")
           ) ::
             Schema.Property(
               "age",
-              Schema.Primitive("integer", Some("int32"), None, None),
+              Schema.Primitive("integer", Some("int32"), None, None, None),
               isRequired = true,
               description = None
             ) ::
             Nil,
+          None,
           None,
           None,
           None
@@ -93,12 +94,15 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
         "Color",
         Some(
           Schema.Enum(
-            Schema.Primitive("string", None, None, None),
+            Schema.Primitive("string", None, None, None, None),
             ujson.Str("Red") :: ujson.Str("Blue") :: Nil,
+            None,
             None,
             None
           )
         ),
+        None,
+        None,
         None
       )
     Fixtures.toSchema(Fixtures.Enum.colorSchema.docs) shouldBe expectedSchema
@@ -118,9 +122,12 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
             ) :: Nil,
             additionalProperties = None,
             description = None,
-            example = None
+            example = None,
+            title = None
           )
         ),
+        None,
+        None,
         None
       )
     val expectedSchema =
@@ -133,7 +140,8 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
         ) :: Nil,
         additionalProperties = None,
         description = None,
-        example = None
+        example = None,
+        title = None
       )
     Fixtures.toSchema(Fixtures.recursiveSchema.docs) shouldBe expectedSchema
   }
@@ -159,7 +167,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
       reqBody shouldBe defined
       reqBody.value.description.value shouldEqual "Text Req"
       reqBody.value.content("text/plain").schema.value shouldEqual Schema
-        .Primitive("string", None, None, None)
+        .Primitive("string", None, None, None, None)
     }
   }
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ExamplesTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ExamplesTest.scala
@@ -22,6 +22,8 @@ class ExamplesTest extends AnyWordSpec with Matchers {
         ujson.Obj("foo" -> ujson.Num(1), "bar" -> ujson.Num(2))
       )
       checkExample(pairSchema)(ujson.Arr(ujson.Num(42), ujson.Str("foo")))
+      checkExample(hexSchema)(ujson.Str("deadbeef"))
+      checkExample(fallbackSchema)(ujson.Num(1))
     }
 
   }
@@ -51,6 +53,13 @@ class ExamplesTest extends AnyWordSpec with Matchers {
     val pairSchema =
       implicitly[JsonSchema[(Int, String)]].withExample((42, "foo"))
 
+    val hexSchema =
+      stringJsonSchema(Some("hex")).withExample("deadbeef")
+
+    val fallbackSchema =
+      defaultStringJsonSchema
+        .orFallbackTo(longJsonSchema)
+        .withExample(Right(1L))
   }
 
   trait Fixtures

--- a/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/JsonSchemasTest.scala
@@ -98,6 +98,8 @@ class JsonSchemasTest extends AnyFreeSpec {
         ujson.Obj("quux" -> ujson.Str("bar")) :: ujson.Obj(
           "quux" -> ujson.Str("baz")
         ) :: Nil,
+        None,
+        None,
         None
       )
     assert(
@@ -109,6 +111,8 @@ class JsonSchemasTest extends AnyFreeSpec {
     DocumentedJsonSchemas.recursiveSchema.docs match {
       case DocumentedRecord(
           List(Field("next", tpe, true, None)),
+          None,
+          None,
           None,
           None,
           None

--- a/openapi/openapi/src/test/scala/endpoints/openapi/TitlesTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/TitlesTest.scala
@@ -16,6 +16,8 @@ class TitlesTest extends AnyWordSpec with Matchers {
       checkTitle(arraySchema)("list of ints")
       checkTitle(mapSchema)("map of ints")
       checkTitle(pairSchema)("pair")
+      checkTitle(hexSchema)("hex string")
+      checkTitle(fallbackSchema)("fallback literals")
     }
 
   }
@@ -45,6 +47,13 @@ class TitlesTest extends AnyWordSpec with Matchers {
     val pairSchema =
       implicitly[JsonSchema[(Int, String)]].withTitle("pair")
 
+    val hexSchema =
+      stringJsonSchema(Some("hex")).withTitle("hex string")
+
+    val fallbackSchema =
+      defaultStringJsonSchema
+        .orFallbackTo(longJsonSchema)
+        .withTitle("fallback literals")
   }
 
   trait Fixtures

--- a/openapi/openapi/src/test/scala/endpoints/openapi/TitlesTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/TitlesTest.scala
@@ -1,0 +1,61 @@
+package endpoints.openapi
+
+import endpoints.openapi.model.OpenApi
+import endpoints.{algebra, openapi}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TitlesTest extends AnyWordSpec with Matchers {
+
+  "Schemas" should {
+
+    "Include titles in documentation" in new Fixtures {
+      checkTitle(recordSchema)("record")
+      checkTitle(coprodSchema)("coprod")
+      checkTitle(enumSchema)("enum")
+      checkTitle(arraySchema)("list of ints")
+      checkTitle(mapSchema)("map of ints")
+      checkTitle(pairSchema)("pair")
+    }
+
+  }
+
+  trait FixturesAlg extends algebra.JsonSchemas {
+
+    override def defaultDiscriminatorName: String = "kind"
+
+    val recordSchema = (
+      field[String]("foo") zip
+        field[Int]("bar")
+    ).withTitle("record")
+
+    val coprodSchema = {
+      val left = field[String]("foo").tagged("L")
+      val right = field[Int]("bar").tagged("R")
+      left.orElse(right).withTitle("coprod")
+    }
+
+    val enumSchema =
+      stringEnumeration(Seq("foo", "bar"))(identity).withTitle("enum")
+
+    val arraySchema = arrayJsonSchema[List, Int].withTitle("list of ints")
+
+    val mapSchema = mapJsonSchema[Int].withTitle("map of ints")
+
+    val pairSchema =
+      implicitly[JsonSchema[(Int, String)]].withTitle("pair")
+
+  }
+
+  trait Fixtures
+      extends FixturesAlg
+      with openapi.Endpoints
+      with openapi.JsonEntitiesFromSchemas {
+
+    def checkTitle[A](schema: JsonSchema[A])(title: String) = {
+      assert(OpenApi.schemaJson(toSchema(schema.docs))("title") == ujson.Str(title))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Extend the core `JsonSchemas` algebra to support setting a title and
description on schemas. This is implemented in the same way as schema
examples.

  * The main user facing change is that `JsonSchemas` now has two more
    methods: `withDescriptionJsonSchema` and `withTitleJsonSchema`

  * The OpenAPI model supports titles and descriptions on every schema.
    The OpenAPI interpreter fills these titles and descriptions in.

  * Other encoder/decoder intepreters ignore any descriptions or titles.

This new functionality is tested in `DescriptionsTest` and `TitlesTest`.

Fixes #500