### PR TITLE
Add `plainTextRequest` and clarify `textRequest`

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -134,6 +134,8 @@ trait EndpointsWithCustomErrors
   lazy val textRequest: (String, HttpRequest) => HttpRequest =
     (body, request) => request.copy(entity = HttpEntity(body))
 
+  lazy val plainTextRequest = textRequest
+
   def request[A, B, C, AB, Out](
       method: Method,
       url: Url[A],

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.marshalling.{
   ToResponseMarshaller
 }
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpEntity, HttpHeader}
+import akka.http.scaladsl.model.{HttpEntity, HttpHeader, MediaTypes}
 import akka.http.scaladsl.server.{
   Directive1,
   Directives,
@@ -117,6 +117,13 @@ trait EndpointsWithCustomErrors
   def textRequest: RequestEntity[String] = {
     val um: FromRequestUnmarshaller[String] = implicitly
     Directives.entity[String](um)
+  }
+
+  def plainTextRequest: RequestEntity[String] = {
+    implicit val um: FromEntityUnmarshaller[String] =
+      Unmarshaller.stringUnmarshaller
+        .forContentTypes(MediaTypes.`text/plain`)
+    Directives.entity[String](implicitly)
   }
 
   implicit lazy val requestEntityPartialInvariantFunctor

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
@@ -10,7 +10,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 /* defines the common api to implement */
-trait EndpointsTestApi extends Endpoints with algebra.EndpointsTestApi
+trait EndpointsTestApi
+    extends Endpoints
+    with algebra.EndpointsTestApi
+    with algebra.TextEntitiesTestApi
 
 /* implements the endpoint using an akka-based custom json handling */
 class EndpointsEntitiesTestApi extends EndpointsTestApi with JsonEntities

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterTest.scala
@@ -23,6 +23,7 @@ class ServerInterpreterTest
     extends algebra.server.EndpointsTestSuite[EndpointsCodecsTestApi]
     with algebra.server.BasicAuthenticationTestSuite[EndpointsCodecsTestApi]
     with algebra.server.ChunkedJsonEntitiesTestSuite[EndpointsCodecsTestApi]
+    with algebra.server.TextEntitiesTestSuite[EndpointsCodecsTestApi]
     with ScalatestRouteTest {
 
   val serverApi = new EndpointsCodecsTestApi
@@ -50,6 +51,11 @@ class ServerInterpreterTest
       response: => Resp
   )(runTests: Int => Unit): Unit =
     serveRoute(endpoint.implementedBy(_ => response))(runTests)
+
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit =
+    serveRoute(endpoint.implementedBy(request => request))(runTests)
 
   def serveStreamedEndpoint[Resp](
       endpoint: serverApi.Endpoint[_, serverApi.Chunks[Resp]],

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -112,9 +112,35 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
 
   /**
     * Request with a `String` body.
+    *
+    *   - Server interpreters are expected to be permissive and accept multiple
+    *     content types (not just `text/plain`) using the charset defined in the
+    *     `Content-Type` header to decide how to decode the body. If no charset
+    *     is defined (or if there is no `Content-Type` header) the interpreters
+    *     are free to define their own defaults for decoding.
+    *
+    *   - Client interpreters produce an HTTP request with a `text/plain` content type.
+    *
+    * @see [[plainTextRequest]] if you want to avoid accepting any content type
     * @group operations
     */
   def textRequest: RequestEntity[String]
+
+  /**
+    * Request with content-type `text/plain`
+    *
+    *   - Server interpreters raise an error if the incoming request entity does
+    *     not have the right content type. By default, they produce a Bad Request (400)
+    *     response with a list of error messages in a JSON array. Refer to the documentation
+    *     of your server interpreter to customize this behavior.
+    *
+    *   - Client interpreters produce an HTTP request with a `text/plain` content type.
+    *
+    * @see [[textRequest]] for a more permissive text request entity.
+    *
+    * @group operations
+    */
+  def plainTextRequest: RequestEntity[String]
 
   /**
     * Request for given parameters

--- a/algebras/algebra/src/test/scala/endpoints/algebra/TextEntitiesTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/TextEntitiesTestApi.scala
@@ -1,0 +1,16 @@
+package endpoints.algebra
+
+trait TextEntitiesTestApi extends EndpointsTestApi {
+
+  val textRequestEndpointTest: Endpoint[String, String] =
+    endpoint(
+      post(path / "text", textRequest),
+      ok(textResponse)
+    )
+
+  val plainTextRequestEndpointTest: Endpoint[String, String] =
+    endpoint(
+      post(path / "plaintext", plainTextRequest),
+      ok(textResponse)
+    )
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/ServerTestBase.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/ServerTestBase.scala
@@ -46,6 +46,14 @@ trait ServerTestBase[T <: algebra.Endpoints]
       response: => Resp
   )(runTests: Int => Unit): Unit
 
+  /**
+    * @param runTests A function that is called after the server is started and before it is stopped. It takes
+    *                 the TCP port number as parameter.
+    */
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit
+
   private[server] implicit val actorSystem: ActorSystem = ActorSystem()
   implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/TextEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/TextEntitiesTestSuite.scala
@@ -1,0 +1,306 @@
+package endpoints.algebra.server
+
+import akka.util.ByteString
+import endpoints.algebra.TextEntitiesTestApi
+import akka.http.scaladsl.model.{
+  HttpMethods,
+  HttpEntity,
+  HttpRequest,
+  HttpCharsets,
+  ContentTypes,
+  MediaTypes
+}
+
+trait TextEntitiesTestSuite[T <: TextEntitiesTestApi]
+    extends ServerTestBase[T] {
+
+  "TextEntities" should {
+    "be forgiving when expecting any text" in {
+      serveIdentityEndpoint(serverApi.textRequestEndpointTest) { port =>
+        // ContentType: text/plain; charset=UTF-8
+        // Request entity is valid UTF-8
+        val request1 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Oekraïene")
+        )
+        whenReady(send(request1)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(decodeEntityAsText(response, entity) == "Oekraïene")
+        }
+
+        // ContentType: text/plain; charset=UTF-16
+        // Request entity is valid UTF-16
+        val request2 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            MediaTypes.`text/plain`.withCharset(HttpCharsets.`UTF-16`),
+            "Oekraïene"
+          )
+        )
+        whenReady(send(request2)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(decodeEntityAsText(response, entity) == "Oekraïene")
+        }
+
+        // ContentType: application/javascript; charset=UTF-8
+        // Request entity is valid UTF-8 encoded JS string
+        val request3 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            MediaTypes.`application/javascript`
+              .withCharset(HttpCharsets.`UTF-8`),
+            "var x = 'Oekraïene'"
+          )
+        )
+        whenReady(send(request3)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(
+              decodeEntityAsText(response, entity) == "var x = 'Oekraïene'"
+            )
+        }
+
+        // ContentType: application/javascript; charset=UTF-16
+        // Request entity is valid UTF-16 encoded JS string
+        val request4 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            MediaTypes.`application/javascript`
+              .withCharset(HttpCharsets.`UTF-16`),
+            "var x = 'Oekraïene'"
+          )
+        )
+        whenReady(send(request4)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(
+              decodeEntityAsText(response, entity) == "var x = 'Oekraïene'"
+            )
+        }
+
+        // No ContentType header
+        // Request entity is valid UTF-8
+        val request5 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          // TODO: switch this back to `Oekraïene` - the leading UTF-8 character is a
+          // workaround to avoid https://github.com/playframework/playframework/issues/10181
+          entity =
+            HttpEntity(ContentTypes.NoContentType, ByteString("Øekraïene"))
+        )
+        whenReady(send(request5)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(decodeEntityAsText(response, entity) == "Øekraïene")
+        }
+
+        // No ContentType header
+        // Request entity is random bytes (not valid UTF-8 encoded string)
+        val request6 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            ContentTypes.NoContentType,
+            Array[Byte](0x00.toByte, 0xA0.toByte, 0xBF.toByte)
+          )
+        )
+        whenReady(send(request6)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+        }
+
+        // ContentType: application/octet-stream
+        // Request entity is valid UTF-8
+        val request7 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          // TODO: switch this back to `Oekraïene` - the leading UTF-8 character is a
+          // workaround to avoid https://github.com/playframework/playframework/issues/10181
+          entity = HttpEntity(
+            ContentTypes.`application/octet-stream`,
+            ByteString("Øekraïene")
+          )
+        )
+        whenReady(send(request7)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(decodeEntityAsText(response, entity) == "Øekraïene")
+        }
+
+        // ContentType: application/octet-stream
+        // Request entity is random bytes (not valid UTF-8 encoded string)
+        val request8 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            ContentTypes.`application/octet-stream`,
+            Array[Byte](0x00.toByte, 0xA0.toByte, 0xBF.toByte)
+          )
+        )
+        whenReady(send(request8)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+        }
+      }
+    }
+
+    "be strict when expecting plain text" in {
+      serveIdentityEndpoint(serverApi.plainTextRequestEndpointTest) { port =>
+        // ContentType: text/plain; charset=UTF-8
+        // Request entity is valid UTF-8
+        val request1 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Oekraïene")
+        )
+        whenReady(send(request1)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(decodeEntityAsText(response, entity) == "Oekraïene")
+        }
+
+        // ContentType: text/plain; charset=UTF-16
+        // Request entity is valid UTF-16
+        val request2 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(
+            MediaTypes.`text/plain`.withCharset(HttpCharsets.`UTF-16`),
+            "Oekraïene"
+          )
+        )
+        whenReady(send(request2)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(decodeEntityAsText(response, entity) == "Oekraïene")
+        }
+
+        // ContentType: application/javascript; charset=UTF-8
+        // Request entity is valid UTF-8 encoded JS string
+        val request3 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(
+            MediaTypes.`application/javascript`
+              .withCharset(HttpCharsets.`UTF-8`),
+            "var x = 'Oekraïene'"
+          )
+        )
+        whenReady(send(request3)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+
+        // ContentType: application/javascript; charset=UTF-16
+        // Request entity is valid UTF-16 encoded JS string
+        val request4 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(
+            MediaTypes.`application/javascript`
+              .withCharset(HttpCharsets.`UTF-16`),
+            "var x = 'Oekraïene'"
+          )
+        )
+        whenReady(send(request4)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+
+        // No ContentType header
+        // Request entity is valid UTF-8
+        val request5 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity =
+            HttpEntity(ContentTypes.NoContentType, ByteString("Oekraïene"))
+        )
+        whenReady(send(request5)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+
+        // No ContentType header
+        // Request entity is random bytes (not valid UTF-8 encoded string)
+        val request6 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(
+            ContentTypes.NoContentType,
+            Array[Byte](0x00.toByte, 0xA0.toByte, 0xBF.toByte)
+          )
+        )
+        whenReady(send(request6)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+
+        // ContentType: application/octet-stream
+        // Request entity is valid UTF-8
+        val request7 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(
+            ContentTypes.`application/octet-stream`,
+            ByteString("Oekraïene")
+          )
+        )
+        whenReady(send(request7)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+
+        // ContentType: application/octet-stream
+        // Request entity is random bytes (not valid UTF-8 encoded string)
+        val request8 = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/plaintext",
+          entity = HttpEntity(
+            ContentTypes.`application/octet-stream`,
+            Array[Byte](0x00.toByte, 0xA0.toByte, 0xBF.toByte)
+          )
+        )
+        whenReady(send(request8)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+      }
+    }
+  }
+}

--- a/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
@@ -10,3 +10,4 @@ class EndpointsTestApi
     with algebra.EndpointsTestApi
     with algebra.BasicAuthenticationTestApi
     with algebra.JsonEntitiesFromSchemasTestApi
+    with algebra.TextEntitiesTestApi

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -43,6 +43,10 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
   lazy val emptyRequest = Map.empty[String, MediaType]
 
   lazy val textRequest = Map(
+    "*/*" -> MediaType(Some(Schema.simpleString))
+  )
+
+  lazy val plainTextRequest = Map(
     "text/plain" -> MediaType(Some(Schema.simpleString))
   )
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/EndpointsTest.scala
@@ -157,7 +157,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
     }
   }
 
-  "Text response" should {
+  "Text request" should {
     "be properly encoded" in {
       val reqBody = Fixtures.documentation
         .paths("/textRequestEndpoint")
@@ -166,6 +166,20 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
 
       reqBody shouldBe defined
       reqBody.value.description.value shouldEqual "Text Req"
+      reqBody.value.content("*/*").schema.value shouldEqual Schema
+        .Primitive("string", None, None, None, None)
+    }
+  }
+
+  "Plain text request" should {
+    "be properly encoded" in {
+      val reqBody = Fixtures.documentation
+        .paths("/plainTextRequestEndpoint")
+        .operations("post")
+        .requestBody
+
+      reqBody shouldBe defined
+      reqBody.value.description.value shouldEqual "Plain Text Req"
       reqBody.value.content("text/plain").schema.value shouldEqual Schema
         .Primitive("string", None, None, None, None)
     }
@@ -320,6 +334,16 @@ trait Fixtures extends algebra.Endpoints with algebra.ChunkedEntities {
     docs = EndpointDocs(deprecated = true)
   )
 
+  val plainTextRequestEndp = endpoint(
+    post(
+      path / "plainTextRequestEndpoint",
+      plainTextRequest,
+      docs = Some("Plain Text Req")
+    ),
+    ok(emptyResponse),
+    docs = EndpointDocs(deprecated = true)
+  )
+
   val emptySegmentNameEndp = endpoint(
     post(
       path / "emptySegmentNameEndp" / segment[Int]() / "x" / segment[String](),
@@ -375,6 +399,7 @@ object Fixtures
       bar,
       baz,
       textRequestEndp,
+      plainTextRequestEndp,
       emptySegmentNameEndp,
       quux,
       assets,

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -123,6 +123,8 @@ trait EndpointsWithCustomErrors
   lazy val textRequest: (String, WSRequest) => WSRequest =
     (body, req) => req.withBody(body)
 
+  lazy val plainTextRequest: (String, WSRequest) => WSRequest = textRequest
+
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -216,7 +216,11 @@ trait EndpointsWithCustomErrors
   lazy val emptyRequest: BodyParser[Unit] =
     BodyParser(_ => Accumulator.done(Right(())))
 
-  lazy val textRequest: BodyParser[String] = playComponents.playBodyParsers.text
+  lazy val textRequest: BodyParser[String] =
+    playComponents.playBodyParsers.tolerantText
+
+  lazy val plainTextRequest: BodyParser[String] =
+    playComponents.playBodyParsers.text
 
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =

--- a/play/server/src/test/scala/endpoints/play/server/EndpointsTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/EndpointsTest.scala
@@ -15,6 +15,7 @@ class EndpointsTestApi(
     with algebra.BasicAuthenticationTestApi
     with algebra.EndpointsTestApi
     with algebra.JsonFromCodecTestApi
+    with algebra.TextEntitiesTestApi
     with algebra.Assets
     with JsonFromCirceCodecTestApi
     with algebra.circe.ChunkedJsonEntitiesTestApi

--- a/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
@@ -8,7 +8,8 @@ import endpoints.algebra.server.{
   BasicAuthenticationTestSuite,
   DecodedUrl,
   EndpointsTestSuite,
-  ChunkedJsonEntitiesTestSuite
+  ChunkedJsonEntitiesTestSuite,
+  TextEntitiesTestSuite
 }
 import play.api.Mode
 import play.api.routing.Router
@@ -24,7 +25,8 @@ import scala.concurrent.Future
 class ServerInterpreterTest
     extends EndpointsTestSuite[EndpointsTestApi]
     with BasicAuthenticationTestSuite[EndpointsTestApi]
-    with ChunkedJsonEntitiesTestSuite[EndpointsTestApi] {
+    with ChunkedJsonEntitiesTestSuite[EndpointsTestApi]
+    with TextEntitiesTestSuite[EndpointsTestApi] {
 
   val serverApi: EndpointsTestApi = {
     object NettyServerComponents extends DefaultNettyServerComponents {
@@ -43,6 +45,13 @@ class ServerInterpreterTest
   )(runTests: Int => Unit): Unit =
     serveRoutes(
       serverApi.routesFromEndpoints(endpoint.implementedBy(_ => response))
+    )(runTests)
+
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit =
+    serveRoutes(
+      serverApi.routesFromEndpoints(endpoint.implementedBy(request => request))
     )(runTests)
 
   def serveStreamedEndpoint[Resp](

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -73,6 +73,8 @@ trait Requests extends algebra.Requests with Urls with Methods {
   def textRequest: (String, HttpRequest) => scalaj.http.HttpRequest =
     (body, req) => req.postData(body)
 
+  def plainTextRequest = textRequest
+
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -127,6 +127,8 @@ trait EndpointsWithCustomErrors[R[_]]
     case (bodyValue, request) => request.body(bodyValue)
   }
 
+  lazy val plainTextRequest: RequestEntity[String] = textRequest
+
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -132,6 +132,8 @@ trait EndpointsWithCustomErrors
     body
   }
 
+  lazy val plainTextRequest: RequestEntity[String] = textRequest
+
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {


### PR DESCRIPTION
The newly added `plainTextRequest` is a request that must have type
`text/plain`. The semantics of `textRequest` have also been clarfied.
The important bits are:

  * it can have any content type
  * if the content-type specifies some charset, that charset gets used

The server implementations of `textRequest` have been adjusted to all
match these semantics - it turned out that the servers were all doing
different things!

  * Akka-HTTP was doing the "right" thing
  * http4s was always decoding the body as UTF-8, regardless of charset
  * Play was not accepting content-types different that `text/plain`

The server semantics of `testRequest`/`plainTextRequest` are tested in
the new `TextEntities` test suite.

Fixes #534