### PR TITLE
Add `withExampleJsonSchema` for Record/Enum/Tagged

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -286,15 +286,60 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     Record(encoder, decoder)
   }
 
+  def withExampleRecord[A](
+      schema: Record[A],
+      example: A
+  ): Record[A] = schema
+
+  def withExampleTagged[A](
+      schema: Tagged[A],
+      example: A
+  ): Tagged[A] = schema
+
+  def withExampleEnum[A](
+      schema: Enum[A],
+      example: A
+  ): Enum[A] = schema
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionRecord[A](
+      schema: Record[A],
+      description: String
+  ): Record[A] = schema
+
+  def withDescriptionTagged[A](
+      schema: Tagged[A],
+      description: String
+  ): Tagged[A] = schema
+
+  def withDescriptionEnum[A](
+      schema: Enum[A],
+      description: String
+  ): Enum[A] = schema
+
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](
+      schema: Record[A],
+      title: String
+  ): Record[A] = schema
+
+  def withTitleTagged[A](
+      schema: Tagged[A],
+      title: String
+  ): Tagged[A] = schema
+
+  def withTitleEnum[A](
+      schema: Enum[A],
+      title: String
+  ): Enum[A] = schema
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -106,16 +106,61 @@ class JsonSchemasTest extends AnyFreeSpec {
     ): String =
       s"$recordA,$recordB"
 
+    def withExampleRecord[A](
+        schema: Record[A],
+        example: A
+    ): Record[A] = schema
+
+    def withExampleTagged[A](
+        schema: Tagged[A],
+        example: A
+    ): Tagged[A] = schema
+
+    def withExampleEnum[A](
+        schema: Enum[A],
+        example: A
+    ): Enum[A] = schema
+
     def withExampleJsonSchema[A](
         schema: JsonSchema[A],
         example: A
     ): JsonSchema[A] =
       schema
 
+    def withDescriptionRecord[A](
+        schema: Record[A],
+        description: String
+    ): Record[A] = schema
+
+    def withDescriptionTagged[A](
+        schema: Tagged[A],
+        description: String
+    ): Tagged[A] = schema
+
+    def withDescriptionEnum[A](
+        schema: Enum[A],
+        description: String
+    ): Enum[A] = schema
+
     def withDescriptionJsonSchema[A](
         schema: JsonSchema[A],
         description: String
     ): JsonSchema[A] = schema
+
+    def withTitleRecord[A](
+        schema: Record[A],
+        title: String
+    ): Record[A] = schema
+
+    def withTitleTagged[A](
+        schema: Tagged[A],
+        title: String
+    ): Tagged[A] = schema
+
+    def withTitleEnum[A](
+        schema: Enum[A],
+        title: String
+    ): Enum[A] = schema
 
     def withTitleJsonSchema[A](
         schema: JsonSchema[A],

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -157,15 +157,60 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       (__ \ name).writeNullable(tpe.writes)
     )
 
+  def withExampleRecord[A](
+      schema: Record[A],
+      example: A
+  ): Record[A] = schema
+
+  def withExampleTagged[A](
+      schema: Tagged[A],
+      example: A
+  ): Tagged[A] = schema
+
+  def withExampleEnum[A](
+      schema: Enum[A],
+      example: A
+  ): Enum[A] = schema
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionRecord[A](
+      schema: Record[A],
+      description: String
+  ): Record[A] = schema
+
+  def withDescriptionTagged[A](
+      schema: Tagged[A],
+      description: String
+  ): Tagged[A] = schema
+
+  def withDescriptionEnum[A](
+      schema: Enum[A],
+      description: String
+  ): Enum[A] = schema
+
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](
+      schema: Record[A],
+      title: String
+  ): Record[A] = schema
+
+  def withTitleTagged[A](
+      schema: Tagged[A],
+      title: String
+  ): Tagged[A] = schema
+
+  def withTitleEnum[A](
+      schema: Enum[A],
+      title: String
+  ): Enum[A] = schema
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -359,8 +359,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * Documentation related methods for annotating schemas. Encoder and decoder
     * interpreters ignore this information.
     */
-  sealed trait DocOps[A] {
-    type Repr[X] <: JsonSchema[X]
+  sealed trait JsonSchemaDocumentationOps[A] {
+    type Self <: JsonSchema[A]
 
     /**
       * Include an example of value in this schema. Documentation interpreters
@@ -369,7 +369,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       *
       * @param example Example value to attach to the schema
       */
-    def withExample(example: A): Repr[A]
+    def withExample(example: A): Self
 
     /**
       * Include a description of what this schema represents. Documentation
@@ -378,7 +378,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       *
       * @param description information about the values described by the schema
       */
-    def withDescription(description: String): Repr[A]
+    def withDescription(description: String): Self
 
     /**
       * Include a title for the schema. Documentation interpreters can show
@@ -386,7 +386,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       *
       * @param title short title to attach to the schema
       */
-    def withTitle(title: String): Repr[A]
+    def withTitle(title: String): Self
   }
 
   /**
@@ -394,8 +394,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @group operations
     */
   final implicit class JsonSchemaOps[A](schemaA: JsonSchema[A])
-      extends DocOps[A] {
-    type Repr[X] = JsonSchema[X]
+      extends JsonSchemaDocumentationOps[A] {
+    type Self = JsonSchema[A]
 
     def withExample(example: A): JsonSchema[A] =
       withExampleJsonSchema(schemaA, example)
@@ -431,8 +431,9 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Implicit methods for values of type [[Record]]
     * @group operations
     */
-  final implicit class RecordOps[A](recordA: Record[A]) extends DocOps[A] {
-    type Repr[X] = Record[X]
+  final implicit class RecordOps[A](recordA: Record[A])
+      extends JsonSchemaDocumentationOps[A] {
+    type Self = Record[A]
 
     /** Merge the fields of `recordA` with the fields of `recordB` */
     def zip[B](recordB: Record[B])(implicit t: Tupler[A, B]): Record[t.Out] =
@@ -463,8 +464,9 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   }
 
   /** @group operations */
-  final implicit class TaggedOps[A](taggedA: Tagged[A]) extends DocOps[A] {
-    type Repr[X] = Tagged[X]
+  final implicit class TaggedOps[A](taggedA: Tagged[A])
+      extends JsonSchemaDocumentationOps[A] {
+    type Self = Tagged[A]
 
     def orElse[B](taggedB: Tagged[B]): Tagged[Either[A, B]] =
       choiceTagged(taggedA, taggedB)
@@ -498,8 +500,9 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   }
 
   /** @group operations */
-  final implicit class EnumOps[A](enumA: Enum[A]) extends DocOps[A] {
-    type Repr[X] = Enum[X]
+  final implicit class EnumOps[A](enumA: Enum[A])
+      extends JsonSchemaDocumentationOps[A] {
+    type Self = Enum[A]
 
     /**
       * Give a name to the schema.

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -272,6 +272,39 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       DocumentedRecord(recordA.docs.fields ++ recordB.docs.fields)
     )
 
+  def withExampleRecord[A](
+      record: Record[A],
+      example: A
+  ): Record[A] = {
+    val exampleJson = record.ujsonSchema.codec.encode(example)
+    new Record[A](
+      record.ujsonSchema,
+      record.docs.copy(example = Some(exampleJson))
+    )
+  }
+
+  def withExampleTagged[A](
+      tagged: Tagged[A],
+      example: A
+  ): Tagged[A] = {
+    val exampleJson = tagged.ujsonSchema.codec.encode(example)
+    new Tagged[A](
+      tagged.ujsonSchema,
+      tagged.docs.copy(example = Some(exampleJson))
+    )
+  }
+
+  def withExampleEnum[A](
+      enum: Enum[A],
+      example: A
+  ): Enum[A] = {
+    val exampleJson = enum.ujsonSchema.codec.encode(example)
+    new Enum[A](
+      enum.ujsonSchema,
+      enum.docs.copy(example = Some(exampleJson))
+    )
+  }
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
@@ -293,6 +326,33 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     )
   }
 
+  def withTitleRecord[A](
+      record: Record[A],
+      title: String
+  ): Record[A] =
+    new Record[A](
+      record.ujsonSchema,
+      record.docs.copy(title = Some(title))
+    )
+
+  def withTitleTagged[A](
+      tagged: Tagged[A],
+      title: String
+  ): Tagged[A] =
+    new Tagged[A](
+      tagged.ujsonSchema,
+      tagged.docs.copy(title = Some(title))
+    )
+
+  def withTitleEnum[A](
+      enum: Enum[A],
+      title: String
+  ): Enum[A] =
+    new Enum[A](
+      enum.ujsonSchema,
+      enum.docs.copy(title = Some(title))
+    )
+
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],
       title: String
@@ -312,6 +372,33 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       updatedDocs(schema.docs)
     )
   }
+
+  def withDescriptionRecord[A](
+      record: Record[A],
+      description: String
+  ): Record[A] =
+    new Record[A](
+      record.ujsonSchema,
+      record.docs.copy(description = Some(description))
+    )
+
+  def withDescriptionTagged[A](
+      tagged: Tagged[A],
+      description: String
+  ): Tagged[A] =
+    new Tagged[A](
+      tagged.ujsonSchema,
+      tagged.docs.copy(description = Some(description))
+    )
+
+  def withDescriptionEnum[A](
+      enum: Enum[A],
+      description: String
+  ): Enum[A] =
+    new Enum[A](
+      enum.ujsonSchema,
+      enum.docs.copy(description = Some(description))
+    )
 
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -238,15 +238,60 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       }
     }
 
+  def withExampleRecord[A](
+      schema: Record[A],
+      example: A
+  ): Record[A] = schema
+
+  def withExampleTagged[A](
+      schema: Tagged[A],
+      example: A
+  ): Tagged[A] = schema
+
+  def withExampleEnum[A](
+      schema: Enum[A],
+      example: A
+  ): Enum[A] = schema
+
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
       example: A
   ): JsonSchema[A] = schema
 
+  def withDescriptionRecord[A](
+      schema: Record[A],
+      description: String
+  ): Record[A] = schema
+
+  def withDescriptionTagged[A](
+      schema: Tagged[A],
+      description: String
+  ): Tagged[A] = schema
+
+  def withDescriptionEnum[A](
+      schema: Enum[A],
+      description: String
+  ): Enum[A] = schema
+
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
       description: String
   ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](
+      schema: Record[A],
+      title: String
+  ): Record[A] = schema
+
+  def withTitleTagged[A](
+      schema: Tagged[A],
+      title: String
+  ): Tagged[A] = schema
+
+  def withTitleEnum[A](
+      schema: Enum[A],
+      title: String
+  ): Enum[A] = schema
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],


### PR DESCRIPTION
Add 9 more methods to `algebra.JsonSchemas`, providing variants of
`withDescription`, `withExample`, and `withTitle` specifically for
`Record`, `Tagged`, and `Enum`. Also added matching implicit methods
on the ops classes.

Fixes #505