### PR TITLE
Use and set `Content-Type` header uniformly

### DIFF
--- a/akka-http/client/src/test/scala/endpoints/akkahttp/client/AkkaHttpClientEndpointsTest.scala
+++ b/akka-http/client/src/test/scala/endpoints/akkahttp/client/AkkaHttpClientEndpointsTest.scala
@@ -17,6 +17,7 @@ class TestClient(settings: EndpointsSettings)(
     with BasicAuthentication
     with algebra.EndpointsTestApi
     with algebra.BasicAuthenticationTestApi
+    with algebra.TextEntitiesTestApi
     with algebra.JsonFromCodecTestApi
     with algebra.circe.JsonFromCirceCodecTestApi
     with JsonEntitiesFromCodecs
@@ -29,6 +30,7 @@ class AkkaHttpClientEndpointsTest
     extends algebra.client.EndpointsTestSuite[TestClient]
     with algebra.client.BasicAuthTestSuite[TestClient]
     with algebra.client.JsonFromCodecTestSuite[TestClient]
+    with algebra.client.TextEntitiesTestSuite[TestClient]
     with algebra.client.ChunkedJsonEntitiesTestSuite[TestClient] {
 
   implicit val system = ActorSystem()
@@ -74,6 +76,7 @@ class AkkaHttpClientEndpointsTest
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  textEntitiesTestSuite()
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.marshalling.{
   ToResponseMarshaller
 }
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpEntity, HttpHeader}
+import akka.http.scaladsl.model.{HttpEntity, HttpHeader, MediaTypes}
 import akka.http.scaladsl.server.{
   Directive1,
   Directives,
@@ -115,8 +115,10 @@ trait EndpointsWithCustomErrors
   def emptyRequest: RequestEntity[Unit] = convToDirective1(Directives.pass)
 
   def textRequest: RequestEntity[String] = {
-    val um: FromRequestUnmarshaller[String] = implicitly
-    Directives.entity[String](um)
+    implicit val um: FromEntityUnmarshaller[String] =
+      Unmarshaller.stringUnmarshaller
+        .forContentTypes(MediaTypes.`text/plain`)
+    Directives.entity[String](implicitly)
   }
 
   implicit lazy val requestEntityPartialInvariantFunctor

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsTest.scala
@@ -10,7 +10,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 /* defines the common api to implement */
-trait EndpointsTestApi extends Endpoints with algebra.EndpointsTestApi
+trait EndpointsTestApi
+    extends Endpoints
+    with algebra.EndpointsTestApi
+    with algebra.TextEntitiesTestApi
 
 /* implements the endpoint using an akka-based custom json handling */
 class EndpointsEntitiesTestApi extends EndpointsTestApi with JsonEntities

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterTest.scala
@@ -23,6 +23,7 @@ class ServerInterpreterTest
     extends algebra.server.EndpointsTestSuite[EndpointsCodecsTestApi]
     with algebra.server.BasicAuthenticationTestSuite[EndpointsCodecsTestApi]
     with algebra.server.ChunkedJsonEntitiesTestSuite[EndpointsCodecsTestApi]
+    with algebra.server.TextEntitiesTestSuite[EndpointsCodecsTestApi]
     with ScalatestRouteTest {
 
   val serverApi = new EndpointsCodecsTestApi
@@ -50,6 +51,11 @@ class ServerInterpreterTest
       response: => Resp
   )(runTests: Int => Unit): Unit =
     serveRoute(endpoint.implementedBy(_ => response))(runTests)
+
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit =
+    serveRoute(endpoint.implementedBy(request => request))(runTests)
 
   def serveStreamedEndpoint[Resp](
       endpoint: serverApi.Endpoint[_, serverApi.Chunks[Resp]],

--- a/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/JsonEntities.scala
@@ -28,8 +28,15 @@ trait JsonEntities extends EndpointsWithCustomErrors {
     * @group types */
   type JsonResponse[A]
 
-  /** Defines a `RequestEntity[A]` given an implicit `JsonRequest[A]`
-    * @group operations */
+  /**
+    * Request with a JSON body, given an implicit `JsonRequest[A]`
+    *
+    *   - Server interpreters accept requests with content-type `application/json` and
+    *     reject requests with an incorrect content-type.
+    *   - Client interpreters supply content-type `application/json`
+    *
+    * @group operations
+    */
   def jsonRequest[A: JsonRequest]: RequestEntity[A]
 
   /** Defines a `Response[A]` given an implicit `JsonResponse[A]`

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -113,6 +113,14 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
 
   /**
     * Request with a `String` body.
+    *
+    *   - Server interpreters accept requests with content-type `text/plain` and
+    *     reject requests with an incorrect content-type.
+    *   - Server interpreters will use the character encoding set in the
+    *     content-type header to determine how the text is decoded.
+    *   - Client interpreters supply content-type `text/plain` with an explicit
+    *     character encoding
+    *
     * @group operations
     */
   def textRequest: RequestEntity[String]

--- a/algebras/algebra/src/test/scala/endpoints/algebra/TextEntitiesTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/TextEntitiesTestApi.scala
@@ -1,0 +1,10 @@
+package endpoints.algebra
+
+trait TextEntitiesTestApi extends EndpointsTestApi {
+
+  val textRequestEndpointTest: Endpoint[String, String] =
+    endpoint(
+      post(path / "text", textRequest),
+      ok(textResponse)
+    )
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/JsonTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/JsonTestSuite.scala
@@ -17,6 +17,7 @@ trait JsonTestSuite[T <: JsonTestApi] extends ClientTestBase[T] {
         val addressStr = """{"street":"avenue1","city":"NY"}"""
         wireMockServer.stubFor(
           post(urlEqualTo("/user"))
+            .withHeader("Content-Type", containing("application/json"))
             .withRequestBody(equalToJson(userStr))
             .willReturn(
               aResponse()

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/TextEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/TextEntitiesTestSuite.scala
@@ -1,0 +1,34 @@
+package endpoints.algebra.client
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import endpoints.algebra.TextEntitiesTestApi
+
+trait TextEntitiesTestSuite[T <: TextEntitiesTestApi]
+    extends ClientTestBase[T] {
+
+  def textEntitiesTestSuite() = {
+
+    "TextEntities" should {
+      "produce `text/plain` requests with an explicit encoding" in {
+
+        val utf8String = "Oekraïene"
+
+        wireMockServer.stubFor(
+          post(urlEqualTo("/text"))
+            .withHeader("Content-Type", containing("text/plain"))
+            .withHeader("Content-Type", containing("charset"))
+            .withRequestBody(equalTo(utf8String))
+            .willReturn(
+              aResponse()
+                .withStatus(200)
+                .withBody(utf8String)
+            )
+        )
+
+        whenReady(call(client.textRequestEndpointTest, utf8String))(
+          _ shouldEqual utf8String
+        )
+      }
+    }
+  }
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/JsonEntitiesFromSchemasTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/JsonEntitiesFromSchemasTestSuite.scala
@@ -96,6 +96,20 @@ trait JsonEntitiesFromSchemasTestSuite[
             )
         }
 
+        // Valid URL and invalid entity (3)
+        whenReady(
+          sendAndDecodeEntityAsText(
+            HttpRequest(HttpMethods.PUT, s"http://localhost:$port/user/42")
+              .withEntity(
+                ContentTypes.`text/plain(UTF-8)`,
+                "{\"name\":\"Alice\",\"age\":55}"
+              )
+          )
+        ) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+        }
+
         // Valid URL and entity
         whenReady(
           sendAndDecodeEntityAsText(
@@ -107,6 +121,9 @@ trait JsonEntitiesFromSchemasTestSuite[
         ) {
           case (response, entity) =>
             assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType == ContentTypes.`application/json`
+            )
             ujson.read(entity) shouldBe ujson.Obj(
               "name" -> ujson.Str("Alice"),
               "age" -> ujson.Num(55)

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/ServerTestBase.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/ServerTestBase.scala
@@ -46,6 +46,14 @@ trait ServerTestBase[T <: algebra.Endpoints]
       response: => Resp
   )(runTests: Int => Unit): Unit
 
+  /**
+    * @param runTests A function that is called after the server is started and before it is stopped. It takes
+    *                 the TCP port number as parameter.
+    */
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit
+
   private[server] implicit val actorSystem: ActorSystem = ActorSystem()
   implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/TextEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/TextEntitiesTestSuite.scala
@@ -1,0 +1,79 @@
+package endpoints.algebra.server
+
+import endpoints.algebra.TextEntitiesTestApi
+import akka.http.scaladsl.model.{
+  HttpMethods,
+  HttpEntity,
+  HttpRequest,
+  HttpCharsets,
+  ContentTypes,
+  MediaTypes
+}
+
+trait TextEntitiesTestSuite[T <: TextEntitiesTestApi]
+    extends ServerTestBase[T] {
+
+  "TextEntities" should {
+    "accept `text/plain` requests with UTF-8 encoding" in {
+      serveIdentityEndpoint(serverApi.textRequestEndpointTest) { port =>
+        val request = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Oekraïene")
+        )
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(response.entity.contentType.charsetOption.nonEmpty)
+            assert(decodeEntityAsText(response, entity) == "Oekraïene")
+            ()
+        }
+      }
+    }
+
+    "accept `text/plain` requests with UTF-16 encoding" in {
+      serveIdentityEndpoint(serverApi.textRequestEndpointTest) { port =>
+        val request = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            MediaTypes.`text/plain`.withCharset(HttpCharsets.`UTF-16`),
+            "Oekraïene"
+          )
+        )
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType.mediaType == MediaTypes.`text/plain`
+            )
+            assert(response.entity.contentType.charsetOption.nonEmpty)
+            assert(decodeEntityAsText(response, entity) == "Oekraïene")
+            ()
+        }
+      }
+    }
+
+    "reject non-`text/plain` requests" in {
+      serveIdentityEndpoint(serverApi.textRequestEndpointTest) { port =>
+        val request = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"http://localhost:$port/text",
+          entity = HttpEntity(
+            MediaTypes.`application/javascript`
+              .withCharset(HttpCharsets.`UTF-8`),
+            "var x = 'Oekraïene'"
+          )
+        )
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 415)
+            ()
+        }
+      }
+    }
+  }
+}

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
@@ -277,7 +277,7 @@ trait EndpointsWithCustomErrors
   def textRequest: RequestEntity[String] =
     req =>
       EntityDecoder
-        .decodeBy(http4s.MediaType.text.plain) { msg: http4s.Media[Effect] =>
+        .decodeBy(http4s.MediaType.text.plain) { (msg: http4s.Media[Effect]) =>
           http4s.DecodeResult.success(EntityDecoder.decodeString(msg))
         }
         .decode(req, strict = true)

--- a/http4s/server/src/main/scala/endpoints/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/JsonEntities.scala
@@ -25,7 +25,7 @@ trait JsonEntitiesFromCodecs
   def jsonRequest[A](implicit codec: JsonCodec[A]): RequestEntity[A] =
     req =>
       http4s.EntityDecoder
-        .decodeBy(MediaType.application.json) { msg: http4s.Media[Effect] =>
+        .decodeBy(MediaType.application.json) { (msg: http4s.Media[Effect]) =>
           http4s.DecodeResult.success(EntityDecoder.decodeString(msg))
         }
         .decode(req, strict = true)

--- a/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
@@ -10,3 +10,4 @@ class EndpointsTestApi
     with algebra.EndpointsTestApi
     with algebra.BasicAuthenticationTestApi
     with algebra.JsonEntitiesFromSchemasTestApi
+    with algebra.TextEntitiesTestApi

--- a/http4s/server/src/test/scala/endpoints/http4s/server/ServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/ServerInterpreterTest.scala
@@ -8,7 +8,8 @@ import endpoints.algebra.server.{
   BasicAuthenticationTestSuite,
   DecodedUrl,
   EndpointsTestSuite,
-  JsonEntitiesFromSchemasTestSuite
+  JsonEntitiesFromSchemasTestSuite,
+  TextEntitiesTestSuite
 }
 import org.http4s.server.Router
 import org.http4s.{HttpRoutes, Uri}
@@ -20,7 +21,8 @@ import scala.concurrent.ExecutionContext
 class ServerInterpreterTest
     extends EndpointsTestSuite[EndpointsTestApi]
     with BasicAuthenticationTestSuite[EndpointsTestApi]
-    with JsonEntitiesFromSchemasTestSuite[EndpointsTestApi] {
+    with JsonEntitiesFromSchemasTestSuite[EndpointsTestApi]
+    with TextEntitiesTestSuite[EndpointsTestApi] {
 
   val serverApi = new EndpointsTestApi()
 
@@ -35,9 +37,9 @@ class ServerInterpreterTest
     }
   }
 
-  def serveEndpoint[Resp](
-      endpoint: serverApi.Endpoint[_, Resp],
-      response: => Resp
+  private def serveGeneralEndpoint[Req, Resp](
+      endpoint: serverApi.Endpoint[Req, Resp],
+      request2response: Req => Resp
   )(runTests: Int => Unit): Unit = {
     val port = {
       val socket = new ServerSocket(0)
@@ -46,7 +48,7 @@ class ServerInterpreterTest
     }
     implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
     implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-    val service = HttpRoutes.of[IO](endpoint.implementedBy(_ => response))
+    val service = HttpRoutes.of[IO](endpoint.implementedBy(request2response))
     val httpApp = Router("/" -> service).orNotFound
     val server =
       BlazeServerBuilder[IO](ExecutionContext.global)
@@ -55,4 +57,14 @@ class ServerInterpreterTest
     server.resource.use(_ => IO(runTests(port))).unsafeRunSync()
   }
 
+  def serveEndpoint[Resp](
+      endpoint: serverApi.Endpoint[_, Resp],
+      response: => Resp
+  )(runTests: Int => Unit): Unit =
+    serveGeneralEndpoint(endpoint, (_: Any) => response)(runTests)
+
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit =
+    serveGeneralEndpoint(endpoint, identity[Resp])(runTests)
 }

--- a/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
+++ b/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
@@ -16,13 +16,15 @@ class TestClient(address: String, wsClient: WSClient)(
     with algebra.BasicAuthenticationTestApi
     with algebra.EndpointsTestApi
     with algebra.JsonFromCodecTestApi
+    with algebra.TextEntitiesTestApi
     with circe.JsonFromCirceCodecTestApi
     with circe.JsonEntitiesFromCodecs
 
 class EndpointsTest
     extends client.EndpointsTestSuite[TestClient]
     with client.BasicAuthTestSuite[TestClient]
-    with client.JsonFromCodecTestSuite[TestClient] {
+    with client.JsonFromCodecTestSuite[TestClient]
+    with client.TextEntitiesTestSuite[TestClient] {
 
   import ExecutionContext.Implicits.global
 
@@ -40,6 +42,7 @@ class EndpointsTest
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  textEntitiesTestSuite()
 
   override def afterAll(): Unit = {
     wsClient.close()

--- a/play/server/src/main/scala/endpoints/play/server/PlayComponents.scala
+++ b/play/server/src/main/scala/endpoints/play/server/PlayComponents.scala
@@ -1,7 +1,7 @@
 package endpoints.play.server
 
 import play.api.BuiltInComponents
-import play.api.http.FileMimeTypes
+import play.api.http.{FileMimeTypes, HttpErrorHandler}
 import play.api.mvc.{DefaultActionBuilder, PlayBodyParsers}
 
 import scala.concurrent.ExecutionContext
@@ -11,6 +11,7 @@ import scala.concurrent.ExecutionContext
   */
 trait PlayComponents {
   def playBodyParsers: PlayBodyParsers
+  def httpErrorHandler: HttpErrorHandler
   def defaultActionBuilder: DefaultActionBuilder
   def fileMimeTypes: FileMimeTypes
   implicit def executionContext: ExecutionContext
@@ -36,6 +37,8 @@ object PlayComponents {
   ): PlayComponents =
     new PlayComponents {
       def playBodyParsers: PlayBodyParsers = builtInComponents.playBodyParsers
+      def httpErrorHandler: HttpErrorHandler =
+        builtInComponents.httpErrorHandler
       def defaultActionBuilder: DefaultActionBuilder =
         builtInComponents.defaultActionBuilder
       def fileMimeTypes: FileMimeTypes = builtInComponents.fileMimeTypes

--- a/play/server/src/test/scala/endpoints/play/server/EndpointsTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/EndpointsTest.scala
@@ -15,6 +15,7 @@ class EndpointsTestApi(
     with algebra.BasicAuthenticationTestApi
     with algebra.EndpointsTestApi
     with algebra.JsonFromCodecTestApi
+    with algebra.TextEntitiesTestApi
     with algebra.Assets
     with JsonFromCirceCodecTestApi
     with algebra.circe.ChunkedJsonEntitiesTestApi

--- a/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
@@ -8,7 +8,8 @@ import endpoints.algebra.server.{
   BasicAuthenticationTestSuite,
   DecodedUrl,
   EndpointsTestSuite,
-  ChunkedJsonEntitiesTestSuite
+  ChunkedJsonEntitiesTestSuite,
+  TextEntitiesTestSuite
 }
 import play.api.Mode
 import play.api.routing.Router
@@ -24,7 +25,8 @@ import scala.concurrent.Future
 class ServerInterpreterTest
     extends EndpointsTestSuite[EndpointsTestApi]
     with BasicAuthenticationTestSuite[EndpointsTestApi]
-    with ChunkedJsonEntitiesTestSuite[EndpointsTestApi] {
+    with ChunkedJsonEntitiesTestSuite[EndpointsTestApi]
+    with TextEntitiesTestSuite[EndpointsTestApi] {
 
   val serverApi: EndpointsTestApi = {
     object NettyServerComponents extends DefaultNettyServerComponents {
@@ -43,6 +45,13 @@ class ServerInterpreterTest
   )(runTests: Int => Unit): Unit =
     serveRoutes(
       serverApi.routesFromEndpoints(endpoint.implementedBy(_ => response))
+    )(runTests)
+
+  def serveIdentityEndpoint[Resp](
+      endpoint: serverApi.Endpoint[Resp, Resp]
+  )(runTests: Int => Unit): Unit =
+    serveRoutes(
+      serverApi.routesFromEndpoints(endpoint.implementedBy(request => request))
     )(runTests)
 
   def serveStreamedEndpoint[Resp](

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -71,7 +71,10 @@ trait Requests extends algebra.Requests with Urls with Methods {
   def emptyRequest: RequestEntity[Unit] = (x: Unit, req: HttpRequest) => req
 
   def textRequest: (String, HttpRequest) => scalaj.http.HttpRequest =
-    (body, req) => req.postData(body)
+    (body, req) =>
+      req
+        .header("content-type", s"text/plain; charset=${req.charset}")
+        .postData(body)
 
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =

--- a/scalaj/client/src/test/scala/endpoints/scalaj/client/JsonEntitiesFromCodecTest.scala
+++ b/scalaj/client/src/test/scala/endpoints/scalaj/client/JsonEntitiesFromCodecTest.scala
@@ -2,7 +2,7 @@ package endpoints.scalaj.client
 
 import endpoints.algebra
 import endpoints.algebra.circe
-import endpoints.algebra.client.JsonFromCodecTestSuite
+import endpoints.algebra.client.{JsonFromCodecTestSuite, TextEntitiesTestSuite}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -11,9 +11,12 @@ class TestJsonClient(val address: String)
     with JsonEntitiesFromCodecs
     with circe.JsonEntitiesFromCodecs
     with algebra.JsonFromCodecTestApi
+    with algebra.TextEntitiesTestApi
     with circe.JsonFromCirceCodecTestApi {}
 
-class JsonEntitiesFromCodecTest extends JsonFromCodecTestSuite[TestJsonClient] {
+class JsonEntitiesFromCodecTest
+    extends JsonFromCodecTestSuite[TestJsonClient]
+    with TextEntitiesTestSuite[TestJsonClient] {
 
   val client: TestJsonClient = new TestJsonClient(s"localhost:$wiremockPort")
   implicit val ec = ExecutionContext.Implicits.global
@@ -39,5 +42,6 @@ class JsonEntitiesFromCodecTest extends JsonFromCodecTestSuite[TestJsonClient] {
   }
 
   jsonFromCodecTestSuite()
+  textEntitiesTestSuite()
 
 }

--- a/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
+++ b/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
@@ -6,9 +6,14 @@ import com.softwaremill.sttp.akkahttp.AkkaHttpBackend
 import endpoints.algebra.client.{
   BasicAuthTestSuite,
   JsonFromCodecTestSuite,
+  TextEntitiesTestSuite,
   EndpointsTestSuite
 }
-import endpoints.algebra.{BasicAuthenticationTestApi, EndpointsTestApi}
+import endpoints.algebra.{
+  BasicAuthenticationTestApi,
+  EndpointsTestApi,
+  TextEntitiesTestApi
+}
 import endpoints.algebra.playjson.JsonFromPlayJsonCodecTestApi
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -21,11 +26,13 @@ class TestClient[R[_]](address: String, backend: sttp.SttpBackend[R, _])
     with BasicAuthenticationTestApi
     with EndpointsTestApi
     with JsonFromPlayJsonCodecTestApi
+    with TextEntitiesTestApi
 
 class EndpointsTestSync
     extends EndpointsTestSuite[TestClient[Try]]
     with BasicAuthTestSuite[TestClient[Try]]
-    with JsonFromCodecTestSuite[TestClient[Try]] {
+    with JsonFromCodecTestSuite[TestClient[Try]]
+    with TextEntitiesTestSuite[TestClient[Try]] {
 
   val backend = TryHttpURLConnectionBackend()
 
@@ -41,12 +48,14 @@ class EndpointsTestSync
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  textEntitiesTestSuite()
 }
 
 class EndpointsTestAkka
     extends EndpointsTestSuite[TestClient[Future]]
     with BasicAuthTestSuite[TestClient[Future]]
-    with JsonFromCodecTestSuite[TestClient[Future]] {
+    with JsonFromCodecTestSuite[TestClient[Future]]
+    with TextEntitiesTestSuite[TestClient[Future]] {
 
   import ExecutionContext.Implicits.global
 
@@ -63,6 +72,7 @@ class EndpointsTestAkka
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  textEntitiesTestSuite()
 
   override def afterAll(): Unit = {
     backend.close()


### PR DESCRIPTION
`textRequest`/`jsonRequest` use the content-type header for more validation:

  - the expected content type is checked against requests (and specified in responses)
  - the character encoding of `textRequest` is determined from the content-type header (`jsonRequest` is always UTF-8 encoded)

Tests are added to check this is the case. In the process the following behaviour changed:

  * Akka HTTP server checks for `text/plain` content-type in `textRequest`
  * Http4s checks for `text/plain` and infers encoding from content-type in `textRequest`
  * Http4s checks for `application/json` from content-type in `jsonRequest`
  * Play checks for `application/json` from content-type in `jsonRequest`
  * Scalaj sets `text/plain` and encoding in `textRequest`
