### PR TITLE
Add `unnamed` annotation

### DIFF
--- a/documentation/manual/src/paradox/algebras/json-schemas.md
+++ b/documentation/manual/src/paradox/algebras/json-schemas.md
@@ -227,7 +227,8 @@ type. The rules for deriving the schema are the following:
   annotation, otherwise the `defaultDiscriminatorName` value is used,
 - the schema is named by the `@name` annotation, if present, or by invoking the
   `classTagToSchemaName` operation with the `ClassTag` of the type for which the schema
-  is derived.
+  is derived. If you wish to avoid naming the schema, use the `@unnamed` annotation
+  (unnamed schemas get inlined in their OpenAPI documentation).
 - the schema title is set with the `@title` annotation, if present
 
 Here is an example that illustrates how to configure the generic schema derivation process:

--- a/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
+++ b/json-schema/json-schema-generic/src/main/scala/endpoints/generic/annotations.scala
@@ -40,6 +40,15 @@ case class title(value: String) extends scala.annotation.Annotation
 case class name(value: String) extends scala.annotation.Annotation
 
 /**
+  * Specifies that a generic schema should not have a name.
+  *
+  * Annotate a sealed trait or case class definition with this annotation to
+  * prevent the schema from being named. This is sometimes useful for forcing
+  * nested schemas to be inlined in OpenAPI documentation.
+  */
+case class unnamed() extends scala.annotation.Annotation
+
+/**
   * Defines the name of the discriminator field of a generic tagged schema.
   *
   * Annotate a sealed trait definition with this annotation to define

--- a/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints/generic/JsonSchemasTest.scala
@@ -32,6 +32,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     sealed trait Doc
     @docs("recordDocA")
     case class DocA(@docs("fieldDocI") i: Int) extends Doc
+    @unnamed()
     case class DocB(
         a: String,
         @docs("fieldDocB") b: Boolean,
@@ -248,7 +249,7 @@ class JsonSchemasTest extends AnyFreeSpec {
   "documentations" in {
     val expectedSchema = s"[[Doc Resource]]'DocResource'!(${List(
       s"'$ns.DocA'!(i:integer{fieldDocI},%){recordDocA}@DocA",
-      s"'$ns.DocB'!(a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%)@DocB",
+      s"a:string,b:boolean{fieldDocB},ss:[string]{fieldDocSS},%@DocB",
       s"'DocC'!(%){recordDocC}@DocC"
     ).mkString("|")})#$$type{traitDoc}"
     assert(FakeAlgebraJsonSchemas.Doc.schema == expectedSchema)


### PR DESCRIPTION
Tweak generic derivation to make the name optional. Although the default
is still to generate a name based on the class tag, there is now an
`unnamed` annotation that can be used to prevent a schema from getting a
name at all.

Fixes #501