### PR TITLE
Add `NoDocsJsonSchemas` for decoder `JsonSchemas`

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints/circe/JsonSchemas.scala
@@ -9,7 +9,7 @@ import scala.collection.compat._
 /**
   * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces a circe codec.
   */
-trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
+trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {
     def encoder: Encoder[A]
@@ -168,10 +168,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     )
   }
 
-  def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
-  def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = schema
-  def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
-
   private def lazySchema[A](
       schema: => JsonSchema[A],
       name: String
@@ -285,66 +281,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       recordA.decoder.product(recordB.decoder).map { case (a, b) => t(a, b) }
     Record(encoder, decoder)
   }
-
-  def withExampleRecord[A](
-      schema: Record[A],
-      example: A
-  ): Record[A] = schema
-
-  def withExampleTagged[A](
-      schema: Tagged[A],
-      example: A
-  ): Tagged[A] = schema
-
-  def withExampleEnum[A](
-      schema: Enum[A],
-      example: A
-  ): Enum[A] = schema
-
-  def withExampleJsonSchema[A](
-      schema: JsonSchema[A],
-      example: A
-  ): JsonSchema[A] = schema
-
-  def withDescriptionRecord[A](
-      schema: Record[A],
-      description: String
-  ): Record[A] = schema
-
-  def withDescriptionTagged[A](
-      schema: Tagged[A],
-      description: String
-  ): Tagged[A] = schema
-
-  def withDescriptionEnum[A](
-      schema: Enum[A],
-      description: String
-  ): Enum[A] = schema
-
-  def withDescriptionJsonSchema[A](
-      schema: JsonSchema[A],
-      description: String
-  ): JsonSchema[A] = schema
-
-  def withTitleRecord[A](
-      schema: Record[A],
-      title: String
-  ): Record[A] = schema
-
-  def withTitleTagged[A](
-      schema: Tagged[A],
-      title: String
-  ): Tagged[A] = schema
-
-  def withTitleEnum[A](
-      schema: Enum[A],
-      title: String
-  ): Enum[A] = schema
-
-  def withTitleJsonSchema[A](
-      schema: JsonSchema[A],
-      title: String
-  ): JsonSchema[A] = schema
 
   def orFallbackToJsonSchema[A, B](
       schemaA: JsonSchema[A],

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints/playjson/JsonSchemas.scala
@@ -10,7 +10,7 @@ import scala.collection.compat._
   * An interpreter for [[endpoints.algebra.JsonSchemas]] that produces Play JSON `play.api.libs.json.Reads`
   * and `play.api.libs.json.Writes`.
   */
-trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
+trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {
     def reads: Reads[A]
@@ -107,10 +107,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     )
   }
 
-  def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
-  def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = schema
-  def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
-
   private def lazySchema[A](
       schema: => JsonSchema[A],
       name: String
@@ -156,66 +152,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       (__ \ name).readNullable(tpe.reads),
       (__ \ name).writeNullable(tpe.writes)
     )
-
-  def withExampleRecord[A](
-      schema: Record[A],
-      example: A
-  ): Record[A] = schema
-
-  def withExampleTagged[A](
-      schema: Tagged[A],
-      example: A
-  ): Tagged[A] = schema
-
-  def withExampleEnum[A](
-      schema: Enum[A],
-      example: A
-  ): Enum[A] = schema
-
-  def withExampleJsonSchema[A](
-      schema: JsonSchema[A],
-      example: A
-  ): JsonSchema[A] = schema
-
-  def withDescriptionRecord[A](
-      schema: Record[A],
-      description: String
-  ): Record[A] = schema
-
-  def withDescriptionTagged[A](
-      schema: Tagged[A],
-      description: String
-  ): Tagged[A] = schema
-
-  def withDescriptionEnum[A](
-      schema: Enum[A],
-      description: String
-  ): Enum[A] = schema
-
-  def withDescriptionJsonSchema[A](
-      schema: JsonSchema[A],
-      description: String
-  ): JsonSchema[A] = schema
-
-  def withTitleRecord[A](
-      schema: Record[A],
-      title: String
-  ): Record[A] = schema
-
-  def withTitleTagged[A](
-      schema: Tagged[A],
-      title: String
-  ): Tagged[A] = schema
-
-  def withTitleEnum[A](
-      schema: Enum[A],
-      title: String
-  ): Enum[A] = schema
-
-  def withTitleJsonSchema[A](
-      schema: JsonSchema[A],
-      title: String
-  ): JsonSchema[A] = schema
 
   def orFallbackToJsonSchema[A, B](
       schemaA: JsonSchema[A],

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/NoDocsJsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/NoDocsJsonSchemas.scala
@@ -1,0 +1,54 @@
+package endpoints.algebra
+
+/**
+  * Helper trait that can be mixed into [[JsonSchemas]] to implement (as no-ops)
+  * the documentation related methods. This is useful for implementing any
+  * non-documentation inteprereters.
+  */
+trait NoDocsJsonSchemas extends JsonSchemas {
+
+  def namedRecord[A](record: Record[A], name: String): Record[A] = record
+
+  def namedTagged[A](tagged: Tagged[A], name: String): Tagged[A] = tagged
+
+  def namedEnum[A](enum: Enum[A], name: String): Enum[A] = enum
+
+  def withExampleRecord[A](record: Record[A], example: A): Record[A] = record
+
+  def withExampleTagged[A](tagged: Tagged[A], example: A): Tagged[A] = tagged
+
+  def withExampleEnum[A](enum: Enum[A], example: A): Enum[A] = enum
+
+  def withExampleJsonSchema[A](
+      schema: JsonSchema[A],
+      example: A
+  ): JsonSchema[A] = schema
+
+  def withDescriptionRecord[A](
+      record: Record[A],
+      description: String
+  ): Record[A] = record
+
+  def withDescriptionTagged[A](
+      tagged: Tagged[A],
+      description: String
+  ): Tagged[A] = tagged
+
+  def withDescriptionEnum[A](enum: Enum[A], description: String): Enum[A] = enum
+
+  def withDescriptionJsonSchema[A](
+      schema: JsonSchema[A],
+      description: String
+  ): JsonSchema[A] = schema
+
+  def withTitleRecord[A](record: Record[A], title: String): Record[A] = record
+
+  def withTitleTagged[A](tagged: Tagged[A], title: String): Tagged[A] = tagged
+
+  def withTitleEnum[A](enum: Enum[A], title: String): Enum[A] = enum
+
+  def withTitleJsonSchema[A](
+      schema: JsonSchema[A],
+      title: String
+  ): JsonSchema[A] = schema
+}

--- a/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/ujson/JsonSchemas.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
 /**
   * @group interpreters
   */
-trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
+trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
 
   trait JsonSchema[A] {
 
@@ -121,12 +121,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       }
       val encoder = tpe.encoder
     }
-
-  def namedRecord[A](schema: Record[A], name: String): Record[A] = schema
-
-  def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] = schema
-
-  def namedEnum[A](schema: Enum[A], name: String): Enum[A] = schema
 
   def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
     new JsonSchema[A] {
@@ -237,66 +231,6 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         }
       }
     }
-
-  def withExampleRecord[A](
-      schema: Record[A],
-      example: A
-  ): Record[A] = schema
-
-  def withExampleTagged[A](
-      schema: Tagged[A],
-      example: A
-  ): Tagged[A] = schema
-
-  def withExampleEnum[A](
-      schema: Enum[A],
-      example: A
-  ): Enum[A] = schema
-
-  def withExampleJsonSchema[A](
-      schema: JsonSchema[A],
-      example: A
-  ): JsonSchema[A] = schema
-
-  def withDescriptionRecord[A](
-      schema: Record[A],
-      description: String
-  ): Record[A] = schema
-
-  def withDescriptionTagged[A](
-      schema: Tagged[A],
-      description: String
-  ): Tagged[A] = schema
-
-  def withDescriptionEnum[A](
-      schema: Enum[A],
-      description: String
-  ): Enum[A] = schema
-
-  def withDescriptionJsonSchema[A](
-      schema: JsonSchema[A],
-      description: String
-  ): JsonSchema[A] = schema
-
-  def withTitleRecord[A](
-      schema: Record[A],
-      title: String
-  ): Record[A] = schema
-
-  def withTitleTagged[A](
-      schema: Tagged[A],
-      title: String
-  ): Tagged[A] = schema
-
-  def withTitleEnum[A](
-      schema: Enum[A],
-      title: String
-  ): Enum[A] = schema
-
-  def withTitleJsonSchema[A](
-      schema: JsonSchema[A],
-      title: String
-  ): JsonSchema[A] = schema
 
   def orFallbackToJsonSchema[A, B](
       schemaA: JsonSchema[A],


### PR DESCRIPTION
The new `NoDocsJsonSchemas` trait implements all the documentation
related methods of `JsonSchemas` as no-ops. This reduces the boilerplate
in decoder inteprereters: they can mix in `algebra.NoDocsJsonSchemas`
instead of having to implement a bunch of pass-through documentation
methods.

This factors out a good chunk of common code in the Circe, Play, and
Ujson interpreters.

Fixes #514.