### PR TITLE
Add `xmapWithCodec` variant of `xmapPartial`

### DIFF
--- a/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Urls.scala
@@ -158,15 +158,6 @@ trait Urls extends PartialInvariantFunctorSyntax {
   implicit def queryStringParamPartialInvariantFunctor
       : PartialInvariantFunctor[QueryStringParam]
 
-  def tryParseString[A](
-      `type`: String
-  )(parse: String => A): String => Validated[A] =
-    s =>
-      Try(parse(s)) match {
-        case Failure(_) => Invalid(s"Invalid ${`type`} value '$s'")
-        case Success(a) => Valid(a)
-      }
-
   /** Ability to define `String` query string parameters
     * @group operations */
   implicit def stringQueryString: QueryStringParam[String]
@@ -174,39 +165,27 @@ trait Urls extends PartialInvariantFunctorSyntax {
   /** Ability to define `UUID` query string parameters
     * @group operations */
   implicit def uuidQueryString: QueryStringParam[UUID] =
-    stringQueryString.xmapPartial(tryParseString("UUID")(UUID.fromString))(
-      _.toString()
-    )
+    stringQueryString.xmapWithCodec(Codec.uuidCodec)
 
   /** Ability to define `Int` query string parameters
     * @group operations */
   implicit def intQueryString: QueryStringParam[Int] =
-    stringQueryString.xmapPartial(tryParseString("integer")(_.toInt))(
-      _.toString()
-    )
+    stringQueryString.xmapWithCodec(Codec.intCodec)
 
   /** Query string parameter containing a `Long` value
     * @group operations */
   implicit def longQueryString: QueryStringParam[Long] =
-    stringQueryString.xmapPartial(tryParseString("integer")(_.toLong))(
-      _.toString()
-    )
+    stringQueryString.xmapWithCodec(Codec.longCodec)
 
   /** Query string parameter containing a `Boolean` value
     * @group operations */
   implicit def booleanQueryString: QueryStringParam[Boolean] =
-    stringQueryString.xmapPartial[Boolean] {
-      case "true" | "1"  => Valid(true)
-      case "false" | "0" => Valid(false)
-      case s             => Invalid(s"Invalid boolean value '$s'")
-    }(_.toString())
+    stringQueryString.xmapWithCodec(Codec.booleanCodec)
 
   /** Codec for query string parameters of type `Double`
     * @group operations */
   implicit def doubleQueryString: QueryStringParam[Double] =
-    stringQueryString.xmapPartial(tryParseString("number")(_.toDouble))(
-      _.toString()
-    )
+    stringQueryString.xmapWithCodec(Codec.doubleCodec)
 
   /**
     * An URL path segment codec for type `A`.
@@ -230,28 +209,24 @@ trait Urls extends PartialInvariantFunctorSyntax {
   /** Ability to define `UUID` path segments
     * @group operations */
   implicit def uuidSegment: Segment[UUID] =
-    stringSegment.xmapPartial(tryParseString("UUID")(UUID.fromString))(
-      _.toString()
-    )
+    stringSegment.xmapWithCodec(Codec.uuidCodec)
 
   /** Ability to define `Int` path segments
     * @group operations */
   implicit def intSegment: Segment[Int] =
-    stringSegment.xmapPartial(tryParseString("integer")(_.toInt))(_.toString())
+    stringSegment.xmapWithCodec(Codec.intCodec)
 
   /** Segment containing a `Long` value
     * @group operations */
   implicit def longSegment: Segment[Long] =
-    stringSegment.xmapPartial(tryParseString("integer")(_.toLong))(_.toString())
+    stringSegment.xmapWithCodec(Codec.longCodec)
 
   /**
     * Segment codec for type `Double`
     * @group operations
     */
   implicit def doubleSegment: Segment[Double] =
-    stringSegment.xmapPartial(tryParseString("number")(_.toDouble))(
-      _.toString()
-    )
+    stringSegment.xmapWithCodec(Codec.doubleCodec)
 
   /** An URL path carrying an `A` information
     * @note  This type has implicit methods provided by the [[PathOps]],

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -93,12 +93,13 @@ trait EndpointsTestApi extends algebra.Endpoints {
   )
 
   val dateTimeFormatter = DateTimeFormatter.ISO_DATE
-  val reqBody1 =
-    textRequest.xmapPartial(s =>
-      Validated
-        .fromTry(Try(LocalDate.parse(s, dateTimeFormatter)))
-        .mapErrors(_ => Seq(s"Invalid date: $s"))
-    )(d => dateTimeFormatter.format(d))
+  val reqBody1 = textRequest.xmapWithCodec(
+    Codec.tryParseString(
+      `type` = "date",
+      parse = LocalDate.parse(_, dateTimeFormatter),
+      print = dateTimeFormatter.format(_)
+    )
+  )
   val xmapReqBodyEndpoint = endpoint(
     post(path / "xmapReqBodyEndpoint", reqBody1),
     ok(textResponse)

--- a/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/EndpointsTestApi.scala
@@ -94,7 +94,7 @@ trait EndpointsTestApi extends algebra.Endpoints {
 
   val dateTimeFormatter = DateTimeFormatter.ISO_DATE
   val reqBody1 = textRequest.xmapWithCodec(
-    Codec.tryParseString(
+    Codec.parseStringCatchingExceptions(
       `type` = "date",
       parse = LocalDate.parse(_, dateTimeFormatter),
       print = dateTimeFormatter.format(_)

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/EndpointsTestSuite.scala
@@ -509,7 +509,7 @@ trait EndpointsTestSuite[T <: endpoints.algebra.EndpointsTestApi]
         whenReady(sendAndDecodeEntityAsText(invalidRequest)) {
           case (response, entity) =>
             assert(response.status == StatusCodes.BadRequest)
-            assert(entity == """["Invalid date: not a date"]""")
+            assert(entity == """["Invalid date value 'not a date'"]""")
         }
       }
     }

--- a/json-schema/json-schema/src/main/scala/endpoints/InvariantFunctor.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/InvariantFunctor.scala
@@ -49,6 +49,17 @@ trait PartialInvariantFunctor[F[_]] extends InvariantFunctor[F] {
     * @see [[http://julienrf.github.io/endpoints/algebras/endpoints.html#transforming-and-refining-url-constituents Some examples]]
     */
   def xmapPartial[A, B](fa: F[A], f: A => Validated[B], g: B => A): F[B]
+
+  /**
+    * Transforms an `F[A]` value into an `F[B]` value given a `Codec[A, B]`.
+    *
+    * This is useful to ''refine'' the type `A` into a possibly smaller type `B`.
+    *
+    * @see [[http://julienrf.github.io/endpoints/algebras/endpoints.html#transforming-and-refining-url-constituents Some examples]]
+    */
+  final def xmapWithCodec[A, B](fa: F[A], codec: algebra.Codec[A, B]): F[B] =
+    xmapPartial(fa, codec.decode, codec.encode)
+
   def xmap[A, B](fa: F[A], f: A => B, g: B => A): F[B] =
     xmapPartial[A, B](fa, a => Valid(f(a)), g)
 }
@@ -68,5 +79,15 @@ trait PartialInvariantFunctorSyntax extends InvariantFunctorSyntax {
       */
     def xmapPartial[B](f: A => Validated[B])(g: B => A): F[B] =
       ev.xmapPartial(fa, f, g)
+
+    /**
+      * Transforms an `F[A]` value into an `F[B]` value given a `Codec[A, B]`.
+      *
+      * This is useful to ''refine'' the type `A` into a possibly smaller type `B`.
+      *
+      * @see [[http://julienrf.github.io/endpoints/algebras/endpoints.html#transforming-and-refining-url-constituents Some examples]]
+      */
+    def xmapWithCodec[B](codec: algebra.Codec[A, B]): F[B] =
+      ev.xmapWithCodec(fa, codec)
   }
 }


### PR DESCRIPTION
This variant takes a `Codec` instead of two functions. This is
accompanied with a couple other smaller changes that seemed natural:

  * `Codec` is moved into `json-schema` (so that `xmapWithCodec` can be
    defined in the `PartialInvariantFunctor` trait)

  * the UUID/Int/Long/Double/Boolean for query strings and segments are
    now defined using `xmapWithCodec` and a shared set of codecs

  * added a `tryParseString` method to the `Codec` companion object for
    easily producing a `Codec[String, A]` given parsing/printing
    functions and use this to create UUID/Int/Long/Double/Boolean
    codecs.

Supersedes #535 
Fixes #528