### PR TITLE
Fix Uri resolving

### DIFF
--- a/http4s/client/src/main/scala/endpoints/http4s/client/Endpoints.scala
+++ b/http4s/client/src/main/scala/endpoints/http4s/client/Endpoints.scala
@@ -135,7 +135,7 @@ trait EndpointsWithCustomErrors
     effect.map(effect.fromEither(url.encodeUrl(urlP)))(uri =>
       entity(
         bodyP,
-        headers(headersP, Http4sRequest(method, Uri.resolve(host, uri)))
+        headers(headersP, Http4sRequest(method, host.withPath(host.path + uri)))
       )
     )
   }


### PR DESCRIPTION
There was a bug here, where under certain circumstances part of the path was lost, due to the way RFC 3986 works. However, what we need is actually much simpler, so this should do just fine.