### PR TITLE
WIP: Improve annotation-driven generic derivation

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -286,15 +286,60 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     Record(encoder, decoder)
   }
 
+  def withExampleRecord[A](
+      schema: Record[A],
+      example: A
+  ): Record[A] = schema
+
+  def withExampleTagged[A](
+      schema: Tagged[A],
+      example: A
+  ): Tagged[A] = schema
+
+  def withExampleEnum[A](
+      schema: Enum[A],
+      example: A
+  ): Enum[A] = schema
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionRecord[A](
+      schema: Record[A],
+      description: String
+  ): Record[A] = schema
+
+  def withDescriptionTagged[A](
+      schema: Tagged[A],
+      description: String
+  ): Tagged[A] = schema
+
+  def withDescriptionEnum[A](
+      schema: Enum[A],
+      description: String
+  ): Enum[A] = schema
+
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](
+      schema: Record[A],
+      title: String
+  ): Record[A] = schema
+
+  def withTitleTagged[A](
+      schema: Tagged[A],
+      title: String
+  ): Tagged[A] = schema
+
+  def withTitleEnum[A](
+      schema: Enum[A],
+      title: String
+  ): Enum[A] = schema
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -6,9 +6,19 @@ package endpoints.generic
   * Annotate a case class field, case class, or selaed trait with this
   * annotation to define its documentation.
   *
-  * @param text Description of the annotated field
+  * @param text Description of the annotated field or schema
   */
 case class docs(text: String) extends scala.annotation.Annotation
+
+/**
+  * Defines the title of a generic schema.
+  *
+  * Annotate a sealed trait or case class definition with this annotation
+  * to define its schema title.
+  *
+  * @param text Title of the schema
+  */
+case class title(value: String) extends scala.annotation.Annotation
 
 /**
   * Defines the name of a generic schema.
@@ -19,6 +29,15 @@ case class docs(text: String) extends scala.annotation.Annotation
   * @param value Name of the schema
   */
 case class name(value: String) extends scala.annotation.Annotation
+
+/**
+  * Specifies that a generic schema should not have a name.
+  *
+  * Annotate a sealed trait or case class definition with this annotation to
+  * prevent the schema from being named. This is sometimes useful for forcing
+  * nested schemas to be inlined in OpenAPI documentation.
+  */
+case class unnamed() extends scala.annotation.Annotation
 
 /**
   * Defines the name of the discriminator field of a generic tagged schema.

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -1,10 +1,10 @@
 package endpoints.generic
 
 /**
-  * Documents a case class field.
+  * Documents a case class field, case class, or sealed trait.
   *
-  * Annotate a case class field with this annotation to define its
-  * documentation.
+  * Annotate a case class field, case class, or selaed trait with this
+  * annotation to define its documentation.
   *
   * @param text Description of the annotated field
   */

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -106,16 +106,61 @@ class JsonSchemasTest extends AnyFreeSpec {
     ): String =
       s"$recordA,$recordB"
 
+    def withExampleRecord[A](
+        schema: Record[A],
+        example: A
+    ): Record[A] = schema
+
+    def withExampleTagged[A](
+        schema: Tagged[A],
+        example: A
+    ): Tagged[A] = schema
+
+    def withExampleEnum[A](
+        schema: Enum[A],
+        example: A
+    ): Enum[A] = schema
+
     def withExampleJsonSchema[A](
         schema: JsonSchema[A],
         example: A
     ): JsonSchema[A] =
       schema
 
+    def withDescriptionRecord[A](
+        schema: Record[A],
+        description: String
+    ): Record[A] = schema
+
+    def withDescriptionTagged[A](
+        schema: Tagged[A],
+        description: String
+    ): Tagged[A] = schema
+
+    def withDescriptionEnum[A](
+        schema: Enum[A],
+        description: String
+    ): Enum[A] = schema
+
     def withDescriptionJsonSchema[A](
         schema: JsonSchema[A],
         description: String
     ): JsonSchema[A] = schema
+
+    def withTitleRecord[A](
+        schema: Record[A],
+        title: String
+    ): Record[A] = schema
+
+    def withTitleTagged[A](
+        schema: Tagged[A],
+        title: String
+    ): Tagged[A] = schema
+
+    def withTitleEnum[A](
+        schema: Enum[A],
+        title: String
+    ): Enum[A] = schema
 
     def withTitleJsonSchema[A](
         schema: JsonSchema[A],

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -157,15 +157,60 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       (__ \ name).writeNullable(tpe.writes)
     )
 
+  def withExampleRecord[A](
+      schema: Record[A],
+      example: A
+  ): Record[A] = schema
+
+  def withExampleTagged[A](
+      schema: Tagged[A],
+      example: A
+  ): Tagged[A] = schema
+
+  def withExampleEnum[A](
+      schema: Enum[A],
+      example: A
+  ): Enum[A] = schema
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionRecord[A](
+      schema: Record[A],
+      description: String
+  ): Record[A] = schema
+
+  def withDescriptionTagged[A](
+      schema: Tagged[A],
+      description: String
+  ): Tagged[A] = schema
+
+  def withDescriptionEnum[A](
+      schema: Enum[A],
+      description: String
+  ): Enum[A] = schema
+
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](
+      schema: Record[A],
+      title: String
+  ): Record[A] = schema
+
+  def withTitleTagged[A](
+      schema: Tagged[A],
+      title: String
+  ): Tagged[A] = schema
+
+  def withTitleEnum[A](
+      schema: Enum[A],
+      title: String
+  ): Enum[A] = schema
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -195,7 +195,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Annotates the tagged JSON schema with a name */
   def namedTagged[A](schema: Tagged[A], name: String): Tagged[A]
 
-  /** Annotates the tagged JSON schema with a name */
+  /** Annotates the enum JSON schema with a name */
   def namedEnum[A](schema: Enum[A], name: String): Enum[A]
 
   /**
@@ -285,14 +285,41 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       implicit t: Tupler[A, B]
   ): Record[t.Out]
 
-  /** Include an example value within the given schema */
+  /** Include an example value within the given record JSON schema */
+  def withExampleRecord[A](record: Record[A], example: A): Record[A]
+
+  /** Include an example value within the given tagged JSON schema */
+  def withExampleTagged[A](tagged: Tagged[A], example: A): Tagged[A]
+
+  /** Include an example value within the given enum JSON schema */
+  def withExampleEnum[A](enum: Enum[A], example: A): Enum[A]
+
+  /** Include an example value within the given JSON schema */
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A]
 
-  /** Add a description to the given schema */
+  /** Add a description to the given record JSON schema */
+  def withDescriptionRecord[A](record: Record[A], description: String): Record[A]
+
+  /** Add a description to the given tagged JSON schema */
+  def withDescriptionTagged[A](tagged: Tagged[A], description: String): Tagged[A]
+
+  /** Add a description to the given enum JSON schema */
+  def withDescriptionEnum[A](enum: Enum[A], description: String): Enum[A]
+
+  /** Add a description to the given JSON schema */
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A]
+
+  /** Add a title to the given record JSON schema */
+  def withTitleRecord[A](record: Record[A], title: String): Record[A]
+
+  /** Add a title to the given tagged JSON schema */
+  def withTitleTagged[A](tagged: Tagged[A], title: String): Tagged[A]
+
+  /** Add a title to the given enum JSON schema */
+  def withTitleEnum[A](enum: Enum[A], title: String): Enum[A]
 
   /** Add a title to the given schema */
   def withTitleJsonSchema[A](
@@ -323,34 +350,52 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   ): JsonSchema[Either[A, B]]
 
   /**
-    * Implicit methods for values of type [[JsonSchema]]
-    * @group operations
+    * Documentation related methods for annotating schemas. Encoder and decoder
+    * interpreters ignore this information.
     */
-  final implicit class JsonSchemaOps[A](schemaA: JsonSchema[A]) {
+  sealed trait DocOps[A] {
+    type Repr[X] <: JsonSchema[X]
 
     /**
       * Include an example of value in this schema. Documentation interpreters
       * can show this example value. Encoder and decoder interpreters ignore
       * this value.
+      *
       * @param example Example value to attach to the schema
       */
-    def withExample(example: A): JsonSchema[A] =
-      withExampleJsonSchema(schemaA, example)
+    def withExample(example: A): Repr[A]
 
     /**
       * Include a description of what this schema represents. Documentation
       * interpreters can show this description. Encoder and decoder interpreters
       * ignore this description.
+      *
       * @param description information about the values described by the schema
       */
-    def withDescription(description: String): JsonSchema[A] =
-      withDescriptionJsonSchema(schemaA, description)
+    def withDescription(description: String): Repr[A]
 
     /**
       * Include a title for the schema. Documentation interpreters can show
       * this title. Encoder and decoder interpreters ignore the title.
+      *
       * @param title short title to attach to the schema
       */
+    def withTitle(title: String): Repr[A]
+  }
+
+  /**
+    * Implicit methods for values of type [[JsonSchema]]
+    * @group operations
+    */
+  final implicit class JsonSchemaOps[A](schemaA: JsonSchema[A]) extends DocOps[A] {
+    type Repr[X] = JsonSchema[X]
+
+    def withExample(example: A): JsonSchema[A] =
+      withExampleJsonSchema(schemaA, example)
+
+    def withDescription(description: String): JsonSchema[A] =
+      withDescriptionJsonSchema(schemaA, description)
+
     def withTitle(title: String): JsonSchema[A] =
       withTitleJsonSchema(schemaA, title)
 
@@ -379,7 +424,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Implicit methods for values of type [[Record]]
     * @group operations
     */
-  final implicit class RecordOps[A](recordA: Record[A]) {
+  final implicit class RecordOps[A](recordA: Record[A]) extends DocOps[A] {
+    type Repr[X] = Record[X]
 
     /** Merge the fields of `recordA` with the fields of `recordB` */
     def zip[B](recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out] =
@@ -398,10 +444,21 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       *       to override the heading displayed in documentation.
       */
     def named(name: String): Record[A] = namedRecord(recordA, name)
+
+    def withExample(example: A): Record[A] =
+      withExampleRecord(recordA, example)
+
+    def withDescription(description: String): Record[A] =
+      withDescriptionRecord(recordA, description)
+
+    def withTitle(title: String): Record[A] =
+      withTitleRecord(recordA, title)
   }
 
   /** @group operations */
-  final implicit class TaggedOps[A](taggedA: Tagged[A]) {
+  final implicit class TaggedOps[A](taggedA: Tagged[A]) extends DocOps[A] {
+    type Repr[X] = Tagged[X]
+
     def orElse[B](taggedB: Tagged[B]): Tagged[Either[A, B]] =
       choiceTagged(taggedA, taggedB)
 
@@ -422,10 +479,20 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       */
     def withDiscriminator(name: String): Tagged[A] =
       withDiscriminatorTagged(taggedA, name)
+
+    def withExample(example: A): Tagged[A] =
+      withExampleTagged(taggedA, example)
+
+    def withDescription(description: String): Tagged[A] =
+      withDescriptionTagged(taggedA, description)
+
+    def withTitle(title: String): Tagged[A] =
+      withTitleTagged(taggedA, title)
   }
 
   /** @group operations */
-  final implicit class EnumOps[A](enumA: Enum[A]) {
+  final implicit class EnumOps[A](enumA: Enum[A]) extends DocOps[A] {
+    type Repr[X] = Enum[X]
 
     /**
       * Give a name to the schema.
@@ -438,6 +505,15 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       *       to override the heading displayed in documentation.
       */
     def named(name: String): Enum[A] = namedEnum(enumA, name)
+
+    def withExample(example: A): Enum[A] =
+      withExampleEnum(enumA, example)
+
+    def withDescription(description: String): Enum[A] =
+      withDescriptionEnum(enumA, description)
+
+    def withTitle(title: String): Enum[A] =
+      withTitleEnum(enumA, title)
   }
 
   /** A JSON schema for type `UUID`

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -268,6 +268,39 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       DocumentedRecord(recordA.docs.fields ++ recordB.docs.fields)
     )
 
+  def withExampleRecord[A](
+      record: Record[A],
+      example: A
+  ): Record[A] = {
+    val exampleJson = record.ujsonSchema.codec.encode(example)
+    new Record[A](
+      record.ujsonSchema,
+      record.docs.copy(example = Some(exampleJson))
+    )
+  }
+
+  def withExampleTagged[A](
+      tagged: Tagged[A],
+      example: A
+  ): Tagged[A] = {
+    val exampleJson = tagged.ujsonSchema.codec.encode(example)
+    new Tagged[A](
+      tagged.ujsonSchema,
+      tagged.docs.copy(example = Some(exampleJson))
+    )
+  }
+
+  def withExampleEnum[A](
+      enum: Enum[A],
+      example: A
+  ): Enum[A] = {
+    val exampleJson = enum.ujsonSchema.codec.encode(example)
+    new Enum[A](
+      enum.ujsonSchema,
+      enum.docs.copy(example = Some(exampleJson))
+    )
+  }
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
@@ -289,6 +322,33 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     )
   }
 
+  def withTitleRecord[A](
+      record: Record[A],
+      title: String
+  ): Record[A] =
+    new Record[A](
+      record.ujsonSchema,
+      record.docs.copy(title = Some(title))
+    )
+
+  def withTitleTagged[A](
+      tagged: Tagged[A],
+      title: String
+  ): Tagged[A] =
+    new Tagged[A](
+      tagged.ujsonSchema,
+      tagged.docs.copy(title = Some(title))
+    )
+
+  def withTitleEnum[A](
+      enum: Enum[A],
+      title: String
+  ): Enum[A] =
+    new Enum[A](
+      enum.ujsonSchema,
+      enum.docs.copy(title = Some(title))
+    )
+
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],
       title: String
@@ -308,6 +368,33 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       updatedDocs(schema.docs)
     )
   }
+
+  def withDescriptionRecord[A](
+      record: Record[A],
+      description: String
+  ): Record[A] =
+    new Record[A](
+      record.ujsonSchema,
+      record.docs.copy(description = Some(description))
+    )
+
+  def withDescriptionTagged[A](
+      tagged: Tagged[A],
+      description: String
+  ): Tagged[A] =
+    new Tagged[A](
+      tagged.ujsonSchema,
+      tagged.docs.copy(description = Some(description))
+    )
+
+  def withDescriptionEnum[A](
+      enum: Enum[A],
+      description: String
+  ): Enum[A] =
+    new Enum[A](
+      enum.ujsonSchema,
+      enum.docs.copy(description = Some(description))
+    )
 
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -238,15 +238,60 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       }
     }
 
+  def withExampleRecord[A](
+      schema: Record[A],
+      example: A
+  ): Record[A] = schema
+
+  def withExampleTagged[A](
+      schema: Tagged[A],
+      example: A
+  ): Tagged[A] = schema
+
+  def withExampleEnum[A](
+      schema: Enum[A],
+      example: A
+  ): Enum[A] = schema
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionRecord[A](
+      schema: Record[A],
+      description: String
+  ): Record[A] = schema
+
+  def withDescriptionTagged[A](
+      schema: Tagged[A],
+      description: String
+  ): Tagged[A] = schema
+
+  def withDescriptionEnum[A](
+      schema: Enum[A],
+      description: String
+  ): Enum[A] = schema
+
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](
+      schema: Record[A],
+      title: String
+  ): Record[A] = schema
+
+  def withTitleTagged[A](
+      schema: Tagged[A],
+      title: String
+  ): Tagged[A] = schema
+
+  def withTitleEnum[A](
+      schema: Enum[A],
+      title: String
+  ): Enum[A] = schema
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],


### PR DESCRIPTION
The end goal of this PR is to support generating schemas from annotated types like the following:

```scala
@docs("a hard or fluffy pet")
@name("Pet")
sealed trait Pet

@docs("felines")
@unnamed
case class Cat(
  @docs("the cat's name") name: String
) extends Pet

@name("Lizard")
@title("A lizard")
@docs("these pets often rest on shoulders")
case class Lizard(
  lovesRocks: Boolean
) extends Pet
```

This involved:

  * extending `withDescriptionJsonSchema`, `withTitleJsonSchema`, and `withExampleJsonSchema` to have variants operating specifically on `Record`, `Tagged`, and `Enum`

  * tweaking generic derivation to allow the `docs` annotation on classes and traits

  * tweaking generic derivation to make the name optional. Although the default is still to generate a name based on the class tag, there is now an `unnamed` annotation that can be used to prevent a schema from being named.

  * adding a `title` annotation, which is used to set the title of schemas for classes or traits

Fixes #501.
Fixes #505.