### PR TITLE
Extend support of operation xmapPartial to more request constituents

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -51,7 +51,7 @@ trait EndpointsWithCustomErrors
 
   type RequestHeaders[A] = (A, List[HttpHeader]) => List[HttpHeader]
 
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       def xmapPartial[A, B](
@@ -61,7 +61,7 @@ trait EndpointsWithCustomErrors
       ): RequestHeaders[B] = (to, headers) => fa(g(to), headers)
     }
 
-  implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit lazy val requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       override def product[A, B](
           fa: (A, List[HttpHeader]) => List[HttpHeader],
@@ -119,7 +119,7 @@ trait EndpointsWithCustomErrors
 
   type RequestEntity[A] = (A, HttpRequest) => HttpRequest
 
-  implicit lazy val reqEntityInvFunctor
+  implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[A, B](
@@ -163,7 +163,7 @@ trait EndpointsWithCustomErrors
       scala.collection.immutable.Seq[HttpHeader]
   ) => Option[ResponseEntity[A]]
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] =
         (status, headers) => fa(status, headers).map(mapResponseEntity(_)(f))
@@ -227,7 +227,8 @@ trait EndpointsWithCustomErrors
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -52,15 +52,13 @@ trait EndpointsWithCustomErrors
   type RequestHeaders[A] = (A, List[HttpHeader]) => List[HttpHeader]
 
   implicit lazy val reqHeadersInvFunctor
-      : endpoints.InvariantFunctor[RequestHeaders] =
-    new InvariantFunctor[RequestHeaders] {
-      override def xmap[From, To](
-          f: (From, List[HttpHeader]) => List[HttpHeader],
-          map: From => To,
-          contramap: To => From
-      ): (To, List[HttpHeader]) => List[HttpHeader] = { (to, headers) =>
-        f(contramap(to), headers)
-      }
+      : PartialInvariantFunctor[RequestHeaders] =
+    new PartialInvariantFunctor[RequestHeaders] {
+      def xmapPartial[A, B](
+          fa: RequestHeaders[A],
+          f: A => Validated[B],
+          g: B => A
+      ): RequestHeaders[B] = (to, headers) => fa(g(to), headers)
     }
 
   implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
@@ -108,18 +106,27 @@ trait EndpointsWithCustomErrors
 
   type Request[A] = A => Future[HttpResponse]
 
+  implicit def requestPartialInvariantFunctor
+      : PartialInvariantFunctor[Request] =
+    new PartialInvariantFunctor[Request] {
+      def xmapPartial[A, B](
+          fa: Request[A],
+          f: A => Validated[B],
+          g: B => A
+      ): Request[B] =
+        fa compose g
+    }
+
   type RequestEntity[A] = (A, HttpRequest) => HttpRequest
 
   implicit lazy val reqEntityInvFunctor
-      : endpoints.InvariantFunctor[RequestEntity] =
-    new InvariantFunctor[RequestEntity] {
-      override def xmap[From, To](
-          f: (From, HttpRequest) => HttpRequest,
-          map: From => To,
-          contramap: To => From
-      ): (To, HttpRequest) => HttpRequest = { (to, req) =>
-        f(contramap(to), req)
-      }
+      : PartialInvariantFunctor[RequestEntity] =
+    new PartialInvariantFunctor[RequestEntity] {
+      def xmapPartial[A, B](
+          f: RequestEntity[A],
+          map: A => Validated[B],
+          contramap: B => A
+      ): RequestEntity[B] = (to, req) => f(contramap(to), req)
     }
 
   lazy val emptyRequest: RequestEntity[Unit] = (_, req) => req
@@ -163,6 +170,17 @@ trait EndpointsWithCustomErrors
     }
 
   type ResponseEntity[A] = HttpEntity => Future[Either[Throwable, A]]
+
+  implicit def responseEntityInvariantFunctor
+      : InvariantFunctor[ResponseEntity] =
+    new InvariantFunctor[ResponseEntity] {
+      def xmap[A, B](
+          fa: ResponseEntity[A],
+          f: A => B,
+          g: B => A
+      ): ResponseEntity[B] =
+        httpEntity => fa(httpEntity).map(_.map(f))
+    }
 
   private[client] def mapResponseEntity[A, B](
       entity: ResponseEntity[A]
@@ -209,15 +227,14 @@ trait EndpointsWithCustomErrors
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor
-      : PartialInvariantFunctor[ResponseHeaders] =
-    new PartialInvariantFunctor[ResponseHeaders] {
-      def xmapPartial[A, B](
+  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+    new InvariantFunctor[ResponseHeaders] {
+      def xmap[A, B](
           fa: ResponseHeaders[A],
-          f: A => Validated[B],
+          f: A => B,
           g: B => A
       ): ResponseHeaders[B] =
-        headers => fa(headers).flatMap(f)
+        headers => fa(headers).map(f)
     }
 
   def emptyResponseHeaders: ResponseHeaders[Unit] = _ => Valid(())

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
@@ -20,7 +20,7 @@ trait Urls extends algebra.Urls {
     def encodeQueryString(a: A): Option[String]
   }
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -57,7 +57,7 @@ trait Urls extends algebra.Urls {
   /** a query string parameter can have zero or several values */
   type QueryStringParam[A] = A => List[String]
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -87,7 +87,8 @@ trait Urls extends algebra.Urls {
     def encode(a: A): String
   }
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -131,7 +132,7 @@ trait Urls extends algebra.Urls {
     def encode(a: A): String
   }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -64,7 +64,7 @@ trait EndpointsWithCustomErrors
 
   type Response[A] = A => Route
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](
           fa: Response[A],
@@ -119,7 +119,7 @@ trait EndpointsWithCustomErrors
     Directives.entity[String](um)
   }
 
-  implicit lazy val reqEntityInvFunctor
+  implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     directive1InvFunctor
 
@@ -138,10 +138,10 @@ trait EndpointsWithCustomErrors
       docs: Documentation
   ): RequestHeaders[Option[String]] = Directives.optionalHeaderValueByName(name)
 
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : PartialInvariantFunctor[RequestHeaders] =
     directive1InvFunctor
-  implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit lazy val requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       override def product[A, B](fa: Directive1[A], fb: Directive1[B])(
           implicit tupler: Tupler[A, B]
@@ -163,7 +163,8 @@ trait EndpointsWithCustomErrors
         }
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Urls.scala
@@ -76,7 +76,7 @@ trait Urls extends algebra.Urls with StatusCodes {
     def validate(params: Map[String, List[String]]): Validated[T]
   }
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -99,7 +99,7 @@ trait Urls extends algebra.Urls with StatusCodes {
     */
   type QueryStringParam[T] = (String, Map[String, Seq[String]]) => Validated[T]
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -120,7 +120,8 @@ trait Urls extends algebra.Urls with StatusCodes {
     def validate(s: String): Validated[A]
   }
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -201,7 +202,7 @@ trait Urls extends algebra.Urls with StatusCodes {
     first.validate(params).zip(second.validate(params))
   }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -50,11 +50,12 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
 
   /** Provides `++` operation.
     * @see [[SemigroupalSyntax]] */
-  implicit def reqHeadersSemigroupal: Semigroupal[RequestHeaders]
+  implicit def requestHeadersSemigroupal: Semigroupal[RequestHeaders]
 
   /** Provides the operations `xmap` and `xmapPartial`.
     * @see [[PartialInvariantFunctorSyntax]] */
-  implicit def reqHeadersInvFunctor: PartialInvariantFunctor[RequestHeaders]
+  implicit def requestHeadersPartialInvariantFunctor
+      : PartialInvariantFunctor[RequestHeaders]
 
   /** Information carried by a whole request (headers and entity)
     * @note This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]] class.
@@ -72,7 +73,8 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
 
   /** Provides the operations `xmap` and `xmapPartial`.
     * @see [[PartialInvariantFunctorSyntax]] */
-  implicit def reqEntityInvFunctor: PartialInvariantFunctor[RequestEntity]
+  implicit def requestEntityPartialInvariantFunctor
+      : PartialInvariantFunctor[RequestEntity]
 
   /**
     * Empty request -- request without a body.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -13,7 +13,7 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * [[requestHeader]], [[optRequestHeader]], or [[emptyRequestHeaders]].
     *
     * @note  This type has implicit methods provided by the [[SemigroupalSyntax]]
-    *        and [[InvariantFunctorSyntax]] classes.
+    *        and [[PartialInvariantFunctorSyntax]] classes.
     * @group types */
   type RequestHeaders[A]
 
@@ -52,22 +52,27 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     * @see [[SemigroupalSyntax]] */
   implicit def reqHeadersSemigroupal: Semigroupal[RequestHeaders]
 
-  /** Provides `xmap` operation.
-    * @see [[InvariantFunctorSyntax]] */
-  implicit def reqHeadersInvFunctor: InvariantFunctor[RequestHeaders]
+  /** Provides the operations `xmap` and `xmapPartial`.
+    * @see [[PartialInvariantFunctorSyntax]] */
+  implicit def reqHeadersInvFunctor: PartialInvariantFunctor[RequestHeaders]
 
   /** Information carried by a whole request (headers and entity)
+    * @note This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]] class.
     * @group types */
   type Request[A]
 
+  /** Provides the operations `xmap` and `xmapPartial`.
+    * @see [[PartialInvariantFunctorSyntax]] */
+  implicit def requestPartialInvariantFunctor: PartialInvariantFunctor[Request]
+
   /** Information carried by request entity
-    * @note  This type has implicit methods provided by the [[InvariantFunctorSyntax]] class.
+    * @note  This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]] class.
     * @group types */
   type RequestEntity[A]
 
-  /** Provides `xmap` operation.
-    * @see [[InvariantFunctorSyntax]] */
-  implicit def reqEntityInvFunctor: InvariantFunctor[RequestEntity]
+  /** Provides the operations `xmap` and `xmapPartial`.
+    * @see [[PartialInvariantFunctorSyntax]] */
+  implicit def reqEntityInvFunctor: PartialInvariantFunctor[RequestEntity]
 
   /**
     * Empty request -- request without a body.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
@@ -1,23 +1,17 @@
 package endpoints.algebra
 
-import endpoints.{
-  InvariantFunctor,
-  PartialInvariantFunctor,
-  PartialInvariantFunctorSyntax,
-  Semigroupal,
-  Tupler
-}
+import endpoints.{InvariantFunctor, InvariantFunctorSyntax, Semigroupal, Tupler}
 
 /**
   * @group algebras
   */
-trait Responses extends StatusCodes with PartialInvariantFunctorSyntax {
+trait Responses extends StatusCodes with InvariantFunctorSyntax {
   this: Errors =>
 
   /** An HTTP response (status, headers, and entity) carrying an information of type A
     *
     * @note This type has implicit methods provided by the [[InvariantFunctorSyntax]]
-    *       and [[ResponseSyntax]] class
+    *       and [[ResponseSyntax]] classes
     * @group types
     */
   type Response[A]
@@ -28,9 +22,14 @@ trait Responses extends StatusCodes with PartialInvariantFunctorSyntax {
   implicit def responseInvFunctor: InvariantFunctor[Response]
 
   /** An HTTP response entity carrying an information of type A
+    *
+    * @note This type has implicit methods provided by the [[InvariantFunctorSyntax]]
+    *       class
     * @group types
     */
   type ResponseEntity[A]
+
+  implicit def responseEntityInvariantFunctor: InvariantFunctor[ResponseEntity]
 
   /**
     * Empty response entity
@@ -51,7 +50,7 @@ trait Responses extends StatusCodes with PartialInvariantFunctorSyntax {
     * [[optResponseHeader]], or [[emptyResponseHeaders]].
     *
     * @note This type has implicit methods provided by the [[SemigroupalSyntax]]
-    *       and [[PartialInvariantFunctorSyntax]] classes.
+    *       and [[InvariantFunctorSyntax]] classes.
     * @group types
     */
   type ResponseHeaders[A]
@@ -63,11 +62,10 @@ trait Responses extends StatusCodes with PartialInvariantFunctorSyntax {
   implicit def responseHeadersSemigroupal: Semigroupal[ResponseHeaders]
 
   /**
-    * Provides `xmap` and `xmapPartial` operations.
-    * @see [[PartialInvariantFunctorSyntax]]
+    * Provides `xmap` operation.
+    * @see [[InvariantFunctorSyntax]]
     */
-  implicit def responseHeadersInvFunctor
-      : PartialInvariantFunctor[ResponseHeaders]
+  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders]
 
   /**
     * No particular response header.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Responses.scala
@@ -19,7 +19,7 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax {
   /** Provides the operation `xmap` to the type `Response`
     * @see [[InvariantFunctorSyntax]]
     */
-  implicit def responseInvFunctor: InvariantFunctor[Response]
+  implicit def responseInvariantFunctor: InvariantFunctor[Response]
 
   /** An HTTP response entity carrying an information of type A
     *
@@ -65,7 +65,8 @@ trait Responses extends StatusCodes with InvariantFunctorSyntax {
     * Provides `xmap` operation.
     * @see [[InvariantFunctorSyntax]]
     */
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders]
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders]
 
   /**
     * No particular response header.

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
@@ -64,7 +64,7 @@ trait Urls extends PartialInvariantFunctorSyntax {
 
   /** Provides `xmap` and `xmapPartial` operations.
     * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
-  implicit def queryStringPartialInvFunctor
+  implicit def queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString]
 
   /** Extension methods on [[QueryString]].
@@ -155,7 +155,7 @@ trait Urls extends PartialInvariantFunctorSyntax {
 
   /** Provides `xmap` and `xmapPartial` operations.
     * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
-  implicit def queryStringParamPartialInvFunctor
+  implicit def queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam]
 
   def tryParseString[A](
@@ -218,7 +218,7 @@ trait Urls extends PartialInvariantFunctorSyntax {
 
   /** Provides `xmap` and `xmapPartial` operations.
     * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
-  implicit def segmentPartialInvFunctor: PartialInvariantFunctor[Segment]
+  implicit def segmentPartialInvariantFunctor: PartialInvariantFunctor[Segment]
 
   /** Ability to define `String` path segments
     * Servers should return an URL-decoded string value,
@@ -331,7 +331,7 @@ trait Urls extends PartialInvariantFunctorSyntax {
 
   /** Provides `xmap` and `xmapPartial` operations
     * @see [[PartialInvariantFunctorSyntax]] and [[InvariantFunctorSyntax]] */
-  implicit def urlPartialInvFunctor: PartialInvariantFunctor[Url]
+  implicit def urlPartialInvariantFunctor: PartialInvariantFunctor[Url]
 
   /** Builds an URL from the given path and query string */
   def urlWithQueryString[A, B](path: Path[A], qs: QueryString[B])(

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -4,7 +4,9 @@ import java.time.format.DateTimeFormatter
 import java.time.LocalDate
 import java.util.UUID
 
-import endpoints.{Invalid, Valid, algebra}
+import endpoints.{Invalid, Valid, Validated, algebra}
+
+import scala.util.Try
 
 trait EndpointsTestApi extends algebra.Endpoints {
 
@@ -75,14 +77,16 @@ trait EndpointsTestApi extends algebra.Endpoints {
     ok(textResponse)
   )
 
-  val headers2 = requestHeader("C").xmap(_.toInt)(_.toString)
+  val headers2 = requestHeader("C").xmapPartial(s =>
+    Validated.fromTry(Try(s.toInt)).mapErrors(_ => Seq(s"Invalid integer: $s"))
+  )(_.toString())
   val xmapHeadersEndpoint = endpoint(
     get(path / "xmapHeadersEndpoint", headers = headers2),
     ok(textResponse)
   )
 
   val url1 = (path / "xmapUrlEndpoint" / segment[Long](): Url[Long])
-    .xmap(_.toString)(_.toLong)
+    .xmap(_.toString())(_.toLong)
   val xmapUrlEndpoint = endpoint(
     get(url1),
     ok(textResponse)
@@ -90,9 +94,11 @@ trait EndpointsTestApi extends algebra.Endpoints {
 
   val dateTimeFormatter = DateTimeFormatter.ISO_DATE
   val reqBody1 =
-    textRequest.xmap(s => LocalDate.parse(s, dateTimeFormatter))(d =>
-      dateTimeFormatter.format(d)
-    )
+    textRequest.xmapPartial(s =>
+      Validated
+        .fromTry(Try(LocalDate.parse(s, dateTimeFormatter)))
+        .mapErrors(_ => Seq(s"Invalid date: $s"))
+    )(d => dateTimeFormatter.format(d))
   val xmapReqBodyEndpoint = endpoint(
     post(path / "xmapReqBodyEndpoint", reqBody1),
     ok(textResponse)
@@ -123,12 +129,8 @@ trait EndpointsTestApi extends algebra.Endpoints {
 
   val cacheHeaders: ResponseHeaders[Cache] =
     (responseHeader("ETag") ++ responseHeader("Last-Modified"))
-      .xmapPartial {
-        case (etag, lastModified) =>
-          val validDate =
-            if (lastModified.contains("GMT")) Valid(lastModified)
-            else Invalid("Invalid date")
-          validDate.map(Cache(etag, _))
+      .xmap {
+        case (etag, lastModified) => Cache(etag, lastModified)
       }(cache => (cache.etag, cache.lastModified))
 
   val versionedResource = endpoint(
@@ -139,6 +141,44 @@ trait EndpointsTestApi extends algebra.Endpoints {
   val endpointWithOptionalResponseHeader = endpoint(
     get(path / "maybe-cors-enabled"),
     ok(textResponse, headers = optResponseHeader("Access-Control-Allow-Origin"))
+  )
+
+  val transformedRequest =
+    get(
+      url = path / "transformed-request" /? qs[Int]("n"),
+      headers = requestHeader("Accept")
+    ).xmapPartial {
+      case (queryParam, headerValue) =>
+        if (headerValue.length == queryParam) Valid((queryParam, headerValue))
+        else
+          Invalid(
+            "Invalid combination of request header and query string parameter"
+          )
+    }(identity)
+
+  val endpointWithTransformedRequest = endpoint(
+    transformedRequest,
+    ok(emptyResponse)
+  )
+
+  case class StringWrapper(str: String)
+
+  val transformedResponseEntity =
+    textResponse.xmap(StringWrapper)(_.str)
+
+  val endpointWithTransformedResponseEntity = endpoint(
+    get(path / "transformed-response-entity"),
+    ok(transformedResponseEntity)
+  )
+
+  case class TransformedResponse(entity: String, etag: String)
+
+  val endpointWithTransformedResponse = endpoint(
+    get(path / "transformed-response"),
+    ok(
+      entity = textResponse,
+      headers = responseHeader("ETag")
+    ).xmap(TransformedResponse.tupled)(r => (r.entity, r.etag))
   )
 
 }

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
@@ -402,25 +402,6 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
         }
       }
 
-      "Report failures when decoding response headers" in {
-        val response = "foo"
-        val etag = s""""${UUID.randomUUID()}""""
-        wireMockServer.stubFor(
-          get(urlEqualTo("/versioned-resource"))
-            .willReturn(
-              aResponse()
-                .withStatus(200)
-                .withBody(response)
-                .withHeader("ETag", etag)
-                .withHeader("Last-Modified", "dummy")
-            )
-        )
-
-        whenReady(call(client.versionedResource, ()).failed) { exception =>
-          assert(exception.getMessage == "Invalid date")
-        }
-      }
-
       "Decode optional response headers" in {
         val response = "foo"
         val origin = "*"

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
@@ -1,14 +1,21 @@
 package endpoints.algebra.server
 
+import java.time.LocalDate
 import java.util.UUID
 
 import akka.http.scaladsl.model.HttpMethods.{DELETE, PUT}
 import akka.http.scaladsl.model.headers.{
   ETag,
+  RawHeader,
   `Access-Control-Allow-Origin`,
   `Last-Modified`
 }
-import akka.http.scaladsl.model.{DateTime, HttpRequest}
+import akka.http.scaladsl.model.{
+  DateTime,
+  HttpMethods,
+  HttpRequest,
+  StatusCodes
+}
 import endpoints.{Invalid, Valid}
 
 trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi]
@@ -459,6 +466,105 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi]
             assert(responseEntity == entity)
             assert(response.header[`Access-Control-Allow-Origin`].isEmpty)
             ()
+        }
+      }
+    }
+
+    "decode transformed request headers" in {
+      serveEndpoint(xmapHeadersEndpoint, "ignored") { port =>
+        val validRequest =
+          HttpRequest(uri = s"http://localhost:$port/xmapHeadersEndpoint")
+            .withHeaders(RawHeader("C", "42"))
+        whenReady(sendAndDecodeEntityAsText(validRequest)) {
+          case (response, _) =>
+            assert(response.status == StatusCodes.OK)
+        }
+        val invalidRequest =
+          HttpRequest(uri = s"http://localhost:$port/xmapHeadersEndpoint")
+            .withHeaders(RawHeader("C", "forty-two"))
+        whenReady(sendAndDecodeEntityAsText(invalidRequest)) {
+          case (response, entity) =>
+            assert(response.status == StatusCodes.BadRequest)
+            assert(entity == """["Invalid integer: forty-two"]""")
+        }
+      }
+    }
+
+    "decode transformed request entities" in {
+      serveEndpoint(xmapReqBodyEndpoint, "ignored") { port =>
+        val validRequest =
+          HttpRequest(
+            uri = s"http://localhost:$port/xmapReqBodyEndpoint",
+            method = HttpMethods.POST
+          ).withEntity(LocalDate.now().format(dateTimeFormatter))
+        whenReady(sendAndDecodeEntityAsText(validRequest)) {
+          case (response, _) =>
+            assert(response.status == StatusCodes.OK)
+        }
+        val invalidRequest =
+          HttpRequest(
+            uri = s"http://localhost:$port/xmapReqBodyEndpoint",
+            method = HttpMethods.POST
+          ).withEntity("not a date")
+        whenReady(sendAndDecodeEntityAsText(invalidRequest)) {
+          case (response, entity) =>
+            assert(response.status == StatusCodes.BadRequest)
+            assert(entity == """["Invalid date: not a date"]""")
+        }
+      }
+    }
+
+    "decode transformed request" in {
+      serveEndpoint(endpointWithTransformedRequest, ()) { port =>
+        val validRequest =
+          HttpRequest(uri = s"http://localhost:$port/transformed-request?n=9")
+            .withHeaders(RawHeader("Accept", "text/html"))
+        whenReady(sendAndDecodeEntityAsText(validRequest)) {
+          case (response, _) =>
+            assert(response.status == StatusCodes.OK)
+        }
+        val invalidRequest =
+          HttpRequest(uri = s"http://localhost:$port/transformed-request?n=10")
+            .withHeaders(RawHeader("Accept", "text/html"))
+        whenReady(sendAndDecodeEntityAsText(invalidRequest)) {
+          case (response, entity) =>
+            assert(response.status == StatusCodes.BadRequest)
+            assert(
+              entity == """["Invalid combination of request header and query string parameter"]"""
+            )
+        }
+      }
+    }
+
+    "encode transformed response entities" in {
+      val entity = StringWrapper("foo")
+      serveEndpoint(
+        serverApi.endpointWithTransformedResponseEntity,
+        entity
+      ) { port =>
+        val request =
+          HttpRequest(uri =
+            s"http://localhost:$port/transformed-response-entity"
+          )
+        whenReady(sendAndDecodeEntityAsText(request)) {
+          case (_, responseEntity) =>
+            assert(responseEntity == entity.str)
+        }
+      }
+    }
+
+    "encode transformed response" in {
+      val resp = TransformedResponse("foo", "\"42\"")
+      serveEndpoint(
+        serverApi.endpointWithTransformedResponse,
+        resp
+      ) { port =>
+        val request =
+          HttpRequest(uri = s"http://localhost:$port/transformed-response")
+        whenReady(sendAndDecodeEntityAsText(request)) {
+          case (response, responseEntity) =>
+            assert(responseEntity == resp.entity)
+            assert(response.headers[ETag].contains(ETag("42")))
         }
       }
     }

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
@@ -154,7 +154,8 @@ trait EndpointsWithCustomErrors
       })
 
   // RESPONSES
-  implicit lazy val responseInvFunctor: endpoints.InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor
+      : endpoints.InvariantFunctor[Response] =
     new endpoints.InvariantFunctor[Response] {
       def xmap[A, B](
           fa: Response[A],
@@ -215,7 +216,7 @@ trait EndpointsWithCustomErrors
         }
     }
 
-  implicit def responseHeadersInvFunctor
+  implicit def responseHeadersInvariantFunctor
       : endpoints.InvariantFunctor[ResponseHeaders] =
     new endpoints.InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
@@ -315,7 +316,7 @@ trait EndpointsWithCustomErrors
       } else None
     }
 
-  implicit def reqEntityInvFunctor
+  implicit def requestEntityPartialInvariantFunctor
       : endpoints.PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[From, To](
@@ -330,7 +331,7 @@ trait EndpointsWithCustomErrors
           }))
     }
 
-  implicit def reqHeadersInvFunctor
+  implicit def requestHeadersPartialInvariantFunctor
       : endpoints.PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       def xmapPartial[From, To](
@@ -341,7 +342,8 @@ trait EndpointsWithCustomErrors
         headers => f(headers).flatMap(map)
     }
 
-  implicit def reqHeadersSemigroupal: endpoints.Semigroupal[RequestHeaders] =
+  implicit def requestHeadersSemigroupal
+      : endpoints.Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(
           implicit tupler: Tupler[A, B]

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Urls.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Urls.scala
@@ -98,7 +98,7 @@ trait Urls extends algebra.Urls with StatusCodes {
             .map(_.result())
       }
 
-  implicit def queryStringParamPartialInvFunctor
+  implicit def queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -115,7 +115,8 @@ trait Urls extends algebra.Urls with StatusCodes {
       Validated.fromOption(maybeValue)("Missing value")
     }
 
-  implicit def segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit def segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -204,7 +205,7 @@ trait Urls extends algebra.Urls with StatusCodes {
       }
   }
 
-  implicit def urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit def urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],
@@ -240,7 +241,7 @@ trait Urls extends algebra.Urls with StatusCodes {
     }
   }
 
-  implicit def queryStringPartialInvFunctor
+  implicit def queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](

--- a/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasOptionalFieldsTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints/algebra/JsonSchemasOptionalFieldsTest.scala
@@ -1,7 +1,5 @@
 package endpoints.algebra
 
-import java.util.UUID
-
 import endpoints.{Invalid, Valid, Validated}
 import org.scalatest.freespec.AnyFreeSpec
 
@@ -100,7 +98,7 @@ trait JsonSchemasOptionalFieldsTest
     val decoded = decodeJson(schema, json)
     decoded match {
       case Valid(n)        => assert(n == 1)
-      case Invalid(errors) => fail(errors.toString)
+      case Invalid(errors) => fail(errors.toString())
     }
     val encoded = encodeJson(schema, 1)
     assert(encoded == Json.obj("relevant" -> Json.num(1)))

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -58,21 +58,31 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
   ): Request[Out] =
     DocumentedRequest(method, url, headers, docs, entity)
 
+  implicit def requestPartialInvariantFunctor
+      : PartialInvariantFunctor[Request] =
+    new PartialInvariantFunctor[Request] {
+      def xmapPartial[A, B](
+          fa: Request[A],
+          f: A => Validated[B],
+          g: B => A
+      ): Request[B] = fa
+    }
+
   implicit lazy val reqEntityInvFunctor
-      : endpoints.InvariantFunctor[RequestEntity] =
-    new InvariantFunctor[RequestEntity] {
-      def xmap[From, To](
+      : endpoints.PartialInvariantFunctor[RequestEntity] =
+    new PartialInvariantFunctor[RequestEntity] {
+      def xmapPartial[From, To](
           x: RequestEntity[From],
-          map: From => To,
+          map: From => Validated[To],
           contramap: To => From
       ): RequestEntity[To] = x
     }
   implicit lazy val reqHeadersInvFunctor
-      : endpoints.InvariantFunctor[RequestHeaders] =
-    new InvariantFunctor[RequestHeaders] {
-      def xmap[From, To](
+      : endpoints.PartialInvariantFunctor[RequestHeaders] =
+    new PartialInvariantFunctor[RequestHeaders] {
+      def xmapPartial[From, To](
           x: RequestHeaders[From],
-          map: From => To,
+          map: From => Validated[To],
           contramap: To => From
       ): RequestHeaders[To] = x
     }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -68,7 +68,7 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
       ): Request[B] = fa
     }
 
-  implicit lazy val reqEntityInvFunctor
+  implicit lazy val requestEntityPartialInvariantFunctor
       : endpoints.PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[From, To](
@@ -77,7 +77,7 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
           contramap: To => From
       ): RequestEntity[To] = x
     }
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : endpoints.PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       def xmapPartial[From, To](
@@ -86,7 +86,7 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
           contramap: To => From
       ): RequestHeaders[To] = x
     }
-  implicit lazy val reqHeadersSemigroupal
+  implicit lazy val requestHeadersSemigroupal
       : endpoints.Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
@@ -31,7 +31,7 @@ trait Responses extends algebra.Responses with StatusCodes with Headers {
       content: Map[String, MediaType]
   )
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] = fa
     }
@@ -76,7 +76,8 @@ trait Responses extends algebra.Responses with StatusCodes with Headers {
         DocumentedHeaders(fa.value ++ fb.value)
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Responses.scala
@@ -36,6 +36,16 @@ trait Responses extends algebra.Responses with StatusCodes with Headers {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] = fa
     }
 
+  implicit lazy val responseEntityInvariantFunctor
+      : InvariantFunctor[ResponseEntity] =
+    new InvariantFunctor[ResponseEntity] {
+      def xmap[A, B](
+          fa: ResponseEntity[A],
+          f: A => B,
+          g: B => A
+      ): ResponseEntity[B] = fa
+    }
+
   def emptyResponse: ResponseEntity[Unit] = Map.empty
 
   def textResponse: ResponseEntity[String] =
@@ -66,12 +76,11 @@ trait Responses extends algebra.Responses with StatusCodes with Headers {
         DocumentedHeaders(fa.value ++ fb.value)
     }
 
-  implicit def responseHeadersInvFunctor
-      : PartialInvariantFunctor[ResponseHeaders] =
-    new PartialInvariantFunctor[ResponseHeaders] {
-      def xmapPartial[A, B](
+  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+    new InvariantFunctor[ResponseHeaders] {
+      def xmap[A, B](
           fa: ResponseHeaders[A],
-          f: A => Validated[B],
+          f: A => B,
           g: B => A
       ): ResponseHeaders[B] = fa
     }

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Urls.scala
@@ -73,7 +73,7 @@ trait Urls extends algebra.Urls {
       isRequired = false
     )
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -83,7 +83,7 @@ trait Urls extends algebra.Urls {
       ): QueryString[B] = fa
     }
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -113,7 +113,8 @@ trait Urls extends algebra.Urls {
 
   type Segment[A] = Schema
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -175,7 +176,7 @@ trait Urls extends algebra.Urls {
 
   type Url[A] = DocumentedUrl
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -72,7 +72,7 @@ trait EndpointsWithCustomErrors
     case (None, req)        => req
   }
 
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       def xmapPartial[A, B](
@@ -83,7 +83,7 @@ trait EndpointsWithCustomErrors
         (b, req) => fa(g(b), req)
     }
 
-  implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit lazy val requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       override def product[A, B](
           fa: (A, WSRequest) => WSRequest,
@@ -123,7 +123,7 @@ trait EndpointsWithCustomErrors
   lazy val textRequest: (String, WSRequest) => WSRequest =
     (body, req) => req.withBody(body)
 
-  implicit lazy val reqEntityInvFunctor
+  implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[A, B](
@@ -161,7 +161,7 @@ trait EndpointsWithCustomErrors
       Map[String, scala.collection.Seq[String]]
   ) => Option[ResponseEntity[A]]
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] =
         (status, headers) => fa(status, headers).map(mapResponseEntity(_)(f))
@@ -208,7 +208,8 @@ trait EndpointsWithCustomErrors
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -72,14 +72,15 @@ trait EndpointsWithCustomErrors
     case (None, req)        => req
   }
 
-  implicit lazy val reqHeadersInvFunctor: InvariantFunctor[RequestHeaders] =
-    new InvariantFunctor[RequestHeaders] {
-      override def xmap[From, To](
-          f: (From, WSRequest) => WSRequest,
-          map: From => To,
-          contramap: To => From
-      ): (To, WSRequest) => WSRequest =
-        (to, req) => f(contramap(to), req)
+  implicit lazy val reqHeadersInvFunctor
+      : PartialInvariantFunctor[RequestHeaders] =
+    new PartialInvariantFunctor[RequestHeaders] {
+      def xmapPartial[A, B](
+          fa: RequestHeaders[A],
+          f: A => Validated[B],
+          g: B => A
+      ): RequestHeaders[B] =
+        (b, req) => fa(g(b), req)
     }
 
   implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
@@ -99,8 +100,19 @@ trait EndpointsWithCustomErrors
     */
   type Request[A] = A => Future[WSResponse]
 
+  implicit def requestPartialInvariantFunctor
+      : PartialInvariantFunctor[Request] =
+    new PartialInvariantFunctor[Request] {
+      def xmapPartial[A, B](
+          fa: Request[A],
+          f: A => Validated[B],
+          g: B => A
+      ): Request[B] =
+        fa compose g
+    }
+
   /**
-    * A function that, given an `A` information and a `WSRequest`, eventually returns a `WSResponse`
+    * A function that, given an `A` information and a `WSRequest`, returns a `WSRequest` with a body correctly set
     */
   type RequestEntity[A] = (A, WSRequest) => WSRequest
 
@@ -111,14 +123,15 @@ trait EndpointsWithCustomErrors
   lazy val textRequest: (String, WSRequest) => WSRequest =
     (body, req) => req.withBody(body)
 
-  implicit lazy val reqEntityInvFunctor: InvariantFunctor[RequestEntity] =
-    new InvariantFunctor[RequestEntity] {
-      override def xmap[From, To](
-          f: (From, WSRequest) => WSRequest,
-          map: From => To,
-          contramap: To => From
-      ): (To, WSRequest) => WSRequest =
-        (to, req) => f(contramap(to), req)
+  implicit lazy val reqEntityInvFunctor
+      : PartialInvariantFunctor[RequestEntity] =
+    new PartialInvariantFunctor[RequestEntity] {
+      def xmapPartial[A, B](
+          fa: RequestEntity[A],
+          f: A => Validated[B],
+          g: B => A
+      ): RequestEntity[B] =
+        (b, req) => fa(g(b), req)
     }
 
   def request[A, B, C, AB, Out](
@@ -156,10 +169,21 @@ trait EndpointsWithCustomErrors
 
   type ResponseEntity[A] = WSResponse => Either[Throwable, A]
 
+  implicit def responseEntityInvariantFunctor
+      : InvariantFunctor[ResponseEntity] =
+    new InvariantFunctor[ResponseEntity] {
+      def xmap[A, B](
+          fa: ResponseEntity[A],
+          f: A => B,
+          g: B => A
+      ): ResponseEntity[B] =
+        mapResponseEntity(fa)(f)
+    }
+
   private[client] def mapResponseEntity[A, B](
       entity: ResponseEntity[A]
   )(f: A => B): ResponseEntity[B] =
-    mapPartialResponseEntity(entity)(a => Right(f(a)))
+    wsResp => entity(wsResp).map(f)
 
   private[client] def mapPartialResponseEntity[A, B](
       entity: ResponseEntity[A]
@@ -184,15 +208,14 @@ trait EndpointsWithCustomErrors
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor
-      : PartialInvariantFunctor[ResponseHeaders] =
-    new PartialInvariantFunctor[ResponseHeaders] {
-      def xmapPartial[A, B](
+  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+    new InvariantFunctor[ResponseHeaders] {
+      def xmap[A, B](
           fa: ResponseHeaders[A],
-          f: A => Validated[B],
+          f: A => B,
           g: B => A
       ): ResponseHeaders[B] =
-        headers => fa(headers).flatMap(f)
+        headers => fa(headers).map(f)
     }
 
   def emptyResponseHeaders: ResponseHeaders[Unit] = _ => Valid(())

--- a/play/client/src/main/scala/endpoints/play/client/Urls.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Urls.scala
@@ -21,7 +21,7 @@ trait Urls extends algebra.Urls {
     def encodeQueryString(a: A): Option[String]
   }
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -58,7 +58,7 @@ trait Urls extends algebra.Urls {
   /** a query string parameter can have zero or several values */
   type QueryStringParam[A] = A => List[String]
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -89,7 +89,8 @@ trait Urls extends algebra.Urls {
     def encode(a: A): String
   }
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -145,7 +146,7 @@ trait Urls extends algebra.Urls {
       }
     }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/play/server/src/main/scala/endpoints/play/server/Assets.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Assets.scala
@@ -70,7 +70,11 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
       throw new Exception(s"No digest for asset $rawPath")
     )
     val assetPath =
-      AssetPath(path.fold(Seq.empty[String])(_.split("/")), digest, name)
+      AssetPath(
+        path.fold(Seq.empty[String])(_.split("/").toIndexedSeq),
+        digest,
+        name
+      )
     AssetRequest(
       assetPath,
       isGzipSupported = false

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -98,7 +98,7 @@ trait EndpointsWithCustomErrors
   ): Headers => Validated[Option[String]] =
     headers => Valid(headers.get(name))
 
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : endpoints.PartialInvariantFunctor[RequestHeaders] =
     new endpoints.PartialInvariantFunctor[RequestHeaders] {
       def xmapPartial[A, B](
@@ -109,7 +109,7 @@ trait EndpointsWithCustomErrors
         headers => fa(headers).flatMap(f)
     }
 
-  implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit lazy val requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(
           implicit tupler: Tupler[A, B]
@@ -218,7 +218,8 @@ trait EndpointsWithCustomErrors
 
   lazy val textRequest: BodyParser[String] = playComponents.playBodyParsers.text
 
-  implicit def reqEntityInvFunctor: PartialInvariantFunctor[RequestEntity] =
+  implicit def requestEntityPartialInvariantFunctor
+      : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[From, To](
           f: BodyParser[From],
@@ -280,7 +281,8 @@ trait EndpointsWithCustomErrors
     */
   type Response[A] = A => Result
 
-  implicit lazy val responseInvFunctor: endpoints.InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor
+      : endpoints.InvariantFunctor[Response] =
     new endpoints.InvariantFunctor[Response] {
       def xmap[A, B](
           fa: Response[A],
@@ -336,7 +338,7 @@ trait EndpointsWithCustomErrors
         }
     }
 
-  implicit def responseHeadersInvFunctor
+  implicit def responseHeadersInvariantFunctor
       : endpoints.InvariantFunctor[ResponseHeaders] =
     new endpoints.InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](

--- a/play/server/src/main/scala/endpoints/play/server/Urls.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Urls.scala
@@ -73,7 +73,8 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
   }
   //#segment
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -118,7 +119,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
     def encode(a: A): Map[String, Seq[String]] // FIXME Encode to a String for better performance
   }
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -175,7 +176,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
     def encode(name: String, a: A): Map[String, Seq[String]]
   }
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -384,7 +385,7 @@ trait Urls extends algebra.Urls { this: EndpointsWithCustomErrors =>
     def encodeUrl(a: A): String
   }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -45,7 +45,8 @@ trait Requests extends algebra.Requests with Urls with Methods {
   ): Option[String] => Seq[(String, String)] =
     valueOpt => valueOpt.map(v => name -> v).toSeq
 
-  implicit def reqHeadersInvFunctor: PartialInvariantFunctor[RequestHeaders] =
+  implicit def requestHeadersPartialInvariantFunctor
+      : PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       def xmapPartial[From, To](
           f: RequestHeaders[From],
@@ -55,7 +56,7 @@ trait Requests extends algebra.Requests with Urls with Methods {
         to => f(contramap(to))
     }
 
-  implicit def reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit def requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       override def product[A, B](
           fa: A => Seq[(String, String)],
@@ -72,7 +73,8 @@ trait Requests extends algebra.Requests with Urls with Methods {
   def textRequest: (String, HttpRequest) => scalaj.http.HttpRequest =
     (body, req) => req.postData(body)
 
-  implicit def reqEntityInvFunctor: PartialInvariantFunctor[RequestEntity] =
+  implicit def requestEntityPartialInvariantFunctor
+      : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[A, B](
           fa: RequestEntity[A],

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Responses.scala
@@ -20,7 +20,7 @@ trait Responses extends algebra.Responses with StatusCodes {
 
   type Response[A] = HttpResponse[String] => Option[ResponseEntity[A]]
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](
           fa: Response[A],
@@ -59,7 +59,8 @@ trait Responses extends algebra.Responses with StatusCodes {
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Urls.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Urls.scala
@@ -34,7 +34,7 @@ trait Urls extends algebra.Urls {
 
   class Url[A](val toReq: A => HttpRequest)
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -44,7 +44,7 @@ trait Urls extends algebra.Urls {
       ): QueryString[B] = fa compose g
     }
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -65,7 +65,8 @@ trait Urls extends algebra.Urls {
     }
   }
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -128,7 +129,7 @@ trait Urls extends algebra.Urls {
     })
   }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -73,7 +73,7 @@ trait EndpointsWithCustomErrors[R[_]]
     case (None, request)        => request
   }
 
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       override def xmapPartial[From, To](
@@ -84,7 +84,7 @@ trait EndpointsWithCustomErrors[R[_]]
         (to, request) => f(contramap(to), request)
     }
 
-  implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit lazy val requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       override def product[A, B](
           fa: (A, SttpRequest) => SttpRequest,
@@ -127,7 +127,8 @@ trait EndpointsWithCustomErrors[R[_]]
     case (bodyValue, request) => request.body(bodyValue)
   }
 
-  implicit def reqEntityInvFunctor: PartialInvariantFunctor[RequestEntity] =
+  implicit def requestEntityPartialInvariantFunctor
+      : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       override def xmapPartial[From, To](
           f: RequestEntity[From],
@@ -164,7 +165,7 @@ trait EndpointsWithCustomErrors[R[_]]
     def decodeResponse(response: sttp.Response[String]): Option[R[A]]
   }
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] =
         new Response[B] {
@@ -232,7 +233,8 @@ trait EndpointsWithCustomErrors[R[_]]
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
@@ -17,7 +17,7 @@ trait Urls extends algebra.Urls {
     def encodeQueryString(a: A): Option[String]
   }
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -54,7 +54,7 @@ trait Urls extends algebra.Urls {
   /** a query string parameter can have zero or several values */
   type QueryStringParam[A] = A => List[String]
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -85,7 +85,8 @@ trait Urls extends algebra.Urls {
     def encode(a: A): String
   }
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -141,7 +142,7 @@ trait Urls extends algebra.Urls {
       }
     }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -65,7 +65,7 @@ trait EndpointsWithCustomErrors
     (valueOpt, xhr) =>
       valueOpt.foreach(value => xhr.setRequestHeader(name, value))
 
-  implicit lazy val reqHeadersInvFunctor
+  implicit lazy val requestHeadersPartialInvariantFunctor
       : PartialInvariantFunctor[RequestHeaders] =
     new PartialInvariantFunctor[RequestHeaders] {
       override def xmapPartial[From, To](
@@ -76,7 +76,7 @@ trait EndpointsWithCustomErrors
         (to, xhr) => f(contramap(to), xhr)
     }
 
-  implicit lazy val reqHeadersSemigroupal: Semigroupal[RequestHeaders] =
+  implicit lazy val requestHeadersSemigroupal: Semigroupal[RequestHeaders] =
     new Semigroupal[RequestHeaders] {
       override def product[A, B](
           fa: js.Function2[A, XMLHttpRequest, Unit],
@@ -132,7 +132,7 @@ trait EndpointsWithCustomErrors
     body
   }
 
-  implicit lazy val reqEntityInvFunctor
+  implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {
       def xmapPartial[From, To](
@@ -186,7 +186,7 @@ trait EndpointsWithCustomErrors
     */
   type Response[A] = js.Function1[XMLHttpRequest, Option[ResponseEntity[A]]]
 
-  implicit lazy val responseInvFunctor: InvariantFunctor[Response] =
+  implicit lazy val responseInvariantFunctor: InvariantFunctor[Response] =
     new InvariantFunctor[Response] {
       def xmap[A, B](fa: Response[A], f: A => B, g: B => A): Response[B] =
         xhr => fa(xhr).map(mapResponseEntity(_)(f))
@@ -243,7 +243,8 @@ trait EndpointsWithCustomErrors
         headers => fa(headers).zip(fb(headers))
     }
 
-  implicit def responseHeadersInvFunctor: InvariantFunctor[ResponseHeaders] =
+  implicit def responseHeadersInvariantFunctor
+      : InvariantFunctor[ResponseHeaders] =
     new InvariantFunctor[ResponseHeaders] {
       def xmap[A, B](
           fa: ResponseHeaders[A],

--- a/xhr/client/src/main/scala/endpoints/xhr/Urls.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Urls.scala
@@ -22,7 +22,8 @@ trait Urls extends algebra.Urls {
   }
   //#segment
 
-  implicit lazy val segmentPartialInvFunctor: PartialInvariantFunctor[Segment] =
+  implicit lazy val segmentPartialInvariantFunctor
+      : PartialInvariantFunctor[Segment] =
     new PartialInvariantFunctor[Segment] {
       def xmapPartial[A, B](
           fa: Segment[A],
@@ -43,7 +44,7 @@ trait Urls extends algebra.Urls {
     def encode(a: A): Option[String]
   }
 
-  implicit lazy val queryStringPartialInvFunctor
+  implicit lazy val queryStringPartialInvariantFunctor
       : PartialInvariantFunctor[QueryString] =
     new PartialInvariantFunctor[QueryString] {
       def xmapPartial[A, B](
@@ -82,7 +83,7 @@ trait Urls extends algebra.Urls {
     def encode(a: A): List[String]
   }
 
-  implicit lazy val queryStringParamPartialInvFunctor
+  implicit lazy val queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam] =
     new PartialInvariantFunctor[QueryStringParam] {
       def xmapPartial[A, B](
@@ -154,7 +155,7 @@ trait Urls extends algebra.Urls {
       }
     }
 
-  implicit lazy val urlPartialInvFunctor: PartialInvariantFunctor[Url] =
+  implicit lazy val urlPartialInvariantFunctor: PartialInvariantFunctor[Url] =
     new PartialInvariantFunctor[Url] {
       def xmapPartial[A, B](
           fa: Url[A],


### PR DESCRIPTION
Fixes #513

Implement `PartialInvariantFunctor` for `RequestHeaders`, `RequestEntity`, and `Request`.

On the response side, `PartialInvariantFunctor` makes less sense: it makes it possible to refine the result sent by the server, on the client-side. I don’t think this is desirable. Consequently, `ResponseHeaders`, `ResponseEntity`, and `Response` only implement `InvariantFunctor`.