### PR TITLE
Option to configure OpenAPI schemas for coproducts

### DIFF
--- a/documentation/manual/src/paradox/algebras/json-schemas.md
+++ b/documentation/manual/src/paradox/algebras/json-schemas.md
@@ -184,6 +184,12 @@ following JSON document:
 }
 ~~~
 
+The encoding of sealed traits in OpenAPI can be configured by overriding the `coproductEncoding`
+method in the OpenAPI interpreter. By default, the OpenAPI interpreter will encode variants of
+sealed traits in the same way that they would be encoded if they were standalone records. However,
+it is sometimes useful to include in each variants' schema a reference to the base type schema.
+The @scaladoc[API documentation](endpoints.openapi.JsonSchemas.coproductEncoding) has more details.
+
 ## Generic derivation of JSON schemas (based on Shapeless) 
 
 The module presented in this section uses Shapeless to generically derive JSON schemas

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -14,6 +14,10 @@ import scala.collection.compat._
   * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces a JSON schema for
   * a given algebraic data type description.
   *
+  * The encoding of the schemas of sealed traits (obtained with the operation
+  * `orElse` or via generic derivation) can be configured by overriding
+  * [[JsonSchemas.coproductEncoding]].
+  *
   * @group interpreters
   */
 trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
@@ -430,7 +434,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     * This object contains the options for how to encode coproduct JSON schemas.
     *
     * The following Scala coproduct is the candidate example. Each encoding
-    * option includes the schema that it would geenrate for that example.
+    * option includes the schema that it would generate for that example.
     *
     * {{{
     * sealed trait Pet
@@ -508,7 +512,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       * referred to in OpenAPI 3 as a way to model polymorphism.
       *
       *  - compatible with OpenAPI clients that don't handle `oneOf` properly
-      *  - complex confusing schemas in Swagger UI
+      *  - more complex schemas in Swagger UI
       *
       * Using the `Pet` example above, this strategy yields the following:
       *
@@ -578,12 +582,13 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   }
 
   /**
-    * Strategy used to encode the JSON schema of coproducts
+    * Override this method to customize the strategy used to encode the JSON
+    * schema of coproducts. By default, it uses [[CoproductEncoding.OneOf]].
     *
     * @see [[JsonSchemas.CoproductEncoding$]]
     *
     */
-  def coproductEncoding: CoproductEncoding = CoproductEncoding.OneOfWithBaseRef
+  def coproductEncoding: CoproductEncoding = CoproductEncoding.OneOf
 
   /** Convert the internal representation of a JSON schema into the public OpenAPI AST */
   def toSchema(jsonSchema: DocumentedJsonSchema): Schema =

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -424,6 +424,167 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       )
     )
 
+  sealed trait CoproductEncoding
+
+  /**
+    * This object contains the options for how to encode coproduct JSON schemas.
+    *
+    * The following Scala coproduct is the candidate example. Each encoding
+    * option includes the schema that it would geenrate for that example.
+    *
+    * {{{
+    * sealed trait Pet
+    * case class Cat(name: String) extends Pet
+    * case class Lizard(lovesRocks: Boolean) extends Pet
+    * }}}
+    */
+  object CoproductEncoding {
+
+    /** Strategy defining the base type schema in terms of `oneOf` and the
+      * variant schemas. The variants themselves don't refer to the base type,
+      * but they do include the discriminator field.
+      *
+      *  - simpler looking schemas in Swagger UI
+      *  - some OpenAPI clients don't handle `oneOf` properly
+      *
+      * Using the `Pet` example above, this strategy yields the following:
+      *
+      * {{{
+      * "schemas": {
+      *   "Pet": {
+      *     "oneOf": [
+      *       { "$ref": "#/components/schemas/Cat" },
+      *       { "$ref": "#/components/schemas/Lizard" }
+      *     ],
+      *     "discriminator": {
+      *       "propertyName": "type",
+      *       "mapping": {
+      *         "Cat": "#/components/schemas/Cat",
+      *         "Lizard": "#/components/schemas/Lizard"
+      *       }
+      *     }
+      *   },
+      *
+      *   "Cat": {
+      *     "type": "object",
+      *     "properties": {
+      *       "type": {
+      *         "type": "string",
+      *         "enum": [ "Cat" ]
+      *       },
+      *       "name": {
+      *         "type": "string"
+      *       }
+      *     },
+      *     "required": [
+      *       "type",
+      *       "name"
+      *     ]
+      *   },
+      *
+      *   "Lizard": {
+      *     "type": "object",
+      *     "properties": {
+      *       "type": {
+      *         "type": "string",
+      *         "enum": [ "Lizard" ]
+      *       },
+      *       "lovesRocks": {
+      *         "type": "boolean"
+      *       }
+      *     },
+      *     "required": [
+      *       "type",
+      *       "lovesRocks"
+      *     ]
+      *   }
+      * }
+      * }}}
+      */
+    case object OneOf extends CoproductEncoding
+
+    /** Strategy that extends [[OneOf]] so that each variant also refers back
+      * to the base type schema using `allOf`. This approach is sometimes
+      * referred to in OpenAPI 3 as a way to model polymorphism.
+      *
+      *  - compatible with OpenAPI clients that don't handle `oneOf` properly
+      *  - complex confusing schemas in Swagger UI
+      *
+      * Using the `Pet` example above, this strategy yields the following:
+      *
+      * {{{
+      * "schemas": {
+      *   "Pet": {
+      *     "oneOf": [
+      *       { "$ref": "#/components/schemas/Cat" },
+      *       { "$ref": "#/components/schemas/Lizard" }
+      *     ],
+      *     "discriminator": {
+      *       "propertyName": "type",
+      *       "mapping": {
+      *         "Cat": "#/components/schemas/Cat",
+      *         "Lizard": "#/components/schemas/Lizard"
+      *       }
+      *     }
+      *   },
+      *
+      *   "Cat": {
+      *     "allOf": [
+      *       { "$ref": "#/components/schemas/Pet" },
+      *       {
+      *         "type": "object",
+      *         "properties": {
+      *           "type": {
+      *             "type": "string",
+      *             "enum": [ "Cat" ]
+      *           },
+      *           "name": {
+      *             "type": "string"
+      *           }
+      *         },
+      *         "required": [
+      *           "type",
+      *           "name"
+      *         ]
+      *       }
+      *     ]
+      *   },
+      *
+      *   "Lizard": {
+      *     "allOf": [
+      *       { "$ref": "#/components/schemas/Pet" },
+      *       {
+      *         "type": "object",
+      *         "properties": {
+      *           "type": {
+      *             "type": "string",
+      *             "enum": [ "Lizard" ]
+      *           },
+      *           "lovesRocks": {
+      *             "type": "boolean"
+      *           }
+      *         },
+      *         "required": [
+      *           "type",
+      *           "lovesRocks"
+      *         ]
+      *       }
+      *     ]
+      *   }
+      * }
+      * }}}
+      */
+    case object OneOfWithBaseRef extends CoproductEncoding
+  }
+
+  /**
+    * Strategy used to encode the JSON schema of coproducts
+    *
+    * @see [[JsonSchemas.CoproductEncoding$]]
+    *
+    */
+  def coproductEncoding: CoproductEncoding = CoproductEncoding.OneOfWithBaseRef
+
   /** Convert the internal representation of a JSON schema into the public OpenAPI AST */
   def toSchema(jsonSchema: DocumentedJsonSchema): Schema =
     toSchema(jsonSchema, None, Set.empty)
@@ -572,30 +733,32 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
             description = None
           )
 
-        coprod.name.fold[Schema] {
-          Schema.Object(
-            discriminatorField :: fieldsSchema,
-            additionalProperties,
-            record.description,
-            record.example,
-            record.title
-          )
-        } { coproductName =>
-          Schema.AllOf(
-            schemas = List(
-              Schema.Reference(coproductName, None, None),
-              Schema.Object(
-                discriminatorField :: fieldsSchema,
-                additionalProperties,
-                None,
-                None,
-                None
-              )
-            ),
-            record.description,
-            record.example,
-            record.title
-          )
+        (coprod.name, coproductEncoding) match {
+          case (Some(coproductName), CoproductEncoding.OneOfWithBaseRef) =>
+            Schema.AllOf(
+              schemas = List(
+                Schema.Reference(coproductName, None, None),
+                Schema.Object(
+                  discriminatorField :: fieldsSchema,
+                  additionalProperties,
+                  None,
+                  None,
+                  None
+                )
+              ),
+              record.description,
+              record.example,
+              record.title
+            )
+
+          case _ =>
+            Schema.Object(
+              discriminatorField :: fieldsSchema,
+              additionalProperties,
+              record.description,
+              record.example,
+              record.title
+            )
         }
     }
   }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/CoproductEncodingTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/CoproductEncodingTest.scala
@@ -35,290 +35,187 @@ class CoproductEncodingTest extends AnyFreeSpec {
   }
 
   "OneOf schema encoding" in {
-    val expectedSchema = Schema.OneOf(
-      Schema.DiscriminatedAlternatives(
-        "type",
-        List(
-          "Bar" -> Schema.Object(
-            List(
-              Schema.Property(
-                "type",
-                Schema.Enum(
-                  Schema.simpleString,
-                  List("Bar"),
-                  None,
-                  Some("Bar"),
-                  None
-                ),
-                true,
-                None
-              ),
-              Schema.Property("s", Schema.simpleString, true, None)
-            ),
-            None,
-            None,
-            None,
-            None
-          ),
-          "Baz" -> Schema.Object(
-            List(
-              Schema.Property(
-                "type",
-                Schema.Enum(
-                  Schema.simpleString,
-                  List("Baz"),
-                  None,
-                  Some("Baz"),
-                  None
-                ),
-                true,
-                None
-              ),
-              Schema.Property(
-                "i",
-                Schema.Primitive("integer", Some("int32"), None, None, None),
-                true,
-                None
-              )
-            ),
-            None,
-            None,
-            None,
-            None
-          ),
-          "Bax" -> Schema.Object(
-            List(
-              Schema.Property(
-                "type",
-                Schema.Enum(
-                  Schema.simpleString,
-                  List("Bax"),
-                  None,
-                  Some("Bax"),
-                  None
-                ),
-                true,
-                None
-              )
-            ),
-            None,
-            None,
-            None,
-            None
-          ),
-          "Qux" -> Schema.Object(
-            List(
-              Schema.Property(
-                "type",
-                Schema.Enum(
-                  Schema.simpleString,
-                  List("Qux"),
-                  None,
-                  Some("Qux"),
-                  None
-                ),
-                true,
-                None
-              )
-            ),
-            None,
-            None,
-            None,
-            None
-          ),
-          "Quux" -> Schema.Object(
-            List(
-              Schema.Property(
-                "type",
-                Schema.Enum(
-                  Schema.simpleString,
-                  List("Quux"),
-                  None,
-                  Some("Quux"),
-                  None
-                ),
-                true,
-                None
-              ),
-              Schema.Property("b", Schema.simpleInteger, true, None)
-            ),
-            None,
-            None,
-            None,
-            None
-          )
-        )
+    val expectedJsonSchema = ujson.Obj(
+      "discriminator" -> ujson.Obj(
+        "propertyName" -> ujson.Str("type"),
+        "mapping" -> ujson.Obj()
       ),
-      None,
-      None,
-      None
+      "oneOf" -> ujson.Arr(
+        ujson.Obj(
+          "type" -> ujson.Str("object"),
+          "properties" -> ujson.Obj(
+            "type" -> ujson.Obj(
+              "type" -> ujson.Str("string"),
+              "enum" -> ujson.Arr(ujson.Str("Bar")),
+              "example" -> ujson.Str("Bar")
+            ),
+            "s" -> ujson.Obj(
+              "type" -> ujson.Str("string")
+            )
+          ),
+          "required" -> ujson.Arr(ujson.Str("type"), ujson.Str("s"))
+        ),
+        ujson.Obj(
+          "type" -> ujson.Str("object"),
+          "properties" -> ujson.Obj(
+            "type" -> ujson.Obj(
+              "type" -> ujson.Str("string"),
+              "enum" -> ujson.Arr(ujson.Str("Baz")),
+              "example" -> ujson.Str("Baz")
+            ),
+            "i" -> ujson.Obj(
+              "type" -> ujson.Str("integer"),
+              "format" -> ujson.Str("int32")
+            )
+          ),
+          "required" -> ujson.Arr(ujson.Str("type"), ujson.Str("i"))
+        ),
+        ujson.Obj(
+          "type" -> ujson.Str("object"),
+          "properties" -> ujson.Obj(
+            "type" -> ujson.Obj(
+              "type" -> ujson.Str("string"),
+              "enum" -> ujson.Arr(ujson.Str("Bax")),
+              "example" -> ujson.Str("Bax")
+            )
+          ),
+          "required" -> ujson.Arr(ujson.Str("type"))
+        ),
+        ujson.Obj(
+          "type" -> ujson.Str("object"),
+          "properties" -> ujson.Obj(
+            "type" -> ujson.Obj(
+              "type" -> ujson.Str("string"),
+              "enum" -> ujson.Arr(ujson.Str("Qux")),
+              "example" -> ujson.Str("Qux")
+            )
+          ),
+          "required" -> ujson.Arr(ujson.Str("type"))
+        ),
+        ujson.Obj(
+          "type" -> ujson.Str("object"),
+          "properties" -> ujson.Obj(
+            "type" -> ujson.Obj(
+              "type" -> ujson.Str("string"),
+              "enum" -> ujson.Arr(ujson.Str("Quux")),
+              "example" -> ujson.Str("Quux")
+            ),
+            "b" -> ujson.Obj(
+              "type" -> ujson.Str("integer")
+            )
+          ),
+          "required" -> ujson.Arr(ujson.Str("type"), ujson.Str("b"))
+        )
+      )
     )
-    assert(OneOfStrategyDocs.api.components.schemas("Foo") == expectedSchema)
+    assert(
+      OpenApi.schemaJson(OneOfStrategyDocs.api.components.schemas("Foo")) == expectedJsonSchema
+    )
   }
 
   "OneOfWithBaseRef schema encoding" in {
-    val expectedSchema = Schema.OneOf(
-      Schema.DiscriminatedAlternatives(
-        "type",
-        List(
-          "Bar" -> Schema.AllOf(
-            List(
-              Schema.Reference("Foo", None, None, None, None),
-              Schema.Object(
-                List(
-                  Schema.Property(
-                    "type",
-                    Schema.Enum(
-                      Schema.simpleString,
-                      List("Bar"),
-                      None,
-                      Some("Bar"),
-                      None
-                    ),
-                    true,
-                    None
-                  ),
-                  Schema.Property("s", Schema.simpleString, true, None)
+    val expectedJsonSchema = ujson.Obj(
+      "discriminator" -> ujson.Obj(
+        "propertyName" -> ujson.Str("type"),
+        "mapping" -> ujson.Obj() // TODO
+      ),
+      "oneOf" -> ujson.Arr(
+        ujson.Obj(
+          "allOf" -> ujson.Arr(
+            ujson.Obj("$ref" -> ujson.Str("#/components/schemas/Foo")),
+            ujson.Obj(
+              "type" -> ujson.Str("object"),
+              "properties" -> ujson.Obj(
+                "type" -> ujson.Obj(
+                  "type" -> ujson.Str("string"),
+                  "enum" -> ujson.Arr(ujson.Str("Bar")),
+                  "example" -> ujson.Str("Bar")
                 ),
-                None,
-                None,
-                None,
-                None
-              )
-            ),
-            None,
-            None,
-            None
-          ),
-          "Baz" -> Schema.AllOf(
-            List(
-              Schema.Reference("Foo", None, None, None, None),
-              Schema.Object(
-                List(
-                  Schema.Property(
-                    "type",
-                    Schema.Enum(
-                      Schema.simpleString,
-                      List("Baz"),
-                      None,
-                      Some("Baz"),
-                      None
-                    ),
-                    true,
-                    None
-                  ),
-                  Schema.Property(
-                    "i",
-                    Schema
-                      .Primitive("integer", Some("int32"), None, None, None),
-                    true,
-                    None
-                  )
+                "s" -> ujson.Obj(
+                  "type" -> ujson.Str("string")
+                )
+              ),
+              "required" -> ujson.Arr(ujson.Str("type"), ujson.Str("s"))
+            )
+          )
+        ),
+        ujson.Obj(
+          "allOf" -> ujson.Arr(
+            ujson.Obj("$ref" -> ujson.Str("#/components/schemas/Foo")),
+            ujson.Obj(
+              "type" -> ujson.Str("object"),
+              "properties" -> ujson.Obj(
+                "type" -> ujson.Obj(
+                  "type" -> ujson.Str("string"),
+                  "enum" -> ujson.Arr(ujson.Str("Baz")),
+                  "example" -> ujson.Str("Baz")
                 ),
-                None,
-                None,
-                None,
-                None
-              )
-            ),
-            None,
-            None,
-            None
-          ),
-          "Bax" -> Schema.AllOf(
-            List(
-              Schema.Reference("Foo", None, None, None, None),
-              Schema.Object(
-                List(
-                  Schema.Property(
-                    "type",
-                    Schema.Enum(
-                      Schema.simpleString,
-                      List("Bax"),
-                      None,
-                      Some("Bax"),
-                      None
-                    ),
-                    true,
-                    None
-                  )
+                "i" -> ujson.Obj(
+                  "type" -> ujson.Str("integer"),
+                  "format" -> ujson.Str("int32")
+                )
+              ),
+              "required" -> ujson.Arr(ujson.Str("type"), ujson.Str("i"))
+            )
+          )
+        ),
+        ujson.Obj(
+          "allOf" -> ujson.Arr(
+            ujson.Obj("$ref" -> ujson.Str("#/components/schemas/Foo")),
+            ujson.Obj(
+              "type" -> ujson.Str("object"),
+              "properties" -> ujson.Obj(
+                "type" -> ujson.Obj(
+                  "type" -> ujson.Str("string"),
+                  "enum" -> ujson.Arr(ujson.Str("Bax")),
+                  "example" -> ujson.Str("Bax")
+                )
+              ),
+              "required" -> ujson.Arr(ujson.Str("type"))
+            )
+          )
+        ),
+        ujson.Obj(
+          "allOf" -> ujson.Arr(
+            ujson.Obj("$ref" -> ujson.Str("#/components/schemas/Foo")),
+            ujson.Obj(
+              "type" -> ujson.Str("object"),
+              "properties" -> ujson.Obj(
+                "type" -> ujson.Obj(
+                  "type" -> ujson.Str("string"),
+                  "enum" -> ujson.Arr(ujson.Str("Qux")),
+                  "example" -> ujson.Str("Qux")
+                )
+              ),
+              "required" -> ujson.Arr(ujson.Str("type"))
+            )
+          )
+        ),
+        ujson.Obj(
+          "allOf" -> ujson.Arr(
+            ujson.Obj("$ref" -> ujson.Str("#/components/schemas/Foo")),
+            ujson.Obj(
+              "type" -> ujson.Str("object"),
+              "properties" -> ujson.Obj(
+                "type" -> ujson.Obj(
+                  "type" -> ujson.Str("string"),
+                  "enum" -> ujson.Arr(ujson.Str("Quux")),
+                  "example" -> ujson.Str("Quux")
                 ),
-                None,
-                None,
-                None,
-                None
-              )
-            ),
-            None,
-            None,
-            None
-          ),
-          "Qux" -> Schema.AllOf(
-            List(
-              Schema.Reference("Foo", None, None, None, None),
-              Schema.Object(
-                List(
-                  Schema.Property(
-                    "type",
-                    Schema.Enum(
-                      Schema.simpleString,
-                      List("Qux"),
-                      None,
-                      Some("Qux"),
-                      None
-                    ),
-                    true,
-                    None
-                  )
-                ),
-                None,
-                None,
-                None,
-                None
-              )
-            ),
-            None,
-            None,
-            None
-          ),
-          "Quux" -> Schema.AllOf(
-            List(
-              Schema.Reference("Foo", None, None, None, None),
-              Schema.Object(
-                List(
-                  Schema.Property(
-                    "type",
-                    Schema.Enum(
-                      Schema.simpleString,
-                      List("Quux"),
-                      None,
-                      Some("Quux"),
-                      None
-                    ),
-                    true,
-                    None
-                  ),
-                  Schema.Property("b", Schema.simpleInteger, true, None)
-                ),
-                None,
-                None,
-                None,
-                None
-              )
-            ),
-            None,
-            None,
-            None
+                "b" -> ujson.Obj(
+                  "type" -> ujson.Str("integer")
+                )
+              ),
+              "required" -> ujson.Arr(ujson.Str("type"), ujson.Str("b"))
+            )
           )
         )
-      ),
-      None,
-      None,
-      None
+      )
     )
     assert(
-      OneOfWithBaseRefStrategyDocs.api.components
-        .schemas("Foo") == expectedSchema
+      OpenApi.schemaJson(
+        OneOfWithBaseRefStrategyDocs.api.components.schemas("Foo")
+      ) == expectedJsonSchema
     )
   }
 }

--- a/openapi/openapi/src/test/scala/endpoints/openapi/CoproductEncodingTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/CoproductEncodingTest.scala
@@ -37,8 +37,7 @@ class CoproductEncodingTest extends AnyFreeSpec {
   "OneOf schema encoding" in {
     val expectedJsonSchema = ujson.Obj(
       "discriminator" -> ujson.Obj(
-        "propertyName" -> ujson.Str("type"),
-        "mapping" -> ujson.Obj()
+        "propertyName" -> ujson.Str("type")
       ),
       "oneOf" -> ujson.Arr(
         ujson.Obj(
@@ -116,8 +115,7 @@ class CoproductEncodingTest extends AnyFreeSpec {
   "OneOfWithBaseRef schema encoding" in {
     val expectedJsonSchema = ujson.Obj(
       "discriminator" -> ujson.Obj(
-        "propertyName" -> ujson.Str("type"),
-        "mapping" -> ujson.Obj() // TODO
+        "propertyName" -> ujson.Str("type")
       ),
       "oneOf" -> ujson.Arr(
         ujson.Obj(

--- a/openapi/openapi/src/test/scala/endpoints/openapi/CoproductEncodingTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/CoproductEncodingTest.scala
@@ -1,0 +1,324 @@
+package endpoints.openapi
+
+import endpoints.algebra
+import endpoints.openapi.model._
+import org.scalatest.freespec.AnyFreeSpec
+
+class CoproductEncodingTest extends AnyFreeSpec {
+
+  trait CoproductEncodingAlg
+      extends algebra.Endpoints
+      with algebra.JsonEntitiesFromSchemas
+      with algebra.JsonSchemasFixtures {
+
+    implicit val fooSchema = Foo.schema.named("Foo")
+
+    val foo = endpoint(get(path / "foo"), ok(jsonResponse[Foo]))
+  }
+
+  object OneOfStrategyDocs
+      extends CoproductEncodingAlg
+      with Endpoints
+      with JsonEntitiesFromSchemas {
+
+    override def coproductEncoding = CoproductEncoding.OneOf
+    val api = openApi(Info("OneOf", "1"))(foo)
+  }
+
+  object OneOfWithBaseRefStrategyDocs
+      extends CoproductEncodingAlg
+      with Endpoints
+      with JsonEntitiesFromSchemas {
+
+    override def coproductEncoding = CoproductEncoding.OneOfWithBaseRef
+    val api = openApi(Info("OneOf", "1"))(foo)
+  }
+
+  "OneOf schema encoding" in {
+    val expectedSchema = Schema.OneOf(
+      Schema.DiscriminatedAlternatives(
+        "type",
+        List(
+          "Bar" -> Schema.Object(
+            List(
+              Schema.Property(
+                "type",
+                Schema.Enum(
+                  Schema.simpleString,
+                  List("Bar"),
+                  None,
+                  Some("Bar"),
+                  None
+                ),
+                true,
+                None
+              ),
+              Schema.Property("s", Schema.simpleString, true, None)
+            ),
+            None,
+            None,
+            None,
+            None
+          ),
+          "Baz" -> Schema.Object(
+            List(
+              Schema.Property(
+                "type",
+                Schema.Enum(
+                  Schema.simpleString,
+                  List("Baz"),
+                  None,
+                  Some("Baz"),
+                  None
+                ),
+                true,
+                None
+              ),
+              Schema.Property(
+                "i",
+                Schema.Primitive("integer", Some("int32"), None, None, None),
+                true,
+                None
+              )
+            ),
+            None,
+            None,
+            None,
+            None
+          ),
+          "Bax" -> Schema.Object(
+            List(
+              Schema.Property(
+                "type",
+                Schema.Enum(
+                  Schema.simpleString,
+                  List("Bax"),
+                  None,
+                  Some("Bax"),
+                  None
+                ),
+                true,
+                None
+              )
+            ),
+            None,
+            None,
+            None,
+            None
+          ),
+          "Qux" -> Schema.Object(
+            List(
+              Schema.Property(
+                "type",
+                Schema.Enum(
+                  Schema.simpleString,
+                  List("Qux"),
+                  None,
+                  Some("Qux"),
+                  None
+                ),
+                true,
+                None
+              )
+            ),
+            None,
+            None,
+            None,
+            None
+          ),
+          "Quux" -> Schema.Object(
+            List(
+              Schema.Property(
+                "type",
+                Schema.Enum(
+                  Schema.simpleString,
+                  List("Quux"),
+                  None,
+                  Some("Quux"),
+                  None
+                ),
+                true,
+                None
+              ),
+              Schema.Property("b", Schema.simpleInteger, true, None)
+            ),
+            None,
+            None,
+            None,
+            None
+          )
+        )
+      ),
+      None,
+      None,
+      None
+    )
+    assert(OneOfStrategyDocs.api.components.schemas("Foo") == expectedSchema)
+  }
+
+  "OneOfWithBaseRef schema encoding" in {
+    val expectedSchema = Schema.OneOf(
+      Schema.DiscriminatedAlternatives(
+        "type",
+        List(
+          "Bar" -> Schema.AllOf(
+            List(
+              Schema.Reference("Foo", None, None, None, None),
+              Schema.Object(
+                List(
+                  Schema.Property(
+                    "type",
+                    Schema.Enum(
+                      Schema.simpleString,
+                      List("Bar"),
+                      None,
+                      Some("Bar"),
+                      None
+                    ),
+                    true,
+                    None
+                  ),
+                  Schema.Property("s", Schema.simpleString, true, None)
+                ),
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          ),
+          "Baz" -> Schema.AllOf(
+            List(
+              Schema.Reference("Foo", None, None, None, None),
+              Schema.Object(
+                List(
+                  Schema.Property(
+                    "type",
+                    Schema.Enum(
+                      Schema.simpleString,
+                      List("Baz"),
+                      None,
+                      Some("Baz"),
+                      None
+                    ),
+                    true,
+                    None
+                  ),
+                  Schema.Property(
+                    "i",
+                    Schema
+                      .Primitive("integer", Some("int32"), None, None, None),
+                    true,
+                    None
+                  )
+                ),
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          ),
+          "Bax" -> Schema.AllOf(
+            List(
+              Schema.Reference("Foo", None, None, None, None),
+              Schema.Object(
+                List(
+                  Schema.Property(
+                    "type",
+                    Schema.Enum(
+                      Schema.simpleString,
+                      List("Bax"),
+                      None,
+                      Some("Bax"),
+                      None
+                    ),
+                    true,
+                    None
+                  )
+                ),
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          ),
+          "Qux" -> Schema.AllOf(
+            List(
+              Schema.Reference("Foo", None, None, None, None),
+              Schema.Object(
+                List(
+                  Schema.Property(
+                    "type",
+                    Schema.Enum(
+                      Schema.simpleString,
+                      List("Qux"),
+                      None,
+                      Some("Qux"),
+                      None
+                    ),
+                    true,
+                    None
+                  )
+                ),
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          ),
+          "Quux" -> Schema.AllOf(
+            List(
+              Schema.Reference("Foo", None, None, None, None),
+              Schema.Object(
+                List(
+                  Schema.Property(
+                    "type",
+                    Schema.Enum(
+                      Schema.simpleString,
+                      List("Quux"),
+                      None,
+                      Some("Quux"),
+                      None
+                    ),
+                    true,
+                    None
+                  ),
+                  Schema.Property("b", Schema.simpleInteger, true, None)
+                ),
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          )
+        )
+      ),
+      None,
+      None,
+      None
+    )
+    assert(
+      OneOfWithBaseRefStrategyDocs.api.components
+        .schemas("Foo") == expectedSchema
+    )
+  }
+}

--- a/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/ReferencedSchemaTest.scala
@@ -188,27 +188,20 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |        "enum" : ["Red", "Blue"]
         |      },
         |      "endpoints.openapi.ReferencedSchemaTest.Storage.Online" : {
-        |        "allOf" : [
-        |          {
-        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
+        |        "type" : "object",
+        |        "properties" : {
+        |          "storageType" : {
+        |            "type" : "string",
+        |            "enum" : ["Online"],
+        |            "example" : "Online"
         |          },
-        |          {
-        |            "type" : "object",
-        |            "properties" : {
-        |              "storageType" : {
-        |                "type" : "string",
-        |                "enum" : ["Online"],
-        |                "example" : "Online"
-        |              },
-        |              "link" : {
-        |                "type" : "string"
-        |              }
-        |            },
-        |            "required" : [
-        |              "storageType",
-        |              "link"
-        |            ]
+        |          "link" : {
+        |            "type" : "string"
         |          }
+        |        },
+        |        "required" : [
+        |          "storageType",
+        |          "link"
         |        ]
         |      },
         |      "endpoints.openapi.ReferencedSchemaTest.Book" : {
@@ -275,32 +268,25 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |        }
         |      },
         |      "endpoints.openapi.ReferencedSchemaTest.Storage.Library" : {
-        |        "allOf" : [
-        |          {
-        |            "$ref" : "#/components/schemas/endpoints.openapi.ReferencedSchemaTest.Storage"
+        |        "type" : "object",
+        |        "properties" : {
+        |          "storageType" : {
+        |            "type" : "string",
+        |            "enum" : ["Library"],
+        |            "example" : "Library"
         |          },
-        |          {
-        |            "type" : "object",
-        |            "properties" : {
-        |              "storageType" : {
-        |                "type" : "string",
-        |                "enum" : ["Library"],
-        |                "example" : "Library"
-        |              },
-        |              "room" : {
-        |                "type" : "string"
-        |              },
-        |              "shelf" : {
-        |                "type" : "integer",
-        |                "format" : "int32"
-        |              }
-        |            },
-        |            "required" : [
-        |              "storageType",
-        |              "room",
-        |              "shelf"
-        |            ]
+        |          "room" : {
+        |            "type" : "string"
+        |          },
+        |          "shelf" : {
+        |            "type" : "integer",
+        |            "format" : "int32"
         |          }
+        |        },
+        |        "required" : [
+        |          "storageType",
+        |          "room",
+        |          "shelf"
         |        ]
         |      }
         |    },


### PR DESCRIPTION
Introduces an overrideable setting in `openapi.JsonSchemas` for
configuring the encoding of OpenAPI schemas for coproducts. The
two options that are supported are:

  1. use `oneOf` in the base type to refer to all of the variants

  2. in addition to using `oneOf` in the base type to refer to all of
     the variants, the variants refer back to the base type with `allOf`

Alternative 1 leads to simpler schemas, but alternative 2 allows users
to work around some OpenAPI code generators' buggy handling of `oneOf`.
See the discussion in #135 for more on the tradeoffs.

Fixes #503