### PR TITLE
Add `orElse` for `RequestEntity` based on content-type

### DIFF
--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -134,6 +134,12 @@ trait EndpointsWithCustomErrors
   lazy val textRequest: (String, HttpRequest) => HttpRequest =
     (body, request) => request.copy(entity = HttpEntity(body))
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
+    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+
   def request[A, B, C, AB, Out](
       method: Method,
       url: Url[A],

--- a/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
+++ b/akka-http/client/src/main/scala/endpoints/akkahttp/client/Endpoints.scala
@@ -135,10 +135,11 @@ trait EndpointsWithCustomErrors
     (body, request) => request.copy(entity = HttpEntity(body))
 
   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
-  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
-    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    (eitherAB, req) =>
+      eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
 
   def request[A, B, C, AB, Out](
       method: Method,

--- a/akka-http/client/src/test/scala/endpoints/akkahttp/client/AkkaHttpClientEndpointsTest.scala
+++ b/akka-http/client/src/test/scala/endpoints/akkahttp/client/AkkaHttpClientEndpointsTest.scala
@@ -19,6 +19,7 @@ class TestClient(settings: EndpointsSettings)(
     with algebra.BasicAuthenticationTestApi
     with algebra.TextEntitiesTestApi
     with algebra.JsonFromCodecTestApi
+    with algebra.SumTypedEntitiesTestApi
     with algebra.circe.JsonFromCirceCodecTestApi
     with JsonEntitiesFromCodecs
     with algebra.circe.JsonEntitiesFromCodecs
@@ -31,6 +32,7 @@ class AkkaHttpClientEndpointsTest
     with algebra.client.BasicAuthTestSuite[TestClient]
     with algebra.client.JsonFromCodecTestSuite[TestClient]
     with algebra.client.TextEntitiesTestSuite[TestClient]
+    with algebra.client.SumTypedEntitiesTestSuite[TestClient]
     with algebra.client.ChunkedJsonEntitiesTestSuite[TestClient] {
 
   implicit val system = ActorSystem()
@@ -77,6 +79,7 @@ class AkkaHttpClientEndpointsTest
   basicAuthSuite()
   jsonFromCodecTestSuite()
   textEntitiesTestSuite()
+  sumTypedRequestsTestSuite()
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -121,6 +121,16 @@ trait EndpointsWithCustomErrors
     Directives.entity[String](implicitly)
   }
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: Directive1[A],
+    requestEntityB: Directive1[B]
+  ): Directive1[Either[A, B]] = {
+    val requestEntityAAsEither = requestEntityA.map(Left(_): Either[A, B])
+    val requestEntityBAsEither = requestEntityB.map(Right(_): Either[A, B])
+
+    requestEntityAAsEither | requestEntityBAsEither
+  }
+
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     directive1InvFunctor

--- a/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints/akkahttp/server/Endpoints.scala
@@ -122,8 +122,8 @@ trait EndpointsWithCustomErrors
   }
 
   def choiceRequestEntity[A, B](
-    requestEntityA: Directive1[A],
-    requestEntityB: Directive1[B]
+      requestEntityA: Directive1[A],
+      requestEntityB: Directive1[B]
   ): Directive1[Either[A, B]] = {
     val requestEntityAAsEither = requestEntityA.map(Left(_): Either[A, B])
     val requestEntityBAsEither = requestEntityB.map(Right(_): Either[A, B])

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsCodecsTestApi.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/EndpointsCodecsTestApi.scala
@@ -10,6 +10,7 @@ class EndpointsCodecsTestApi
     with algebra.ChunkedJsonEntitiesTestApi
     with algebra.circe.ChunkedJsonEntitiesTestApi
     with algebra.BasicAuthenticationTestApi
+    with algebra.SumTypedEntitiesTestApi
     with JsonEntitiesFromCodecs
     with ChunkedJsonEntities
     with BasicAuthentication

--- a/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterTest.scala
+++ b/akka-http/server/src/test/scala/endpoints/akkahttp/server/ServerInterpreterTest.scala
@@ -24,6 +24,7 @@ class ServerInterpreterTest
     with algebra.server.BasicAuthenticationTestSuite[EndpointsCodecsTestApi]
     with algebra.server.ChunkedJsonEntitiesTestSuite[EndpointsCodecsTestApi]
     with algebra.server.TextEntitiesTestSuite[EndpointsCodecsTestApi]
+    with algebra.server.SumTypedEntitiesTestSuite[EndpointsCodecsTestApi]
     with ScalatestRouteTest {
 
   val serverApi = new EndpointsCodecsTestApi

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -125,6 +125,29 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     */
   def textRequest: RequestEntity[String]
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]]
+
+  implicit class RequestEntitySyntax[A](requestEntity: RequestEntity[A]) {
+
+    /**
+      * If the entity does not seem enc/decodable as an [[A]], try decoding as a [[B]] using otherRequestEntity
+      * @note If the Entity may be enc/decodable as an [[A]], it will be. This is particularly important when
+      *       [[requestEntity]] is akka-server's [[textRequest]], which will match and decode any text-serializable
+      *       entity, regardless of Content-Type
+      * @note If [[A]] and [[B]] are both JSON-encoded and use disjoint schemas, use
+      *       [[endpoints.algebra.JsonSchemas.TaggedOps#orElse]] at the schema level instead
+      * @see [[SumTypedRequestEntity#choiceRequestEntity]]
+      * @param otherRequestEntity A [[RequestEntity]] to use to enc/decode a [[B]]
+      * @tparam B what to attempt as an enc/decoding target if not an [[A]]
+      * @return a [[RequestEntity]][Either[A, B]]
+      */
+    def orElse[B](otherRequestEntity: RequestEntity[B]): RequestEntity[Either[A, B]] =
+      choiceRequestEntity(requestEntity, otherRequestEntity)
+  }
+
   /**
     * Request for given parameters
     *

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -95,7 +95,8 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     *     in a JSON array. Refer to the documentation of your server interpreter
     *     to customize this behavior.
     *
-    * @note  This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]] class.
+    * @note This type has implicit methods provided by the [[PartialInvariantFunctorSyntax]] and
+    *       [[RequestEntitySyntax]] classes.
     * @group types */
   type RequestEntity[A]
 

--- a/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
+++ b/algebras/algebra/src/main/scala/endpoints/algebra/Requests.scala
@@ -125,26 +125,38 @@ trait Requests extends Urls with Methods with SemigroupalSyntax {
     */
   def textRequest: RequestEntity[String]
 
+  /**
+    * Alternative between two possible request entities, differentiated by the
+    * `Content-Type` header
+    *
+    * @note If [[A]] and [[B]] are both JSON-encoded and use disjoint schemas, use
+    *       [[endpoints.algebra.JsonSchemas.TaggedOps#orElse]] at the schema level instead
+    *
+    * Server interpreters accept either of the request entities
+    * Client interpreters provide one of the two request entities
+    * Documentation interpreters list all possible content types and their entities
+    */
   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
   ): RequestEntity[Either[A, B]]
 
   implicit class RequestEntitySyntax[A](requestEntity: RequestEntity[A]) {
 
     /**
-      * If the entity does not seem enc/decodable as an [[A]], try decoding as a [[B]] using otherRequestEntity
-      * @note If the Entity may be enc/decodable as an [[A]], it will be. This is particularly important when
-      *       [[requestEntity]] is akka-server's [[textRequest]], which will match and decode any text-serializable
-      *       entity, regardless of Content-Type
+      * Alternative between two possible request entities, differentiated by the
+      * `Content-Type` header
+      *
       * @note If [[A]] and [[B]] are both JSON-encoded and use disjoint schemas, use
       *       [[endpoints.algebra.JsonSchemas.TaggedOps#orElse]] at the schema level instead
-      * @see [[SumTypedRequestEntity#choiceRequestEntity]]
-      * @param otherRequestEntity A [[RequestEntity]] to use to enc/decode a [[B]]
-      * @tparam B what to attempt as an enc/decoding target if not an [[A]]
-      * @return a [[RequestEntity]][Either[A, B]]
+      *
+      * Server interpreters accept either of the request entities
+      * Client interpreters provide one of the two request entities
+      * Documentation interpreters list all possible content types and their entities
       */
-    def orElse[B](otherRequestEntity: RequestEntity[B]): RequestEntity[Either[A, B]] =
+    final def orElse[B](
+        otherRequestEntity: RequestEntity[B]
+    ): RequestEntity[Either[A, B]] =
       choiceRequestEntity(requestEntity, otherRequestEntity)
   }
 

--- a/algebras/algebra/src/test/scala/endpoints/algebra/SumTypedEntitiesTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/SumTypedEntitiesTestApi.scala
@@ -1,0 +1,16 @@
+package endpoints.algebra
+
+trait SumTypedEntitiesTestApi extends Endpoints with JsonEntitiesFromCodecs {
+
+  implicit def userCodec: JsonCodec[User]
+
+  def sumTypedEndpoint = endpoint[Either[User, String], Either[User, String]](
+    post(path / "user-or-name", jsonRequest[User].orElse(textRequest)),
+    ok(jsonResponse[User]).orElse(ok(textResponse))
+  )
+
+  def sumTypedEndpoint2 = endpoint[Either[User, String], Unit](
+    post(path / "user-or-name", jsonRequest[User].orElse(textRequest)),
+    ok(emptyResponse)
+  )
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/client/SumTypedEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/client/SumTypedEntitiesTestSuite.scala
@@ -1,0 +1,37 @@
+package endpoints.algebra.client
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import endpoints.algebra
+
+trait SumTypedEntitiesTestSuite[
+    T <: algebra.SumTypedEntitiesTestApi
+] extends ClientTestBase[T] {
+
+  def sumTypedRequestsTestSuite() = {
+
+    "Client interpreter" should {
+
+      "handle the sum-typed request entities" in {
+        val user = algebra.User("name2", 19)
+        val name = "name3"
+
+        wireMockServer.stubFor(
+          post(urlEqualTo("/user-or-name"))
+            .withHeader(
+              "Content-Type",
+              matching("application/json|(text/plain.*)")
+            )
+            .willReturn(
+              aResponse().withStatus(200)
+            )
+        )
+
+        whenReady(call(client.sumTypedEndpoint2, Left(user)))(_.shouldEqual(()))
+        whenReady(call(client.sumTypedEndpoint2, Right(name)))(
+          _.shouldEqual(())
+        )
+      }
+    }
+  }
+
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/SumTypedEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/SumTypedEntitiesTestSuite.scala
@@ -1,0 +1,69 @@
+package endpoints.algebra.server
+
+import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest}
+import endpoints.algebra
+
+trait SumTypedEntitiesTestSuite[
+    T <: algebra.SumTypedEntitiesTestApi
+] extends ServerTestBase[T] {
+
+  "Sum typed route" should {
+
+    "handle `text/plain` content-type requests" in {
+      serveIdentityEndpoint(serverApi.sumTypedEndpoint) { port =>
+        val request =
+          HttpRequest(HttpMethods.POST, s"http://localhost:$port/user-or-name")
+            .withEntity(ContentTypes.`text/plain(UTF-8)`, "Alice")
+        whenReady(sendAndDecodeEntityAsText(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType == ContentTypes.`text/plain(UTF-8)`
+            )
+            entity shouldEqual "Alice"
+        }
+        ()
+      }
+    }
+
+    "handle `application/json` content-type requests" in {
+      serveIdentityEndpoint(serverApi.sumTypedEndpoint) { port =>
+        val request =
+          HttpRequest(HttpMethods.POST, s"http://localhost:$port/user-or-name")
+            .withEntity(
+              ContentTypes.`application/json`,
+              "{\"name\":\"Alice\",\"age\":42}"
+            )
+        whenReady(sendAndDecodeEntityAsText(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            assert(
+              response.entity.contentType == ContentTypes.`application/json`
+            )
+            ujson.read(entity) shouldEqual ujson.Obj(
+              "name" -> ujson.Str("Alice"),
+              "age" -> ujson.Num(42)
+            )
+        }
+        ()
+      }
+    }
+
+    "not handle `application/x-www-form-urlencoded` content-type requests" in {
+      serveIdentityEndpoint(serverApi.sumTypedEndpoint) { port =>
+        val request =
+          HttpRequest(HttpMethods.POST, s"http://localhost:$port/user-or-name")
+            .withEntity(
+              ContentTypes.`application/x-www-form-urlencoded`,
+              "name=Alice&age=42"
+            )
+        whenReady(sendAndDecodeEntityAsText(request)) {
+          case (response, _) =>
+            assert(response.status.intValue() == 415)
+        }
+        ()
+      }
+    }
+  }
+
+}

--- a/algebras/algebra/src/test/scala/endpoints/algebra/server/SumTypedEntitiesTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints/algebra/server/SumTypedEntitiesTestSuite.scala
@@ -49,6 +49,23 @@ trait SumTypedEntitiesTestSuite[
       }
     }
 
+    "handle `application/json` content-type requests with malformed bodies" in {
+      serveIdentityEndpoint(serverApi.sumTypedEndpoint) { port =>
+        val request =
+          HttpRequest(HttpMethods.POST, s"http://localhost:$port/user-or-name")
+            .withEntity(
+              ContentTypes.`application/json`,
+              "{\"name\":\"Alice\"}"
+            )
+        whenReady(sendAndDecodeEntityAsText(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 400)
+        }
+        ()
+      }
+
+    }
+
     "not handle `application/x-www-form-urlencoded` content-type requests" in {
       serveIdentityEndpoint(serverApi.sumTypedEndpoint) { port =>
         val request =
@@ -65,5 +82,4 @@ trait SumTypedEntitiesTestSuite[
       }
     }
   }
-
 }

--- a/documentation/examples/authentication/src/main/scala/authentication/Authentication.scala
+++ b/documentation/examples/authentication/src/main/scala/authentication/Authentication.scala
@@ -258,7 +258,8 @@ trait ServerAuthentication extends Authentication with server.Endpoints {
     extractMethodUrlAndHeaders(method, url, authenticationTokenRequestHeaders)
       .toRequest[UET] {
         case (_, None) =>
-          _ => Some(BodyParser(_ => Accumulator.done(Left(Results.Unauthorized))))
+          _ =>
+            Some(BodyParser(_ => Accumulator.done(Left(Results.Unauthorized))))
         case (u, Some(token)) =>
           hdrs => entity(hdrs).map(_.map(e => tuplerUET(tuplerUE(u, e), token)))
       } { uet =>

--- a/documentation/examples/authentication/src/main/scala/authentication/Authentication.scala
+++ b/documentation/examples/authentication/src/main/scala/authentication/Authentication.scala
@@ -258,9 +258,9 @@ trait ServerAuthentication extends Authentication with server.Endpoints {
     extractMethodUrlAndHeaders(method, url, authenticationTokenRequestHeaders)
       .toRequest[UET] {
         case (_, None) =>
-          BodyParser(_ => Accumulator.done(Left(Results.Unauthorized)))
+          _ => Some(BodyParser(_ => Accumulator.done(Left(Results.Unauthorized))))
         case (u, Some(token)) =>
-          entity.map(e => tuplerUET(tuplerUE(u, e), token))
+          hdrs => entity(hdrs).map(_.map(e => tuplerUET(tuplerUE(u, e), token)))
       } { uet =>
         val (ue, t) = tuplerUET.unapply(uet)
         val (u, _) = tuplerUE.unapply(ue)

--- a/http4s/client/src/main/scala/endpoints/http4s/client/Endpoints.scala
+++ b/http4s/client/src/main/scala/endpoints/http4s/client/Endpoints.scala
@@ -105,6 +105,12 @@ trait EndpointsWithCustomErrors
   override def textRequest: RequestEntity[String] =
     (value, req) => req.withEntity(value)
 
+  override def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
+    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+
   type Request[A] = A => Effect[Http4sRequest[Effect]]
 
   implicit def requestPartialInvariantFunctor

--- a/http4s/client/src/main/scala/endpoints/http4s/client/Endpoints.scala
+++ b/http4s/client/src/main/scala/endpoints/http4s/client/Endpoints.scala
@@ -106,10 +106,11 @@ trait EndpointsWithCustomErrors
     (value, req) => req.withEntity(value)
 
   override def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
-  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
-    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    (eitherAB, req) =>
+      eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
 
   type Request[A] = A => Effect[Http4sRequest[Effect]]
 

--- a/http4s/client/src/test/scala/endpoints/http4s/client/Http4sClientEndpointsJsonSchemaTest.scala
+++ b/http4s/client/src/test/scala/endpoints/http4s/client/Http4sClientEndpointsJsonSchemaTest.scala
@@ -20,13 +20,15 @@ class TestJsonSchemaClient[F[_]: Sync](host: Uri, client: Client[F])
     with algebra.BasicAuthenticationTestApi
     with algebra.EndpointsTestApi
     with algebra.JsonFromCodecTestApi
+    with algebra.SumTypedEntitiesTestApi
     with circe.JsonFromCirceCodecTestApi
     with circe.JsonEntitiesFromCodecs
 
 class Http4sClientEndpointsJsonSchemaTest
     extends client.EndpointsTestSuite[TestJsonSchemaClient[IO]]
     with client.BasicAuthTestSuite[TestJsonSchemaClient[IO]]
-    with client.JsonFromCodecTestSuite[TestJsonSchemaClient[IO]] {
+    with client.JsonFromCodecTestSuite[TestJsonSchemaClient[IO]]
+    with client.SumTypedEntitiesTestSuite[TestJsonSchemaClient[IO]] {
 
   implicit val ctx: ContextShift[IO] = IO.contextShift(global)
 

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
@@ -285,6 +285,16 @@ trait EndpointsWithCustomErrors
         .rethrowT
         .map(Right(_))
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    req => {
+      def decodedA = requestEntityA(req).map(_.map(Left(_): Either[A,B]))
+      def decodedB = requestEntityB(req).map(_.map(Right(_): Either[A,B]))
+      decodedA.orElse(decodedB)
+    }
+
   def request[UrlP, BodyP, HeadersP, UrlAndBodyPTupled, Out](
       method: Method,
       url: Url[UrlP],

--- a/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints/http4s/server/Endpoints.scala
@@ -286,12 +286,12 @@ trait EndpointsWithCustomErrors
         .map(Right(_))
 
   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
   ): RequestEntity[Either[A, B]] =
     req => {
-      def decodedA = requestEntityA(req).map(_.map(Left(_): Either[A,B]))
-      def decodedB = requestEntityB(req).map(_.map(Right(_): Either[A,B]))
+      def decodedA = requestEntityA(req).map(_.map(Left(_): Either[A, B]))
+      def decodedB = requestEntityB(req).map(_.map(Right(_): Either[A, B]))
       decodedA.orElse(decodedB)
     }
 

--- a/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/EndpointsTestApi.scala
@@ -11,3 +11,7 @@ class EndpointsTestApi
     with algebra.BasicAuthenticationTestApi
     with algebra.JsonEntitiesFromSchemasTestApi
     with algebra.TextEntitiesTestApi
+    with algebra.SumTypedEntitiesTestApi {
+
+  implicit def userCodec = userJsonSchema
+}

--- a/http4s/server/src/test/scala/endpoints/http4s/server/ServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints/http4s/server/ServerInterpreterTest.scala
@@ -9,6 +9,7 @@ import endpoints.algebra.server.{
   DecodedUrl,
   EndpointsTestSuite,
   JsonEntitiesFromSchemasTestSuite,
+  SumTypedEntitiesTestSuite,
   TextEntitiesTestSuite
 }
 import org.http4s.server.Router
@@ -22,7 +23,8 @@ class ServerInterpreterTest
     extends EndpointsTestSuite[EndpointsTestApi]
     with BasicAuthenticationTestSuite[EndpointsTestApi]
     with JsonEntitiesFromSchemasTestSuite[EndpointsTestApi]
-    with TextEntitiesTestSuite[EndpointsTestApi] {
+    with TextEntitiesTestSuite[EndpointsTestApi]
+    with SumTypedEntitiesTestSuite[EndpointsTestApi] {
 
   val serverApi = new EndpointsTestApi()
 

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -46,6 +46,12 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
     "text/plain" -> MediaType(Some(Schema.simpleString))
   )
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: Map[String, MediaType],
+    requestEntityB: Map[String, MediaType]
+  ): Map[String, MediaType] =
+    requestEntityB ++ requestEntityA
+
   def request[A, B, C, AB, Out](
       method: Method,
       url: Url[A],

--- a/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
+++ b/openapi/openapi/src/main/scala/endpoints/openapi/Requests.scala
@@ -47,8 +47,8 @@ trait Requests extends algebra.Requests with Urls with Methods with Headers {
   )
 
   def choiceRequestEntity[A, B](
-    requestEntityA: Map[String, MediaType],
-    requestEntityB: Map[String, MediaType]
+      requestEntityA: Map[String, MediaType],
+      requestEntityB: Map[String, MediaType]
   ): Map[String, MediaType] =
     requestEntityB ++ requestEntityA
 

--- a/openapi/openapi/src/test/scala/endpoints/openapi/SumTypedRequests.scala
+++ b/openapi/openapi/src/test/scala/endpoints/openapi/SumTypedRequests.scala
@@ -1,0 +1,59 @@
+package endpoints.openapi
+
+import endpoints.{algebra, openapi}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SumTypedRequests extends AnyWordSpec with Matchers {
+
+  "Request bondy content" should {
+
+    "Include all supported content-types" in new Fixtures {
+      checkRequestContentTypes(sumTypedEndpoint)(
+        Set("text/plain", "application/json")
+      )
+      checkRequestContentTypes(onlyTextEndpoint)(Set("text/plain"))
+      checkRequestContentTypes(onlyJsonEndpoint)(Set("application/json"))
+    }
+  }
+
+  trait FixtureAlg
+      extends algebra.Endpoints
+      with algebra.JsonEntitiesFromSchemas
+      with algebra.JsonSchemasFixtures {
+
+    import User._  // Extra help for Scala 2.12 to find User json schema
+
+    def sumTypedEndpoint = endpoint[Either[User, String], Unit](
+      post(path / "user-or-name", jsonRequest[User].orElse(textRequest)),
+      ok(emptyResponse)
+    )
+
+    def onlyTextEndpoint = endpoint[String, Unit](
+      post(path / "name", textRequest),
+      ok(emptyResponse)
+    )
+
+    def onlyJsonEndpoint = endpoint[User, Unit](
+      post(path / "user", jsonRequest[User]),
+      ok(emptyResponse)
+    )
+  }
+
+  trait Fixtures
+      extends FixtureAlg
+      with openapi.Endpoints
+      with openapi.JsonEntitiesFromSchemas {
+
+    def checkRequestContentTypes[A](
+        endpoint: DocumentedEndpoint
+    )(contentTypes: Set[String]) = {
+      val foundContentTypes = endpoint.item.operations.values.iterator
+        .flatMap(_.requestBody.iterator)
+        .flatMap(_.content.keys)
+        .toSet
+      assert(foundContentTypes == contentTypes)
+    }
+
+  }
+}

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -123,6 +123,12 @@ trait EndpointsWithCustomErrors
   lazy val textRequest: (String, WSRequest) => WSRequest =
     (body, req) => req.withBody(body)
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
+    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
+++ b/play/client/src/main/scala/endpoints/play/client/Endpoints.scala
@@ -124,10 +124,11 @@ trait EndpointsWithCustomErrors
     (body, req) => req.withBody(body)
 
   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
-  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
-    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    (eitherAB, req) =>
+      eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
 
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =

--- a/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
+++ b/play/client/src/test/scala/endpoints/play/client/EndpointsTest.scala
@@ -17,6 +17,7 @@ class TestClient(address: String, wsClient: WSClient)(
     with algebra.EndpointsTestApi
     with algebra.JsonFromCodecTestApi
     with algebra.TextEntitiesTestApi
+    with algebra.SumTypedEntitiesTestApi
     with circe.JsonFromCirceCodecTestApi
     with circe.JsonEntitiesFromCodecs
 
@@ -24,6 +25,7 @@ class EndpointsTest
     extends client.EndpointsTestSuite[TestClient]
     with client.BasicAuthTestSuite[TestClient]
     with client.JsonFromCodecTestSuite[TestClient]
+    with client.SumTypedEntitiesTestSuite[TestClient]
     with client.TextEntitiesTestSuite[TestClient] {
 
   import ExecutionContext.Implicits.global
@@ -42,6 +44,7 @@ class EndpointsTest
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  sumTypedRequestsTestSuite()
   textEntitiesTestSuite()
 
   override def afterAll(): Unit = {

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
@@ -40,7 +40,10 @@ trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
             .left
             .map(Show[ParsingFailure].show)
             .flatMap { json =>
-              CirceDecoder[A].decodeJson(json).left.map(Show[DecodingFailure].show)
+              CirceDecoder[A]
+                .decodeJson(json)
+                .left
+                .map(Show[DecodingFailure].show)
             }
             .left
             .map(error => handleClientErrors(Invalid(error)))

--- a/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
+++ b/play/server-circe/src/main/scala/endpoints/play/server/circe/JsonEntities.scala
@@ -32,16 +32,22 @@ trait JsonEntities extends EndpointsWithCustomErrors with algebra.JsonEntities {
   type JsonResponse[A] = CirceEncoder[A]
 
   def jsonRequest[A: CirceDecoder]: RequestEntity[A] =
-    playComponents.playBodyParsers.tolerantText.validate { text =>
-      parser
-        .parse(text)
-        .left
-        .map(Show[ParsingFailure].show)
-        .flatMap { json =>
-          CirceDecoder[A].decodeJson(json).left.map(Show[DecodingFailure].show)
-        }
-        .left
-        .map(error => handleClientErrors(Invalid(error)))
+    headers => {
+      if (headers.contentType.exists(_.equalsIgnoreCase("application/json"))) {
+        Some(playComponents.playBodyParsers.tolerantText.validate { text =>
+          parser
+            .parse(text)
+            .left
+            .map(Show[ParsingFailure].show)
+            .flatMap { json =>
+              CirceDecoder[A].decodeJson(json).left.map(Show[DecodingFailure].show)
+            }
+            .left
+            .map(error => handleClientErrors(Invalid(error)))
+        })
+      } else {
+        None
+      }
     }
 
   def jsonResponse[A: CirceEncoder]: ResponseEntity[A] =

--- a/play/server/src/main/scala/endpoints/play/server/BasicAuthentication.scala
+++ b/play/server/src/main/scala/endpoints/play/server/BasicAuthentication.scala
@@ -59,19 +59,24 @@ trait BasicAuthentication
       url,
       headers ++ basicAuthenticationHeader
     ).toRequest[Out] {
-      case (_, (_, None /* credentials */)) =>
+      case (_, (_, None /* credentials */ )) =>
         _ =>
-          Some(BodyParser(_ =>
-            Accumulator.done(
-              Left(
-                Results.Unauthorized.withHeaders(
-                  HeaderNames.WWW_AUTHENTICATE -> "Basic realm=Realm"
+          Some(
+            BodyParser(_ =>
+              Accumulator.done(
+                Left(
+                  Results.Unauthorized.withHeaders(
+                    HeaderNames.WWW_AUTHENTICATE -> "Basic realm=Realm"
+                  )
                 )
               )
             )
-          ))
+          )
       case (u, (h, Some(credentials))) =>
-        headers => entity(headers).map(_.map(e => tuplerUEHC(tuplerUE(u, e), tuplerHC(h, credentials))))
+        headers =>
+          entity(headers).map(
+            _.map(e => tuplerUEHC(tuplerUE(u, e), tuplerHC(h, credentials)))
+          )
     } { out =>
       val (ue, hc) = tuplerUEHC.unapply(out)
       val (u, _) = tuplerUE.unapply(ue)

--- a/play/server/src/main/scala/endpoints/play/server/ChunkedEntities.scala
+++ b/play/server/src/main/scala/endpoints/play/server/ChunkedEntities.scala
@@ -34,8 +34,8 @@ trait ChunkedEntities
 
   private[server] def chunkedRequestEntity[A](
       fromByteString: ByteString => Either[Throwable, A]
-  ): RequestEntity[Chunks[A]] = {
-    BodyParser.apply { _ =>
+  ): RequestEntity[Chunks[A]] = _ => {
+    Some(BodyParser.apply { _ =>
       Accumulator.source[ByteString].map { byteStrings =>
         val source: Source[A, _] =
           byteStrings.map(fromByteString).flatMapConcat {
@@ -44,7 +44,7 @@ trait ChunkedEntities
           }
         Right(source)
       }
-    }
+    })
   }
 
   private[server] def chunkedResponseEntity[A](

--- a/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/Endpoints.scala
@@ -2,7 +2,15 @@ package endpoints.play.server
 
 import endpoints.algebra.Documentation
 import play.api.http.{HttpEntity, Writeable}
-import endpoints.{Invalid, PartialInvariantFunctor, Semigroupal, Tupler, Valid, Validated, algebra}
+import endpoints.{
+  Invalid,
+  PartialInvariantFunctor,
+  Semigroupal,
+  Tupler,
+  Valid,
+  Validated,
+  algebra
+}
 import play.api.http.Status.UNSUPPORTED_MEDIA_TYPE
 import play.api.libs.functional.InvariantFunctor
 import play.api.libs.streams.Accumulator
@@ -473,14 +481,19 @@ trait EndpointsWithCustomErrors
                     val action =
                       playComponents.defaultActionBuilder.async(bodyParser) {
                         request =>
-                          service(request.body).map { b => endpoint.response(b) }
+                          service(request.body).map { b =>
+                            endpoint.response(b)
+                          }
                       }
                     action(headers).recover {
                       case NonFatal(t) => handleServerError(t)
                     }
                   // Unable to handle request entity
                   case None =>
-                    Accumulator.done(playComponents.httpErrorHandler.onClientError(headers, UNSUPPORTED_MEDIA_TYPE))
+                    Accumulator.done(
+                      playComponents.httpErrorHandler
+                        .onClientError(headers, UNSUPPORTED_MEDIA_TYPE)
+                    )
                 }
               } catch {
                 case NonFatal(t) => Accumulator.done(handleServerError(t))

--- a/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/LowLevelEndpoints.scala
@@ -14,12 +14,13 @@ trait LowLevelEndpoints extends algebra.LowLevelEndpoints with Endpoints {
   /** Represents a request entity as a Play `Request[AnyContent]` */
   type RawRequestEntity = mvc.Request[AnyContent]
 
-  lazy val rawRequestEntity: BodyParser[mvc.Request[AnyContent]] =
-    BodyParser { requestHeader =>
-      val accumulator =
-        playComponents.playBodyParsers.anyContent.apply(requestHeader)
-      accumulator.map(_.map(anyContent => Request(requestHeader, anyContent)))
-    }
+  lazy val rawRequestEntity: RequestEntity[mvc.Request[AnyContent]] =
+    _ =>
+      Some(BodyParser { requestHeader =>
+        val accumulator =
+          playComponents.playBodyParsers.anyContent.apply(requestHeader)
+        accumulator.map(_.map(anyContent => Request(requestHeader, anyContent)))
+      })
 
   /** An HTTP response is a Play `Result` */
   type RawResponseEntity = Result

--- a/play/server/src/main/scala/endpoints/play/server/MuxEndpoints.scala
+++ b/play/server/src/main/scala/endpoints/play/server/MuxEndpoints.scala
@@ -69,7 +69,10 @@ trait MuxEndpoints extends algebra.MuxEndpoints with EndpointsWithCustomErrors {
                     }
                   // Unable to handle request entity
                   case None =>
-                    Accumulator.done(playComponents.httpErrorHandler.onClientError(headers, UNSUPPORTED_MEDIA_TYPE))
+                    Accumulator.done(
+                      playComponents.httpErrorHandler
+                        .onClientError(headers, UNSUPPORTED_MEDIA_TYPE)
+                    )
                 }
               } catch {
                 case NonFatal(t) => Accumulator.done(handleServerError(t))

--- a/play/server/src/test/scala/endpoints/play/server/EndpointsTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/EndpointsTest.scala
@@ -15,6 +15,7 @@ class EndpointsTestApi(
     with algebra.BasicAuthenticationTestApi
     with algebra.EndpointsTestApi
     with algebra.JsonFromCodecTestApi
+    with algebra.SumTypedEntitiesTestApi
     with algebra.TextEntitiesTestApi
     with algebra.Assets
     with JsonFromCirceCodecTestApi

--- a/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
+++ b/play/server/src/test/scala/endpoints/play/server/ServerInterpreterTest.scala
@@ -9,6 +9,7 @@ import endpoints.algebra.server.{
   DecodedUrl,
   EndpointsTestSuite,
   ChunkedJsonEntitiesTestSuite,
+  SumTypedEntitiesTestSuite,
   TextEntitiesTestSuite
 }
 import play.api.Mode
@@ -26,6 +27,7 @@ class ServerInterpreterTest
     extends EndpointsTestSuite[EndpointsTestApi]
     with BasicAuthenticationTestSuite[EndpointsTestApi]
     with ChunkedJsonEntitiesTestSuite[EndpointsTestApi]
+    with SumTypedEntitiesTestSuite[EndpointsTestApi]
     with TextEntitiesTestSuite[EndpointsTestApi] {
 
   val serverApi: EndpointsTestApi = {

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -76,6 +76,12 @@ trait Requests extends algebra.Requests with Urls with Methods {
         .header("content-type", s"text/plain; charset=${req.charset}")
         .postData(body)
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
+    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
+++ b/scalaj/client/src/main/scala/endpoints/scalaj/client/Requests.scala
@@ -77,10 +77,11 @@ trait Requests extends algebra.Requests with Urls with Methods {
         .postData(body)
 
   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
-  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
-    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    (eitherAB, req) =>
+      eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
 
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -127,11 +127,12 @@ trait EndpointsWithCustomErrors[R[_]]
     case (bodyValue, request) => request.body(bodyValue)
   }
 
-   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
-  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
-    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+  def choiceRequestEntity[A, B](
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    (eitherAB, req) =>
+      eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
 
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =

--- a/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
+++ b/sttp/client/src/main/scala/endpoints/sttp/client/Endpoints.scala
@@ -127,6 +127,12 @@ trait EndpointsWithCustomErrors[R[_]]
     case (bodyValue, request) => request.body(bodyValue)
   }
 
+   def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] = (eitherAB, req) =>
+    eitherAB.fold(requestEntityA(_, req), requestEntityB(_, req))
+
   implicit def requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
+++ b/sttp/client/src/test/scala/endpoints/sttp/client/EnpointsTest.scala
@@ -7,11 +7,13 @@ import endpoints.algebra.client.{
   BasicAuthTestSuite,
   JsonFromCodecTestSuite,
   TextEntitiesTestSuite,
+  SumTypedEntitiesTestSuite,
   EndpointsTestSuite
 }
 import endpoints.algebra.{
   BasicAuthenticationTestApi,
   EndpointsTestApi,
+  SumTypedEntitiesTestApi,
   TextEntitiesTestApi
 }
 import endpoints.algebra.playjson.JsonFromPlayJsonCodecTestApi
@@ -26,12 +28,14 @@ class TestClient[R[_]](address: String, backend: sttp.SttpBackend[R, _])
     with BasicAuthenticationTestApi
     with EndpointsTestApi
     with JsonFromPlayJsonCodecTestApi
+    with SumTypedEntitiesTestApi
     with TextEntitiesTestApi
 
 class EndpointsTestSync
     extends EndpointsTestSuite[TestClient[Try]]
     with BasicAuthTestSuite[TestClient[Try]]
     with JsonFromCodecTestSuite[TestClient[Try]]
+    with SumTypedEntitiesTestSuite[TestClient[Try]]
     with TextEntitiesTestSuite[TestClient[Try]] {
 
   val backend = TryHttpURLConnectionBackend()
@@ -48,6 +52,7 @@ class EndpointsTestSync
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  sumTypedRequestsTestSuite()
   textEntitiesTestSuite()
 }
 
@@ -55,6 +60,7 @@ class EndpointsTestAkka
     extends EndpointsTestSuite[TestClient[Future]]
     with BasicAuthTestSuite[TestClient[Future]]
     with JsonFromCodecTestSuite[TestClient[Future]]
+    with SumTypedEntitiesTestSuite[TestClient[Future]]
     with TextEntitiesTestSuite[TestClient[Future]] {
 
   import ExecutionContext.Implicits.global
@@ -72,6 +78,7 @@ class EndpointsTestAkka
   clientTestSuite()
   basicAuthSuite()
   jsonFromCodecTestSuite()
+  sumTypedRequestsTestSuite()
   textEntitiesTestSuite()
 
   override def afterAll(): Unit = {

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -132,6 +132,12 @@ trait EndpointsWithCustomErrors
     body
   }
 
+  def choiceRequestEntity[A, B](
+    requestEntityA: RequestEntity[A],
+    requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] = (eitherAB, xhr) =>
+    eitherAB.fold(requestEntityA(_, xhr), requestEntityB(_, xhr))
+
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =
     new PartialInvariantFunctor[RequestEntity] {

--- a/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
+++ b/xhr/client/src/main/scala/endpoints/xhr/Endpoints.scala
@@ -133,10 +133,11 @@ trait EndpointsWithCustomErrors
   }
 
   def choiceRequestEntity[A, B](
-    requestEntityA: RequestEntity[A],
-    requestEntityB: RequestEntity[B]
-  ): RequestEntity[Either[A, B]] = (eitherAB, xhr) =>
-    eitherAB.fold(requestEntityA(_, xhr), requestEntityB(_, xhr))
+      requestEntityA: RequestEntity[A],
+      requestEntityB: RequestEntity[B]
+  ): RequestEntity[Either[A, B]] =
+    (eitherAB, xhr) =>
+      eitherAB.fold(requestEntityA(_, xhr), requestEntityB(_, xhr))
 
   implicit lazy val requestEntityPartialInvariantFunctor
       : PartialInvariantFunctor[RequestEntity] =


### PR DESCRIPTION
Add a `choiceRequestEntity` combinator and `orElse` implicit ops method
for combining two request entities and branching based on content-type.
OpenAPI supports describing this sort of endpoint too.

Motivating use case: it is now possible to define an endpoint that
accepts either a plain `textRequest` or a richer `jsonRequest`.

Implements #529
