### PR TITLE
Fix encoding of Urls Segment

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Urls.scala
@@ -3,6 +3,7 @@ package endpoints.akkahttp.client
 import scala.collection.compat.Factory
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
+import akka.http.scaladsl.model.Uri
 
 import endpoints.{PartialInvariantFunctor, Tupler, Validated, algebra}
 import endpoints.algebra.Documentation
@@ -84,7 +85,7 @@ trait Urls extends algebra.Urls {
     URLEncoder.encode(s, utf8Name) :: Nil
 
   trait Segment[A] {
-    def encode(a: A): String
+    def encode(a: A): Uri.Path
   }
 
   implicit lazy val segmentPartialInvariantFunctor
@@ -98,7 +99,7 @@ trait Urls extends algebra.Urls {
     }
 
   implicit lazy val stringSegment: Segment[String] = (s: String) =>
-    URLEncoder.encode(s, utf8Name)
+    Uri.Path.Segment(s, Uri.Path.Empty)
 
   trait Path[A] extends Url[A]
 
@@ -115,7 +116,7 @@ trait Urls extends algebra.Urls {
 
   def segment[A](name: String, docs: Documentation)(
       implicit s: Segment[A]
-  ): Path[A] = a => s.encode(a)
+  ): Path[A] = a => s.encode(a).toString()
 
   def remainingSegments(name: String, docs: Documentation): Path[String] =
     s => s

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/EndpointsTestSuite.scala
@@ -319,6 +319,7 @@ trait EndpointsTestSuite[T <: EndpointsTestApi] extends ClientTestBase[T] {
         import client._
         encodeUrl(path / "foo" / segment[String]())("bar/baz") shouldEqual "/foo/bar%2Fbaz"
         encodeUrl(path / segment[String]())("bar/baz") shouldEqual "/bar%2Fbaz"
+        encodeUrl(path / segment[String]())("bar baz") shouldEqual "/bar%20baz"
         encodeUrl(path / segment[String]() / "baz")("bar") shouldEqual "/bar/baz"
         encodeUrl(path / segment[Int]())(42) shouldEqual "/42"
         encodeUrl(path / segment[Long]())(42L) shouldEqual "/42"

--- a/http4s/client/src/main/scala/endpoints/http4s/client/Urls.scala
+++ b/http4s/client/src/main/scala/endpoints/http4s/client/Urls.scala
@@ -8,8 +8,6 @@ import endpoints.Validated
 import org.http4s.Query
 import endpoints.algebra.Documentation
 import org.http4s.ParseResult
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets.UTF_8
 
 trait Urls extends endpoints.algebra.Urls with StatusCodes {
 
@@ -88,7 +86,7 @@ trait Urls extends endpoints.algebra.Urls with StatusCodes {
     }
 
   override def stringSegment: Segment[String] =
-    s => URLEncoder.encode(s, UTF_8.name)
+    s => Uri.pathEncode(s)
 
   trait Path[A] extends Url[A] {
     final def encodeUrl(value: A): ParseResult[Uri] =

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Urls.scala
@@ -95,8 +95,8 @@ trait Urls extends algebra.Urls {
       ): Segment[B] = (b: B) => fa.encode(g(b))
     }
 
-  implicit lazy val stringSegment: Segment[String] = (s: String) =>
-    URLEncoder.encode(s, utf8Name)
+  implicit lazy val stringSegment: Segment[String] =
+    Urls.encodeSegment(_)
 
   trait Path[A] extends Url[A]
 
@@ -151,4 +151,33 @@ trait Urls extends algebra.Urls {
       ): Url[B] = (b: B) => fa.encode(g(b))
     }
 
+}
+
+private object Urls {
+  val noEncodeChars = "-_.~:@!$&'()*+,;=".toCharArray().sorted
+  val hexChars = "0123456789ABCDEF".toCharArray()
+
+  def shouldEncode(c: Char): Boolean =
+    if ((c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        java.util.Arrays.binarySearch(noEncodeChars, c) >= 0) false
+    else true
+
+  def encodeSegment(s: String): String = {
+    val in = UTF_8.encode(s)
+    val out = new StringBuilder(in.remaining() * 3)
+    while (in.hasRemaining) {
+      val c = in.get.toChar
+      if (shouldEncode(c)) {
+        out
+          .append('%')
+          .append(hexChars((c >> 4) & 0xF))
+          .append(hexChars(c & 0xF))
+      } else {
+        out.append(c)
+      }
+    }
+    out.result()
+  }
 }


### PR DESCRIPTION
Addresses #574

For akka and http4s, I used existing encoder from these frameworks to encode `Segment`. For the others, I re-implemented the encoding inspired by the http4s implementation.