### PR TITLE
`docs` annotation works on classes/traits

### DIFF
--- a/documentation/manual/src/paradox/algebras/json-schemas.md
+++ b/documentation/manual/src/paradox/algebras/json-schemas.md
@@ -221,8 +221,8 @@ type. The rules for deriving the schema are the following:
   type has a `width` required property of type `integer`),
 - each case class field of type `Option[A]` for some type `A` has a corresponding
   optional JSON object property of the same name and type,
-- documentation specific to case class fields can be defined by annotating the fields
-  with the `@docs` annotation,
+- descriptions can be set for case class fields, case classes, or sealed traits
+  by annotating these things with the `@docs` annotation,
 - for sealed traits, the discriminator field name can be defined by the `@discriminator`
   annotation, otherwise the `defaultDiscriminatorName` value is used,
 - the schema is named by the `@name` annotation, if present, or by invoking the

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/JsonSchemas.scala
@@ -71,7 +71,8 @@ trait JsonSchemas extends algebra.JsonSchemas {
   object GenericJsonSchema
       extends GenericJsonSchemaLowPriority
       with GenericDiscriminatorNames
-      with GenericSchemaNames {
+      with GenericSchemaNames
+      with GenericDescriptions {
 
     implicit def emptyRecordCase: DocumentedGenericRecord[HNil, HNil] =
       (docs: HNil) => emptyRecord.xmap[HNil](_ => HNil)(_ => ())
@@ -178,28 +179,34 @@ trait JsonSchemas extends algebra.JsonSchemas {
     implicit def recordGeneric[A, R, D <: HList](
         implicit
         gen: LabelledGeneric.Aux[A, R],
+        docOpt: GenericDescription[A],
         docAnns: Annotations.Aux[docs, A, D],
         record: DocumentedGenericRecord[R, D],
         name: GenericSchemaName[A]
-    ): GenericRecord[A] =
-      new GenericRecord[A](
-        record.record(docAnns()).xmap[A](gen.from)(gen.to).named(name.value)
-      )
+    ): GenericRecord[A] = {
+      val recordA = record
+        .record(docAnns())
+        .xmap[A](gen.from)(gen.to)
+        .named(name.value)
+      val docA = docOpt.description.fold(recordA)(recordA.withDescription(_))
+      new GenericRecord[A](docA)
+    }
 
     implicit def taggedGeneric[A, R](
         implicit
         gen: LabelledGeneric.Aux[A, R],
+        docOpt: GenericDescription[A],
         tagged: GenericTagged[R],
         name: GenericSchemaName[A],
         discriminator: GenericDiscriminatorName[A]
-    ): GenericTagged[A] =
-      new GenericTagged[A](
-        tagged.jsonSchema
-          .xmap[A](gen.from)(gen.to)
-          .named(name.value)
-          .withDiscriminator(discriminator.name)
-      )
-
+    ): GenericTagged[A] = {
+      val taggedA = tagged.jsonSchema
+        .xmap[A](gen.from)(gen.to)
+        .named(name.value)
+        .withDiscriminator(discriminator.name)
+      val docA = docOpt.description.fold(taggedA)(taggedA.withDescription(_))
+      new GenericTagged[A](docA)
+    }
   }
 
   /** Internal machinery for deriving the discriminator name of a type */
@@ -241,6 +248,24 @@ trait JsonSchemas extends algebra.JsonSchemas {
         new GenericSchemaName(classTagToSchemaName(ct))
     }
 
+  }
+
+  /** Internal machinery for extracting a description of a type */
+  trait GenericDescriptions {
+
+    class GenericDescription[A](val description: Option[String])
+
+    object GenericDescription extends GenericDescriptionLowPriority {
+      implicit def annotated[A](
+          implicit ann: Annotation[docs, A]
+      ): GenericDescription[A] =
+        new GenericDescription(Some(ann().text))
+    }
+
+    trait GenericDescriptionLowPriority {
+      implicit def noDescription[A]: GenericDescription[A] =
+        new GenericDescription[A](None)
+    }
   }
 
   /**

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -1,12 +1,12 @@
 package endpoints.generic
 
 /**
-  * Documents a case class field.
+  * Adds a description to a case class field, a case class, or a sealed trait.
   *
-  * Annotate a case class field with this annotation to define its
-  * documentation.
+  * Annotate a case class field, case class, or sealed trait with this
+  * annotation to define its the description of the schema or record field.
   *
-  * @param text Description of the annotated field
+  * @param text Description of the annotated schema or field
   */
 case class docs(text: String) extends scala.annotation.Annotation
 

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -4,7 +4,7 @@ package endpoints.generic
   * Adds a description to a case class field, a case class, or a sealed trait.
   *
   * Annotate a case class field, case class, or sealed trait with this
-  * annotation to define its the description of the schema or record field.
+  * annotation to set a description for the schema or the record field.
   *
   * @param text Description of the annotated schema or field
   */

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
@@ -29,6 +29,7 @@ trait JsonSchemasDocs extends JsonSchemas {
     case class Circle(radius: Double) extends Shape
 
     @name("RectangleSchema")
+    @docs("A quadrilateral with four right angles")
     case class Rectangle(
         @docs("Rectangle width") width: Double,
         height: Double

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -27,7 +27,9 @@ class JsonSchemasTest extends AnyFreeSpec {
 
     @discriminator("$type")
     @name("DocResource")
+    @docs("traitDoc")
     sealed trait Doc
+    @docs("recordDocA")
     case class DocA(@docs("fieldDocI") i: Int) extends Doc
     case class DocB(
         a: String,
@@ -35,6 +37,7 @@ class JsonSchemasTest extends AnyFreeSpec {
         @docs("fieldDocSS") ss: List[String]
     ) extends Doc
     @name("DocC")
+    @docs("recordDocC")
     case object DocC extends Doc
 
     object Doc {
@@ -130,22 +133,22 @@ class JsonSchemasTest extends AnyFreeSpec {
     def withDescriptionRecord[A](
         schema: Record[A],
         description: String
-    ): Record[A] = schema
+    ): String = s"$schema{$description}"
 
     def withDescriptionTagged[A](
         schema: Tagged[A],
         description: String
-    ): Tagged[A] = schema
+    ): String = s"$schema{$description}"
 
     def withDescriptionEnum[A](
         schema: Enum[A],
         description: String
-    ): Enum[A] = schema
+    ): String = s"$schema{$description}"
 
     def withDescriptionJsonSchema[A](
         schema: JsonSchema[A],
         description: String
-    ): JsonSchema[A] = schema
+    ): String = s"$schema{$description}"
 
     def withTitleRecord[A](
         schema: Record[A],
@@ -249,10 +252,10 @@ class JsonSchemasTest extends AnyFreeSpec {
 
   "documentations" in {
     val expectedSchema = s"'DocResource'!(${List(
-      s"'$ns.DocA'!(i:integer{fieldDocI},%)@DocA",
+      s"'$ns.DocA'!(i:integer{fieldDocI},%){recordDocA}@DocA",
       s"'$ns.DocB'!(a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%)@DocB",
-      s"'DocC'!(%)@DocC"
-    ).mkString("|")})#$$type"
+      s"'DocC'!(%){recordDocC}@DocC"
+    ).mkString("|")})#$$type{traitDoc}"
     assert(FakeAlgebraJsonSchemas.Doc.schema == expectedSchema)
   }
 


### PR DESCRIPTION
The `docs` annotation will now work on classes and traits as well as
fields. When specified, it will set the description of the matching
schema.

Also tweaked the `generic.JsonSchemas` test case to check the new
annotation locations too.