### PR TITLE
OpenAPI: add `description` to an operations JSON

### DIFF
--- a/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/model/OpenApi.scala
@@ -171,6 +171,9 @@ object OpenApi {
     operation.summary.foreach { summary =>
       fields += "summary" -> ujson.Str(summary)
     }
+    operation.description.foreach { description =>
+      fields += "description" -> ujson.Str(description)
+    }
     if (operation.parameters.nonEmpty) {
       fields += "parameters" -> ujson.Arr(
         operation.parameters.map(parameterJson): _*

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -230,6 +230,19 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
     }
   }
 
+  "Descriptions and summary documentation" should {
+    "be rendered according to provided docs" in {
+      import Fixtures.{openApi, documentedEndp}
+
+      val docs = openApi(Info("test", "0.0.0"))(documentedEndp)
+      val json = ujson.read(OpenApi.stringEncoder.encode(docs))
+      val documentedEndpJson = json("paths")("/documented")("get")
+
+      documentedEndpJson("summary") shouldBe ujson.Str("summary of endpoint")
+      documentedEndpJson("description") shouldBe ujson.Str("description of endpoint")
+    }
+  }
+
   "Fields order" in {
     import Fixtures.{
       emptyRecord,
@@ -337,6 +350,14 @@ trait Fixtures extends algebra.Endpoints with algebra.ChunkedEntities {
       ok(textResponse, headers = responseHeader("ETag", Some("version number")))
     )
 
+  val documentedEndp = endpoint(
+    request = get(path / "documented"),
+    response = ok(emptyResponse),
+    docs = EndpointDocs(
+      summary = Some("summary of endpoint"),
+      description = Some("description of endpoint")
+    )
+  )
 }
 
 object Fixtures


### PR DESCRIPTION
The `Operations` OpenAPI model class has a `description: Option[String]`
field which gets set, but was never rendered in the final JSON. Now it
is, and there is a test case to check that it is.

Fixes #508