### PR TITLE
Remove some warnings on Dotty

### DIFF
--- a/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Endpoints.scala
@@ -80,11 +80,50 @@ trait EndpointsWithCustomErrors extends Requests with Responses with Errors {
     * @param entity   Contents of the callback message
     * @param response Expected response
     */
-  case class CallbackDocs(
+  case class CallbackDocs private (
       method: Method,
-      entity: RequestEntity[_],
-      response: Response[_],
-      requestDocs: Documentation = None
+      entity: CallbackDocs.SomeRequestEntity,
+      response: CallbackDocs.SomeResponse,
+      requestDocs: Documentation
   )
+
+  object CallbackDocs {
+
+    /**
+      * A wrapper type for a [[RequestEntity]] whose carried information is unknown.
+      *
+      * This wrapper type is necessary because Scala 3 does not support writing `RequestEntity[_]`.
+      */
+    trait SomeRequestEntity {
+      type T
+      def value: RequestEntity[T]
+    }
+
+    /**
+      * A wrapper type for a [[Response]] whose carried information is unknown.
+      *
+      * This wrapper type is necessary because Scala 3 does not support writing `Response[_]`
+      */
+    trait SomeResponse {
+      type T
+      def value: Response[T]
+    }
+
+    /**
+      * Convenience constructor that wraps the `entity` and `response` parameters.
+      */
+    def apply[A, B](
+        method: Method,
+        entity: RequestEntity[A],
+        response: Response[B],
+        requestDocs: Documentation = None
+    ): CallbackDocs =
+      new CallbackDocs(
+        method,
+        new SomeRequestEntity { type T = A; def value = entity },
+        new SomeResponse { type T = B; def value = response },
+        requestDocs
+      )
+  }
 
 }

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/JsonSchemas.scala
@@ -220,7 +220,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Annotates the tagged JSON schema with a name */
   def namedTagged[A](schema: Tagged[A], name: String): Tagged[A]
 
-  /** Annotates the enum JSON schema with a name */
+  /** Annotates the enumeration JSON schema with a name */
   def namedEnum[A](schema: Enum[A], name: String): Enum[A]
 
   /**
@@ -346,8 +346,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Include an example value within the given tagged JSON schema */
   def withExampleTagged[A](tagged: Tagged[A], example: A): Tagged[A]
 
-  /** Include an example value within the given enum JSON schema */
-  def withExampleEnum[A](enum: Enum[A], example: A): Enum[A]
+  /** Include an example value within the given enumeration JSON schema */
+  def withExampleEnum[A](enumeration: Enum[A], example: A): Enum[A]
 
   /** Include an example value within the given JSON schema */
   def withExampleJsonSchema[A](schema: JsonSchema[A], example: A): JsonSchema[A]
@@ -364,8 +364,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       description: String
   ): Tagged[A]
 
-  /** Add a description to the given enum JSON schema */
-  def withDescriptionEnum[A](enum: Enum[A], description: String): Enum[A]
+  /** Add a description to the given enumeration JSON schema */
+  def withDescriptionEnum[A](enumeration: Enum[A], description: String): Enum[A]
 
   /** Add a description to the given JSON schema */
   def withDescriptionJsonSchema[A](
@@ -379,8 +379,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** Add a title to the given tagged JSON schema */
   def withTitleTagged[A](tagged: Tagged[A], title: String): Tagged[A]
 
-  /** Add a title to the given enum JSON schema */
-  def withTitleEnum[A](enum: Enum[A], title: String): Enum[A]
+  /** Add a title to the given enumeration JSON schema */
+  def withTitleEnum[A](enumeration: Enum[A], title: String): Enum[A]
 
   /** Add a title to the given schema */
   def withTitleJsonSchema[A](

--- a/json-schema/json-schema/src/main/scala/endpoints/algebra/NoDocsJsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints/algebra/NoDocsJsonSchemas.scala
@@ -11,13 +11,14 @@ trait NoDocsJsonSchemas extends JsonSchemas {
 
   def namedTagged[A](tagged: Tagged[A], name: String): Tagged[A] = tagged
 
-  def namedEnum[A](enum: Enum[A], name: String): Enum[A] = enum
+  def namedEnum[A](enumeration: Enum[A], name: String): Enum[A] = enumeration
 
   def withExampleRecord[A](record: Record[A], example: A): Record[A] = record
 
   def withExampleTagged[A](tagged: Tagged[A], example: A): Tagged[A] = tagged
 
-  def withExampleEnum[A](enum: Enum[A], example: A): Enum[A] = enum
+  def withExampleEnum[A](enumeration: Enum[A], example: A): Enum[A] =
+    enumeration
 
   def withExampleJsonSchema[A](
       schema: JsonSchema[A],
@@ -34,7 +35,10 @@ trait NoDocsJsonSchemas extends JsonSchemas {
       description: String
   ): Tagged[A] = tagged
 
-  def withDescriptionEnum[A](enum: Enum[A], description: String): Enum[A] = enum
+  def withDescriptionEnum[A](
+      enumeration: Enum[A],
+      description: String
+  ): Enum[A] = enumeration
 
   def withDescriptionJsonSchema[A](
       schema: JsonSchema[A],
@@ -45,7 +49,8 @@ trait NoDocsJsonSchemas extends JsonSchemas {
 
   def withTitleTagged[A](tagged: Tagged[A], title: String): Tagged[A] = tagged
 
-  def withTitleEnum[A](enum: Enum[A], title: String): Enum[A] = enum
+  def withTitleEnum[A](enumeration: Enum[A], title: String): Enum[A] =
+    enumeration
 
   def withTitleJsonSchema[A](
       schema: JsonSchema[A],

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Endpoints.scala
@@ -143,9 +143,9 @@ trait EndpointsWithCustomErrors
               case (urlPattern, callback) =>
                 val method = callback.method.toString.toLowerCase
                 val requestBody =
-                  RequestBody(callback.requestDocs, callback.entity)
+                  RequestBody(callback.requestDocs, callback.entity.value)
                 val responses =
-                  callback.response
+                  callback.response.value
                     .map(r =>
                       r.status.toString() -> Response(
                         r.documentation,

--- a/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/JsonSchemas.scala
@@ -295,13 +295,13 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   }
 
   def withExampleEnum[A](
-      enum: Enum[A],
+      enumeration: Enum[A],
       example: A
   ): Enum[A] = {
-    val exampleJson = enum.ujsonSchema.codec.encode(example)
+    val exampleJson = enumeration.ujsonSchema.codec.encode(example)
     new Enum[A](
-      enum.ujsonSchema,
-      enum.docs.copy(example = Some(exampleJson))
+      enumeration.ujsonSchema,
+      enumeration.docs.copy(example = Some(exampleJson))
     )
   }
 
@@ -345,12 +345,12 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     )
 
   def withTitleEnum[A](
-      enum: Enum[A],
+      enumeration: Enum[A],
       title: String
   ): Enum[A] =
     new Enum[A](
-      enum.ujsonSchema,
-      enum.docs.copy(title = Some(title))
+      enumeration.ujsonSchema,
+      enumeration.docs.copy(title = Some(title))
     )
 
   def withTitleJsonSchema[A](
@@ -392,12 +392,12 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     )
 
   def withDescriptionEnum[A](
-      enum: Enum[A],
+      enumeration: Enum[A],
       description: String
   ): Enum[A] =
     new Enum[A](
-      enum.ujsonSchema,
-      enum.docs.copy(description = Some(description))
+      enumeration.ujsonSchema,
+      enumeration.docs.copy(description = Some(description))
     )
 
   def withDescriptionJsonSchema[A](


### PR DESCRIPTION
- Remove occurrences of unreducible application of higher-kinded types
- Rename `enum` identifier to `enumeration`
