### PR TITLE
Add `title` annotation

### DIFF
--- a/documentation/manual/src/paradox/algebras/json-schemas.md
+++ b/documentation/manual/src/paradox/algebras/json-schemas.md
@@ -228,6 +228,7 @@ type. The rules for deriving the schema are the following:
 - the schema is named by the `@name` annotation, if present, or by invoking the
   `classTagToSchemaName` operation with the `ClassTag` of the type for which the schema
   is derived.
+- the schema title is set with the `@title` annotation, if present
 
 Here is an example that illustrates how to configure the generic schema derivation process:
 

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -11,10 +11,29 @@ package endpoints.generic
 case class docs(text: String) extends scala.annotation.Annotation
 
 /**
+  * Defines the title of a generic schema.
+  *
+  * Annotate a sealed trait or case class definition with this annotation
+  * to define its schema title.
+  *
+  * @param text Title of the schema
+  */
+case class title(value: String) extends scala.annotation.Annotation
+
+/**
   * Defines the name of a generic schema.
   *
   * Annotate a sealed trait or case class definition with this annotation
-  * to define its schema name.
+  * to define its schema name. Setting the name of a schema explicitly means
+  * that you can control exactly what the URI of the JSON schema will be in the
+  * OpenAPI documentation.
+  *
+  * @note The name of the schema is used internally by OpenAPI in the URI that
+  *       gets used to refer to the schema. Consequently, the name set here
+  *       should include only characters allowed in URIs.
+  *
+  * @see Use [[title]] to customize the user-friendly name of the schema in the
+  *      OpenAPI documentation
   *
   * @param value Name of the schema
   */

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasDocs.scala
@@ -22,6 +22,7 @@ trait JsonSchemasDocs extends JsonSchemas {
   locally {
     //#documented-generic-schema
     @discriminator("kind")
+    @title("Geometric shape")
     @name("ShapeSchema")
     sealed trait Shape
 

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -28,6 +28,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     @discriminator("$type")
     @name("DocResource")
     @docs("traitDoc")
+    @title("Doc Resource")
     sealed trait Doc
     @docs("recordDocA")
     case class DocA(@docs("fieldDocI") i: Int) extends Doc
@@ -150,20 +151,14 @@ class JsonSchemasTest extends AnyFreeSpec {
         description: String
     ): String = s"$schema{$description}"
 
-    def withTitleRecord[A](
-        schema: Record[A],
-        title: String
-    ): Record[A] = schema
+    def withTitleRecord[A](schema: Record[A], title: String): Record[A] =
+      s"[[$title]]$schema"
 
-    def withTitleTagged[A](
-        schema: Tagged[A],
-        title: String
-    ): Tagged[A] = schema
+    def withTitleTagged[A](schema: Tagged[A], title: String): Tagged[A] =
+      s"[[$title]]$schema"
 
-    def withTitleEnum[A](
-        schema: Enum[A],
-        title: String
-    ): Enum[A] = schema
+    def withTitleEnum[A](schema: Enum[A], title: String): Enum[A] =
+      s"[[$title]]$schema"
 
     def withTitleJsonSchema[A](
         schema: JsonSchema[A],
@@ -251,7 +246,7 @@ class JsonSchemasTest extends AnyFreeSpec {
   }
 
   "documentations" in {
-    val expectedSchema = s"'DocResource'!(${List(
+    val expectedSchema = s"[[Doc Resource]]'DocResource'!(${List(
       s"'$ns.DocA'!(i:integer{fieldDocI},%){recordDocA}@DocA",
       s"'$ns.DocB'!(a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%)@DocB",
       s"'DocC'!(%){recordDocC}@DocC"


### PR DESCRIPTION
The new `title` annotation sets the title of a schema in the generic
derivation process. This is likely to be more useful than the `name`
annotation, since the latter is actually the internal OpenAPI name,
which has to be a valid URI suffix.

The `name` annotation's scaladoc now includes a note about OpenAPI's
use and a reference to `title`.