### PR TITLE
More precise supertype to `Endpoint` for `xhr`

### DIFF
--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -302,9 +302,7 @@ trait EndpointsWithCustomErrors
     * A function that takes the information needed to build a request and returns
     * a task yielding the information carried by the response.
     */
-  abstract class Endpoint[A, B](request: Request[A]) {
-    def apply(a: A): Result[B]
-
+  abstract class Endpoint[A, B](request: Request[A]) extends (A => Result[B]) {
     def href(a: A): String = request.href(a)
   }
 


### PR DESCRIPTION
This make it possible to abstract a little more over the particular
client used:

    case class App(
      routes: MyRoutesTrait with endpoints.ujson.JsonSchemas {
        type Endpoint[A, B] <: (A => Future[B])
      },
      ...
    )

This makes it trivial to instantiate `App` both with an interpreter that
uses _endpoints_ xhr client as well as test/mock interpreter that fakes
all backend interaction.

    object ProdRoutes
      extends MyRoutesTrait
      with endpoints.xhr.JsonEntitiesFromSchemas
      with endpoints.xhr.future.Endpoints
      with endpoints.ujson.JsonSchemas

    object MockedRoutes
      extends MyRoutesTrait {

      type Endpoint[A,B] = A => Future[B]

      /* mocked implementations snipped */
    }